### PR TITLE
Adjusted docs to new repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Heimdall Android [![Build Status](https://travis-ci.org/gnosis/heimdall-android.svg?branch=master)](https://travis-ci.org/gnosis/heimdall-android)
+# Gnosis Safe Android App [![Build Status](https://travis-ci.org/gnosis/safe-android.svg?branch=master)](https://travis-ci.org/gnosis/safe-android)
 
 **WARNING: Under development. Don't use the application with real funds! Application right now targets the Rinkeby test network. Switching to mainnet (or any other ethereum network) can be done by the user but it's its responsibility in doing so.**
 
@@ -48,7 +48,7 @@ Replace each field with the respective information (found in Fabric).
 **If you don't want to setup Fabric for this project you can follow the steps present in this [page](https://docs.fabric.io/android/crashlytics/build-tools.html) to disable the integration. We will improve this integration in the future so it can be easily enabled/disabled**
 
 ### Firebase
-Heimdall uses Firebase and your build will fail if you don't have the `google-services.json` file.
+The Gnosis Safe Android App uses Firebase and your build will fail if you don't have the `google-services.json` file.
 
 This file can be found in the Settings page of the Firebase project.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-## How to contribute to Heimdall Android
+## How to contribute to Gnosis Safe Android App
 
 #### **Did you find a bug?**
 
 * **Ensure the bug was not already reported**  by searching on GitHub under [Issues][issue_search]
 
-* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/gnosis/heimdall-android/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/gnosis/safe-android/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
 
-* Bugs will be labeled *bug*. See all bugs under [Bugs](https://github.com/gnosis/heimdall-android/labels/bug).
+* Bugs will be labeled *bug*. See all bugs under [Bugs](https://github.com/gnosis/safe-android/labels/bug).
 
 #### **Did you write a patch that fixes a bug?**
 
@@ -16,19 +16,19 @@
 
 #### **Did you fix whitespace, format code, or make a purely cosmetic patch?**
 
-Changes that are cosmetic in nature and do not add anything substantial to the stability, functionality, or testability of Heimdall Android will generally not be accepted.
+Changes that are cosmetic in nature and do not add anything substantial to the stability, functionality, or testability of the Gnosis Safe Android Android will generally not be accepted.
 
 #### **Do you intend to add a new feature or change an existing one?**
 
 * You can suggest new features as a GitHub issue. **Ensure that there is not already a similar request** by searching on GitHub under [Issues][issue_search].
 
-* Featured requests will be labeled *enhancement*. See all feature requests under [Feature requests](https://github.com/gnosis/heimdall-android/labels/enhancement).
+* Featured requests will be labeled *enhancement*. See all feature requests under [Feature requests](https://github.com/gnosis/safe-android/labels/enhancement).
 
 #### **Do you have questions about the project?**
 
 * You can ask questions about this project as a GitHub issue. **Ensure that there is not already a similar question** by searching on GitHub under [Issues][issue_search].
 
-* Questions will be labeled *question*. See all questions under [Questions](https://github.com/gnosis/heimdall-android/labels/question).
+* Questions will be labeled *question*. See all questions under [Questions](https://github.com/gnosis/safe-android/labels/question).
 
 #### **Addition info**
 
@@ -40,4 +40,4 @@ Thanks! :rocket: :tada:
 
 Gnosis Team
 
-[issue_search]: https://github.com/gnosis/heimdall-android/issues
+[issue_search]: https://github.com/gnosis/safe-android/issues


### PR DESCRIPTION
Changes proposed in this pull request:
- Repo was called heimdall-android before. Now it is called safe-android

@gnosis/mobile-devs
