### PR TITLE
WA-420: Adjust restricted transactions

### DIFF
--- a/app/src/main/java/pm/gnosis/heimdall/data/repositories/TokenRepository.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/repositories/TokenRepository.kt
@@ -13,7 +13,6 @@ interface TokenRepository {
     fun observeToken(address: Solidity.Address): Flowable<ERC20Token>
     fun loadTokens(): Single<List<ERC20Token>>
     fun loadToken(address: Solidity.Address): Single<ERC20Token>
-    fun loadTokenInfo(contractAddress: Solidity.Address): Observable<ERC20Token>
     fun loadTokenBalances(ofAddress: Solidity.Address, erC20Tokens: List<ERC20Token>): Observable<List<Pair<ERC20Token, BigInteger?>>>
     fun addToken(erC20Token: ERC20Token): Completable
     fun removeToken(address: Solidity.Address): Completable

--- a/app/src/main/java/pm/gnosis/heimdall/data/repositories/TransactionInfoRepository.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/repositories/TransactionInfoRepository.kt
@@ -21,6 +21,8 @@ sealed class RestrictedTransactionException : IllegalArgumentException() {
     object DelegateCall: RestrictedTransactionException()
     object ModifyOwners: RestrictedTransactionException()
     object ModifyModules: RestrictedTransactionException()
+    object ChangeThreshold: RestrictedTransactionException()
+    object ChangeMasterCopy: RestrictedTransactionException()
 }
 
 data class TransactionInfo(

--- a/app/src/main/java/pm/gnosis/heimdall/data/repositories/impls/DefaultTransactionInfoRepository.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/repositories/impls/DefaultTransactionInfoRepository.kt
@@ -41,6 +41,10 @@ class DefaultTransactionInfoRepository @Inject constructor(
                     throw RestrictedTransactionException.ModifyModules
                 transaction.wrapped.data?.isSolidityMethod(GnosisSafePersonalEdition.DisableModule.METHOD_ID) == true ->
                     throw RestrictedTransactionException.ModifyModules
+                transaction.wrapped.data?.isSolidityMethod(GnosisSafePersonalEdition.ChangeThreshold.METHOD_ID) == true ->
+                    throw RestrictedTransactionException.ChangeThreshold
+                transaction.wrapped.data?.isSolidityMethod(GnosisSafePersonalEdition.ChangeMasterCopy.METHOD_ID) == true ->
+                    throw RestrictedTransactionException.ChangeMasterCopy
             }
             transaction
         }

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsViewModel.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsViewModel.kt
@@ -75,13 +75,7 @@ class SafeTransactionsViewModel @Inject constructor(
         transactionInfoRepository.loadTransactionInfo(id)
 
     override fun loadTokenInfo(token: Solidity.Address): Single<ERC20Token> =
-        if (token == ERC20Token.ETHER_TOKEN.address)
-            Single.just(ERC20Token.ETHER_TOKEN)
-        else
-            tokenRepository.loadToken(token)
-                .onErrorResumeNext {
-                    tokenRepository.loadTokenInfo(token).firstOrError()
-                }
+        tokenRepository.loadToken(token)
 
     override fun observeTransactionStatus(id: String): Observable<TransactionExecutionRepository.PublishStatus> =
         safeTransactionsRepository.observePublishStatus(id)

--- a/app/src/main/java/pm/gnosis/heimdall/ui/tokens/add/AddTokenActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/tokens/add/AddTokenActivity.kt
@@ -61,11 +61,11 @@ class AddTokenActivity : BaseActivity() {
             }, onError = Timber::e)
 
         disposables += layout_add_token_load_info_button.clicks()
-            .flatMap {
+            .flatMapSingle {
                 viewModel.loadTokenInfo(layout_add_token_address.text.toString())
                     .observeOn(AndroidSchedulers.mainThread())
                     .doOnSubscribe { onTokenInfoLoading(true) }
-                    .doOnTerminate { onTokenInfoLoading(false) }
+                    .doAfterTerminate { onTokenInfoLoading(false) }
             }
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeForResult(onNext = ::onTokenInfo, onError = ::onTokenInfoError)

--- a/app/src/main/java/pm/gnosis/heimdall/ui/tokens/add/AddTokenContract.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/tokens/add/AddTokenContract.kt
@@ -8,5 +8,5 @@ import pm.gnosis.svalinn.common.utils.Result
 
 abstract class AddTokenContract : ViewModel() {
     abstract fun addToken(): Single<Result<Unit>>
-    abstract fun loadTokenInfo(tokenAddress: String): Observable<Result<ERC20Token>>
+    abstract fun loadTokenInfo(tokenAddress: String): Single<Result<ERC20Token>>
 }

--- a/app/src/main/java/pm/gnosis/heimdall/ui/tokens/add/AddTokenViewModel.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/tokens/add/AddTokenViewModel.kt
@@ -35,12 +35,12 @@ class AddTokenViewModel @Inject constructor(
             .mapToResult()
     }
 
-    override fun loadTokenInfo(tokenAddress: String): Observable<Result<ERC20Token>> =
-        Observable
+    override fun loadTokenInfo(tokenAddress: String): Single<Result<ERC20Token>> =
+        Single
             .fromCallable { tokenAddress.asEthereumAddress() ?: throw InvalidAddressException(tokenAddress) }
-            .flatMap { tokenRepository.loadTokenInfo(it) }
-            .doOnNext { this.erc20Token = it }
-            .onErrorResumeNext { throwable: Throwable -> errorHandler.observable(throwable) }
+            .flatMap { tokenRepository.loadToken(it) }
+            .doOnSuccess { this.erc20Token = it }
+            .onErrorResumeNext { throwable: Throwable -> errorHandler.single(throwable) }
             .mapToResult()
 
     private class NoTokenSetException : Exception()

--- a/app/src/main/java/pm/gnosis/heimdall/ui/transactions/create/CreateAssetTransferViewModel.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/transactions/create/CreateAssetTransferViewModel.kt
@@ -6,7 +6,6 @@ import com.gojuno.koptional.Optional
 import com.gojuno.koptional.toOptional
 import io.reactivex.Observable
 import io.reactivex.ObservableTransformer
-import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.functions.BiFunction
 import pm.gnosis.heimdall.data.repositories.TokenRepository
@@ -94,8 +93,7 @@ class CreateAssetTransferViewModel @Inject constructor(
         }
 
     private fun loadTokenInfo(safe: Solidity.Address, tokenAddress: Solidity.Address) =
-        (if (tokenAddress == ERC20Token.ETHER_TOKEN.address) Single.just(ERC20Token.ETHER_TOKEN)
-        else tokenRepository.loadToken(tokenAddress))
+        tokenRepository.loadToken(tokenAddress)
             .emitAndNext(
                 emit = { ERC20TokenWithBalance(it, null).toOptional() },
                 next = { loadBalance(safe, it).map { it.toOptional() } }

--- a/app/src/main/java/pm/gnosis/heimdall/ui/transactions/view/confirm/ConfirmTransactionViewModel.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/transactions/view/confirm/ConfirmTransactionViewModel.kt
@@ -100,6 +100,10 @@ class ConfirmTransactionViewModel @Inject constructor(
                             InvalidTransactionException(R.string.restricted_transaction_modify_owners)
                         is RestrictedTransactionException.ModifyModules ->
                             InvalidTransactionException(R.string.restricted_transaction_modify_modules)
+                        is RestrictedTransactionException.ChangeThreshold ->
+                            InvalidTransactionException(R.string.restricted_transaction_change_threshold)
+                        is RestrictedTransactionException.ChangeMasterCopy ->
+                            InvalidTransactionException(R.string.restricted_transaction_modify_proxy)
                         else ->
                             it
                     }

--- a/app/src/main/java/pm/gnosis/heimdall/ui/transactions/view/viewholders/AssetTransferViewHolder.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/transactions/view/viewholders/AssetTransferViewHolder.kt
@@ -57,7 +57,7 @@ class AssetTransferViewHolder(
     }
 
     private fun setupTokenInfo() {
-        disposables += loadTokenInfo()
+        disposables += tokenRepository.loadToken(data.token)
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeBy(
                 onSuccess = {
@@ -92,15 +92,6 @@ class AssetTransferViewHolder(
                 view?.layout_asset_transfer_info_safe_balance?.text = null
             })
     }
-
-    private fun loadTokenInfo() =
-        if (data.token == ERC20Token.ETHER_TOKEN.address)
-            Single.just(ERC20Token.ETHER_TOKEN)
-        else
-            tokenRepository.loadToken(data.token)
-                .onErrorResumeNext {
-                    tokenRepository.loadTokenInfo(data.token).firstOrError()
-                }
 
     private fun setupSafeInfo() {
         view?.apply {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -405,6 +405,8 @@
     <string name="restricted_transaction_delegatecall">Delegate calls are not allowed</string>
     <string name="restricted_transaction_modify_owners">It is not allowed to modify the owners of the Safe</string>
     <string name="restricted_transaction_modify_modules">It is not allowed to modify the modules of the Safe</string>
+    <string name="restricted_transaction_change_threshold">It is not allowed to change the threshold of the Safe</string>
+    <string name="restricted_transaction_modify_proxy">It is not allowed to modify the proxy of the Safe</string>
     <string name="error_loading_transaction">Error loading transaction</string>
     <string name="transaction_type_generic">Contract interaction</string>
     <string name="transaction_type_asset_transfer">Outgoing transfer</string>

--- a/app/src/test/java/pm/gnosis/heimdall/data/repositories/impls/DefaultTokenRepositoryTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/data/repositories/impls/DefaultTokenRepositoryTest.kt
@@ -387,6 +387,12 @@ class DefaultTokenRepositoryTest {
 
         then(erc20DaoMock).should().loadToken(Solidity.Address(BigInteger.TEN))
         then(erc20DaoMock).shouldHaveNoMoreInteractions()
+
+        val etherObserver = TestObserver<ERC20Token>()
+        repository.loadToken(ERC20Token.ETHER_TOKEN.address).subscribe(etherObserver)
+        etherObserver.assertResult(ERC20Token.ETHER_TOKEN)
+
+        then(erc20DaoMock).shouldHaveNoMoreInteractions()
     }
 
     private fun testLoadTokenInfo(
@@ -395,6 +401,7 @@ class DefaultTokenRepositoryTest {
         symbolResult: EthRequest.Response<String>,
         decimalResult: EthRequest.Response<String>
     ) {
+        given(erc20DaoMock.loadToken(MockUtils.any())).willReturn(Single.error(NoSuchElementException()))
         given(ethereumRepositoryMock.request(MockUtils.any<BulkRequest>())).will {
             val bulk = it.arguments.first() as BulkRequest
             val requests = bulk.requests
@@ -434,7 +441,7 @@ class DefaultTokenRepositoryTest {
         }
 
         val testObserver = TestObserver<ERC20Token>()
-        repository.loadTokenInfo(Solidity.Address(BigInteger.TEN)).subscribe(testObserver)
+        repository.loadToken(Solidity.Address(BigInteger.TEN)).subscribe(testObserver)
         expectedResult.handle({
             testObserver.assertResult(it)
         }, { error ->

--- a/app/src/test/java/pm/gnosis/heimdall/ui/tokens/add/AddTokenViewModelTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/tokens/add/AddTokenViewModelTest.kt
@@ -2,6 +2,7 @@ package pm.gnosis.heimdall.ui.tokens.add
 
 import android.content.Context
 import io.reactivex.Observable
+import io.reactivex.Single
 import io.reactivex.observers.TestObserver
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -52,13 +53,13 @@ class AddTokenViewModelTest {
         val testObserver = TestObserver<Result<Unit>>()
         val testCompletable = TestCompletable()
         given(tokenRepositoryMock.addToken(MockUtils.any())).willReturn(testCompletable)
-        given(tokenRepositoryMock.loadTokenInfo(MockUtils.any())).willReturn(Observable.just(testToken))
+        given(tokenRepositoryMock.loadToken(MockUtils.any())).willReturn(Single.just(testToken))
 
         viewModel.loadTokenInfo(testAddress.asEthereumAddressString()).subscribe(TestObserver())
         viewModel.addToken().subscribe(testObserver)
 
         then(tokenRepositoryMock).should().addToken(testToken)
-        then(tokenRepositoryMock).should().loadTokenInfo(testAddress)
+        then(tokenRepositoryMock).should().loadToken(testAddress)
         then(tokenRepositoryMock).shouldHaveNoMoreInteractions()
         assertEquals(1, testCompletable.callCount)
         testObserver.assertValue(DataResult(Unit)).assertNoErrors()
@@ -77,11 +78,11 @@ class AddTokenViewModelTest {
     @Test
     fun loadTokenInfo() {
         val testObserver = TestObserver<Result<ERC20Token>>()
-        given(tokenRepositoryMock.loadTokenInfo(MockUtils.any())).willReturn(Observable.just(testToken))
+        given(tokenRepositoryMock.loadToken(MockUtils.any())).willReturn(Single.just(testToken))
 
         viewModel.loadTokenInfo(testAddress.asEthereumAddressString()).subscribe(testObserver)
 
-        then(tokenRepositoryMock).should().loadTokenInfo(testAddress)
+        then(tokenRepositoryMock).should().loadToken(testAddress)
         then(tokenRepositoryMock).shouldHaveNoMoreInteractions()
         testObserver.assertValue(DataResult(testToken)).assertNoErrors()
     }
@@ -100,11 +101,11 @@ class AddTokenViewModelTest {
     @Test
     fun loadTokenInfoErrorLoadingInfo() {
         val testObserver = TestObserver<Result<ERC20Token>>()
-        given(tokenRepositoryMock.loadTokenInfo(MockUtils.any())).willReturn(Observable.just(testToken))
+        given(tokenRepositoryMock.loadToken(MockUtils.any())).willReturn(Single.just(testToken))
 
         viewModel.loadTokenInfo(testAddress.asEthereumAddressString()).subscribe(testObserver)
 
-        then(tokenRepositoryMock).should().loadTokenInfo(testAddress)
+        then(tokenRepositoryMock).should().loadToken(testAddress)
         then(tokenRepositoryMock).shouldHaveNoMoreInteractions()
         testObserver.assertValue(DataResult(testToken)).assertNoErrors()
     }

--- a/app/src/test/java/pm/gnosis/heimdall/ui/transactions/create/CreateAssetTransferViewModelTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/transactions/create/CreateAssetTransferViewModelTest.kt
@@ -2,6 +2,7 @@ package pm.gnosis.heimdall.ui.transactions.create
 
 import android.content.Context
 import io.reactivex.Observable
+import io.reactivex.Single
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
@@ -55,6 +56,7 @@ class CreateAssetTransferViewModelTest {
 
     @Test
     fun processInputEtherTransfer() {
+        given(tokenRepositoryMock.loadToken(MockUtils.any())).willReturn(Single.just(ERC20Token.ETHER_TOKEN))
         val balancesSubject = PublishSubject.create<List<Pair<ERC20Token, BigInteger?>>>()
         given(tokenRepositoryMock.loadTokenBalances(MockUtils.any(), MockUtils.any())).willReturn(balancesSubject)
         val estimationSingleFactory = TestSingleFactory<TransactionExecutionRepository.ExecuteInformation>()
@@ -149,6 +151,7 @@ class CreateAssetTransferViewModelTest {
         testObserver.assertValueCount(10)
         testObserver.assertValueAt(9, { it is DataResult && it.data is CreateAssetTransferContract.ViewUpdate.StartReview })
 
+        then(tokenRepositoryMock).should().loadToken(TEST_ETHER_TOKEN)
         then(tokenRepositoryMock).should().loadTokenBalances(TEST_SAFE, listOf(ERC20Token.ETHER_TOKEN))
         then(tokenRepositoryMock).shouldHaveNoMoreInteractions()
         then(relayRepositoryMock).should(times(3)).loadExecuteInformation(MockUtils.any(), MockUtils.any())
@@ -265,6 +268,7 @@ class CreateAssetTransferViewModelTest {
 
     @Test
     fun processInputLoadTokenError() {
+        given(tokenRepositoryMock.loadToken(MockUtils.any())).willReturn(Single.just(ERC20Token.ETHER_TOKEN))
         given(tokenRepositoryMock.loadTokenBalances(MockUtils.any(), MockUtils.any())).willReturn(Observable.error(TimeoutException()))
         val reviewEvents = TestObservableFactory<Unit>()
         val inputSubject = PublishSubject.create<CreateAssetTransferContract.Input>()
@@ -277,6 +281,7 @@ class CreateAssetTransferViewModelTest {
             DataResult(CreateAssetTransferContract.ViewUpdate.TokenInfo(ERC20TokenWithBalance(ERC20Token.ETHER_TOKEN, null))),
             DataResult(CreateAssetTransferContract.ViewUpdate.TokenInfo(ERC20TokenWithBalance(ERC20Token.ETHER_TOKEN, null)))
         )
+        then(tokenRepositoryMock).should().loadToken(TEST_ETHER_TOKEN)
         then(tokenRepositoryMock).should().loadTokenBalances(TEST_SAFE, listOf(ERC20Token.ETHER_TOKEN))
         then(tokenRepositoryMock).shouldHaveNoMoreInteractions()
         then(relayRepositoryMock).shouldHaveZeroInteractions()

--- a/app/src/test/java/pm/gnosis/heimdall/ui/transactions/view/confirm/ConfirmTransactionViewModelTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/transactions/view/confirm/ConfirmTransactionViewModelTest.kt
@@ -190,7 +190,13 @@ class ConfirmTransactionViewModelTest {
                     ConfirmTransactionContract.InvalidTransactionException(R.string.restricted_transaction_modify_owners)),
             RestrictedTransactionException.ModifyModules::class to
                     (RestrictedTransactionException.ModifyModules to
-                    ConfirmTransactionContract.InvalidTransactionException(R.string.restricted_transaction_modify_modules))
+                    ConfirmTransactionContract.InvalidTransactionException(R.string.restricted_transaction_modify_modules)),
+            RestrictedTransactionException.ChangeThreshold::class to
+                    (RestrictedTransactionException.ChangeThreshold to
+                    ConfirmTransactionContract.InvalidTransactionException(R.string.restricted_transaction_change_threshold)),
+            RestrictedTransactionException.ChangeMasterCopy::class to
+                    (RestrictedTransactionException.ChangeMasterCopy to
+                    ConfirmTransactionContract.InvalidTransactionException(R.string.restricted_transaction_modify_proxy))
         )
 
         RestrictedTransactionException::class.nestedClasses.forEach {

--- a/app/src/test/java/pm/gnosis/heimdall/ui/transactions/view/status/TransactionStatusViewModelTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/transactions/view/status/TransactionStatusViewModelTest.kt
@@ -64,7 +64,7 @@ class TransactionStatusViewModelTest {
 
     private fun testObserve(
         gasTokenAddress: Solidity.Address,
-        gasToken: Result<ERC20Token>?,
+        gasToken: Result<ERC20Token>,
         transactionData: TransactionData,
         type: Int
     ) {
@@ -86,7 +86,7 @@ class TransactionStatusViewModelTest {
                 )
             )
 
-        gasToken?.let {
+        gasToken.let {
             when (it) {
                 is DataResult ->
                     given(tokenRepositoryMock.loadToken(MockUtils.any())).willReturn(Single.just(it.data))
@@ -100,7 +100,6 @@ class TransactionStatusViewModelTest {
         val expectedGasToken = when (gasToken) {
             is DataResult -> gasToken.data
             is ErrorResult -> ERC20Token(gasTokenAddress, decimals = 0)
-            null -> ERC20Token.ETHER_TOKEN
         }
         observer.assertResult(
             TransactionStatusContract.ViewUpdate.Params(
@@ -115,9 +114,7 @@ class TransactionStatusViewModelTest {
             )
         )
 
-        gasToken?.let {
-            then(tokenRepositoryMock).should().loadToken(gasTokenAddress)
-        }
+        then(tokenRepositoryMock).should().loadToken(expectedGasToken.address)
         then(tokenRepositoryMock).shouldHaveNoMoreInteractions()
 
         then(infoRepositoryMock).should().loadTransactionInfo(TEST_ID)
@@ -130,7 +127,7 @@ class TransactionStatusViewModelTest {
     @Test
     fun observeUpdateAssetTransferEtherGasToken() {
         val transactionData = TransactionData.AssetTransfer(TEST_GAS_TOKEN.address, BigInteger.TEN, TEST_SAFE)
-        testObserve(ERC20Token.ETHER_TOKEN.address, null, transactionData, R.string.transaction_type_asset_transfer)
+        testObserve(ERC20Token.ETHER_TOKEN.address, DataResult(ERC20Token.ETHER_TOKEN), transactionData, R.string.transaction_type_asset_transfer)
     }
 
     @Test
@@ -148,7 +145,7 @@ class TransactionStatusViewModelTest {
     @Test
     fun observeUpdateGenericTransactionEtherGasToken() {
         val transactionData = TransactionData.Generic(TEST_SAFE, BigInteger.TEN, null)
-        testObserve(ERC20Token.ETHER_TOKEN.address, null, transactionData, R.string.transaction_type_generic)
+        testObserve(ERC20Token.ETHER_TOKEN.address, DataResult(ERC20Token.ETHER_TOKEN), transactionData, R.string.transaction_type_generic)
     }
 
     @Test


### PR DESCRIPTION
Closes WA-420.

Changes proposed in this pull request:
- Restrict transactions that change threshold or change master copy
- Refactor `loadToken` (local) and `loadTokenInfo` (network) into one method `loadToken` which first does a local lookup and if nothing is found a network lookup

@gnosis/mobile-devs
