### PR TITLE
WA-487: Fix crashes on API19 due to the use of vector resources

### DIFF
--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/create/ConfirmSafeRecoveryPhraseAdapter.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/create/ConfirmSafeRecoveryPhraseAdapter.kt
@@ -9,6 +9,7 @@ import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import pm.gnosis.heimdall.R
 import pm.gnosis.heimdall.di.ForView
+import pm.gnosis.heimdall.utils.setCompoundDrawableResource
 import javax.inject.Inject
 
 
@@ -19,7 +20,9 @@ class ConfirmSafeRecoveryPhraseAdapter @Inject constructor() : RecyclerView.Adap
     private val dataChanged = PublishSubject.create<List<String>>()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder =
-        ViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.layout_confirm_safe_recovery_phrase_item, parent, false))
+        ViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.layout_confirm_safe_recovery_phrase_item, parent, false)).apply {
+            (itemView as TextView).setCompoundDrawableResource(right = R.drawable.ic_cross_action)
+        }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) = holder.bind(items[position])
 

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/create/CreateSafeIntroActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/create/CreateSafeIntroActivity.kt
@@ -12,6 +12,7 @@ import pm.gnosis.heimdall.R
 import pm.gnosis.heimdall.helpers.ToolbarHelper
 import pm.gnosis.heimdall.reporting.ScreenId
 import pm.gnosis.heimdall.ui.base.BaseActivity
+import pm.gnosis.heimdall.utils.setCompoundDrawableResource
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -28,6 +29,7 @@ class CreateSafeIntroActivity : BaseActivity() {
         viewComponent().inject(this)
 
         layout_create_safe_intro_third_text.text = Html.fromHtml(getString(R.string.safe_intro_message_3))
+        layout_create_safe_intro_next.setCompoundDrawableResource(right = R.drawable.ic_arrow_forward_24dp)
     }
 
     override fun onStart() {

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/details/SafeDetailsFragment.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/details/SafeDetailsFragment.kt
@@ -26,6 +26,7 @@ import pm.gnosis.heimdall.ui.safe.details.transactions.SafeTransactionsFragment
 import pm.gnosis.heimdall.ui.tokens.balances.TokenBalancesFragment
 import pm.gnosis.heimdall.ui.tokens.receive.ReceiveTokenActivity
 import pm.gnosis.heimdall.ui.tokens.select.SelectTokenActivity
+import pm.gnosis.heimdall.utils.setCompoundDrawableResource
 import pm.gnosis.model.Solidity
 import pm.gnosis.svalinn.common.utils.withArgs
 import pm.gnosis.utils.asEthereumAddress
@@ -54,6 +55,8 @@ class SafeDetailsFragment : BaseFragment() {
         tabToSelect = arguments?.getInt(EXTRA_SELECTED_TAB, tabToSelect) ?: tabToSelect
         arguments?.remove(EXTRA_SELECTED_TAB)
         pagerAdapter = pagerAdapter()
+        layout_safe_details_send_button.setCompoundDrawableResource(left = R.drawable.ic_send_azure)
+        layout_safe_details_receive_button.setCompoundDrawableResource(left = R.drawable.ic_qrcode_scan_azure)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/main/SafeMainActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/main/SafeMainActivity.kt
@@ -42,6 +42,7 @@ import pm.gnosis.heimdall.ui.settings.general.GeneralSettingsActivity
 import pm.gnosis.heimdall.ui.tokens.manage.ManageTokensActivity
 import pm.gnosis.heimdall.utils.CustomAlertDialogBuilder
 import pm.gnosis.heimdall.utils.errorSnackbar
+import pm.gnosis.heimdall.utils.setCompoundDrawableResource
 import pm.gnosis.model.Solidity
 import pm.gnosis.svalinn.common.utils.*
 import pm.gnosis.utils.asEthereumAddress
@@ -97,6 +98,13 @@ class SafeMainActivity : ViewModelActivity<SafeMainContract>() {
                 getString(R.string.remove_from_device), ForegroundColorSpan(getColorCompat(R.color.tomato))
             )
         }
+
+        layout_safe_main_add_safe.setCompoundDrawableResource(left = R.drawable.ic_create_new_safe)
+        layout_safe_main_recover_safe.setCompoundDrawableResource(left = R.drawable.ic_recover_safe)
+        layout_safe_main_account.setCompoundDrawableResource(left = R.drawable.ic_settings_account)
+        layout_safe_main_tokens.setCompoundDrawableResource(left = R.drawable.ic_tokens)
+        layout_safe_main_address_book.setCompoundDrawableResource(left = R.drawable.ic_settings_address_book)
+        layout_safe_main_debug_settings.setCompoundDrawableResource(left = R.drawable.ic_settings_debug)
     }
 
     override fun onStart() {

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/mnemonic/InputRecoveryPhraseActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/mnemonic/InputRecoveryPhraseActivity.kt
@@ -2,6 +2,7 @@ package pm.gnosis.heimdall.ui.safe.mnemonic
 
 
 import android.content.Intent
+import android.os.Bundle
 import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.widget.textChanges
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -12,6 +13,7 @@ import pm.gnosis.heimdall.R
 import pm.gnosis.heimdall.helpers.ToolbarHelper
 import pm.gnosis.heimdall.ui.base.ViewModelActivity
 import pm.gnosis.heimdall.utils.errorSnackbar
+import pm.gnosis.heimdall.utils.setCompoundDrawableResource
 import pm.gnosis.model.Solidity
 import pm.gnosis.svalinn.common.utils.visible
 import pm.gnosis.utils.asEthereumAddress
@@ -26,6 +28,11 @@ abstract class InputRecoveryPhraseActivity<VM : InputRecoveryPhraseContract> : V
     lateinit var toolbarHelper: ToolbarHelper
 
     override fun layout() = R.layout.layout_input_recovery_phrase
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        layout_input_recovery_phrase_next.setCompoundDrawableResource(right = R.drawable.ic_arrow_forward_24dp)
+    }
 
     override fun onStart() {
         super.onStart()

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/recover/address/CheckSafeActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/recover/address/CheckSafeActivity.kt
@@ -3,6 +3,7 @@ package pm.gnosis.heimdall.ui.safe.recover.address
 
 import android.content.Context
 import android.content.Intent
+import android.os.Bundle
 import android.support.v4.content.ContextCompat
 import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.widget.textChanges
@@ -20,6 +21,7 @@ import pm.gnosis.heimdall.ui.qrscan.QRCodeScanActivity
 import pm.gnosis.heimdall.ui.safe.recover.extension.RecoverPairingActivity
 import pm.gnosis.heimdall.utils.handleQrCodeActivityResult
 import pm.gnosis.heimdall.utils.parseEthereumAddress
+import pm.gnosis.heimdall.utils.setCompoundDrawableResource
 import pm.gnosis.heimdall.utils.setCompoundDrawables
 import pm.gnosis.svalinn.common.utils.snackbar
 import pm.gnosis.svalinn.common.utils.subscribeForResult
@@ -50,6 +52,11 @@ class CheckSafeActivity : ViewModelActivity<CheckSafeContract>() {
                     snackbar(layout_check_safe_address_input, R.string.invalid_ethereum_address)
                 }
             })
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        layout_check_safe_next.setCompoundDrawableResource(right = R.drawable.ic_arrow_forward_24dp)
     }
 
     override fun onStart() {

--- a/app/src/main/java/pm/gnosis/heimdall/utils/ViewUtils.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/utils/ViewUtils.kt
@@ -2,7 +2,9 @@ package pm.gnosis.heimdall.utils
 
 import android.graphics.drawable.Drawable
 import android.support.annotation.ColorRes
+import android.support.annotation.DrawableRes
 import android.support.v4.view.ViewCompat
+import android.support.v7.content.res.AppCompatResources
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
@@ -32,3 +34,16 @@ fun TextView.setCompoundDrawables(
 ) =
     if (useIntrinsicBounds) setCompoundDrawablesWithIntrinsicBounds(left, top, right, bottom)
     else setCompoundDrawablesRelative(left, top, right, bottom)
+
+fun TextView.setCompoundDrawableResource(
+    @DrawableRes left: Int = 0,
+    @DrawableRes top: Int = 0,
+    @DrawableRes right: Int = 0,
+    @DrawableRes bottom: Int = 0,
+    useIntrinsicBounds: Boolean = true
+) {
+    setCompoundDrawables(getDrawable(left), getDrawable(top), getDrawable(right), getDrawable(bottom), useIntrinsicBounds)
+}
+
+fun View.getDrawable(@DrawableRes id: Int)
+    = if (id == 0) null else AppCompatResources.getDrawable(context, id)

--- a/app/src/main/res/layout/layout_check_safe.xml
+++ b/app/src/main/res/layout/layout_check_safe.xml
@@ -100,9 +100,9 @@
             android:id="@+id/layout_check_safe_toolbar_shadow"
             android:layout_width="match_parent"
             android:layout_height="@dimen/toolbar_shadow_size"
+            android:alpha="0"
             android:background="@drawable/toolbar_dropshadow"
             app:layout_constraintTop_toBottomOf="@id/layout_check_safe_title"
-            android:alpha="0"
             tools:alpha="1" />
 
         <TextView
@@ -111,12 +111,12 @@
             android:layout_width="match_parent"
             android:layout_height="46dp"
             android:drawablePadding="8dp"
-            android:drawableEnd="@drawable/ic_arrow_forward_24dp"
             android:fontFamily="sans-serif-medium"
             android:gravity="end|center_vertical"
             android:text="@string/continue_text"
             android:textColor="@color/white"
-            app:layout_constraintBottom_toBottomOf="parent" />
+            app:layout_constraintBottom_toBottomOf="parent"
+            tools:drawableEnd="@drawable/ic_arrow_forward_24dp" />
 
     </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/layout_confirm_safe_recovery_phrase_item.xml
+++ b/app/src/main/res/layout/layout_confirm_safe_recovery_phrase_item.xml
@@ -7,7 +7,6 @@
     android:layout_height="wrap_content"
     android:layout_margin="4dp"
     android:background="@drawable/word_selected"
-    android:drawableEnd="@drawable/ic_cross_action"
     android:drawablePadding="8dp"
     android:gravity="center"
     android:maxLines="1"
@@ -15,4 +14,5 @@
     android:textColor="@color/white"
     app:autoSizeMinTextSize="6sp"
     app:autoSizeTextType="uniform"
+    tools:drawableEnd="@drawable/ic_cross_action"
     tools:text="Mnemonic" />

--- a/app/src/main/res/layout/layout_create_safe_intro.xml
+++ b/app/src/main/res/layout/layout_create_safe_intro.xml
@@ -144,7 +144,6 @@
         android:layout_width="wrap_content"
         android:layout_height="0dp"
         android:background="@drawable/selectable_background"
-        android:drawableEnd="@drawable/ic_arrow_forward_24dp"
         android:drawablePadding="8dp"
         android:fontFamily="sans-serif-medium"
         android:gravity="center"
@@ -155,7 +154,8 @@
         android:textSize="16sp"
         app:layout_constraintBottom_toBottomOf="@+id/layout_create_safe_intro_bottom_bar"
         app:layout_constraintEnd_toEndOf="@+id/layout_create_safe_intro_bottom_bar"
-        app:layout_constraintTop_toTopOf="@+id/layout_create_safe_intro_bottom_bar" />
+        app:layout_constraintTop_toTopOf="@+id/layout_create_safe_intro_bottom_bar"
+        tools:drawableEnd="@drawable/ic_arrow_forward_24dp" />
 
     <View
         android:id="@+id/layout_create_safe_intro_toolbar_shadow"

--- a/app/src/main/res/layout/layout_input_recovery_phrase.xml
+++ b/app/src/main/res/layout/layout_input_recovery_phrase.xml
@@ -76,8 +76,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:visibility="gone"
-                    tools:visibility="visible"
-                    app:constraint_referenced_ids="layout_input_recovery_phrase_input_layout,layout_input_recovery_phrase_input_info" />
+                    app:constraint_referenced_ids="layout_input_recovery_phrase_input_layout,layout_input_recovery_phrase_input_info"
+                    tools:visibility="visible" />
 
             </android.support.constraint.ConstraintLayout>
 
@@ -124,14 +124,14 @@
             style="@style/PrimaryButton.Blue.FullWidth"
             android:layout_width="match_parent"
             android:layout_height="46dp"
-            android:drawableEnd="@drawable/ic_arrow_forward_24dp"
             android:drawablePadding="8dp"
             android:enabled="false"
             android:fontFamily="sans-serif-medium"
             android:gravity="end|center_vertical"
             android:text="@string/continue_text"
             android:textColor="@color/white"
-            app:layout_constraintBottom_toBottomOf="parent" />
+            app:layout_constraintBottom_toBottomOf="parent"
+            tools:drawableEnd="@drawable/ic_arrow_forward_24dp" />
 
     </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/layout_safe_details.xml
+++ b/app/src/main/res/layout/layout_safe_details.xml
@@ -33,9 +33,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="16dp"
                 android:drawablePadding="8dp"
-                android:drawableStart="@drawable/ic_send_azure"
                 android:gravity="center"
-                android:text="@string/send" />
+                android:text="@string/send"
+                tools:drawableStart="@drawable/ic_send_azure" />
 
             <TextView
                 android:id="@+id/layout_safe_details_receive_button"
@@ -44,9 +44,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:drawablePadding="8dp"
-                android:drawableStart="@drawable/ic_qrcode_scan_azure"
                 android:gravity="center"
-                android:text="@string/receive" />
+                android:text="@string/receive"
+                tools:drawableStart="@drawable/ic_qrcode_scan_azure" />
         </LinearLayout>
 
         <me.zhanghai.android.materialprogressbar.MaterialProgressBar

--- a/app/src/main/res/layout/layout_safe_main.xml
+++ b/app/src/main/res/layout/layout_safe_main.xml
@@ -227,18 +227,18 @@
                     style="@style/NavigationText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:drawableStart="@drawable/ic_create_new_safe"
                     android:text="@string/create_safe"
-                    app:layout_constraintTop_toBottomOf="@id/layout_safe_main_safes_list" />
+                    app:layout_constraintTop_toBottomOf="@id/layout_safe_main_safes_list"
+                    tools:drawableStart="@drawable/ic_create_new_safe" />
 
                 <TextView
                     android:id="@+id/layout_safe_main_recover_safe"
                     style="@style/NavigationText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:drawableStart="@drawable/ic_recover_safe"
                     android:text="@string/recover_safe"
-                    app:layout_constraintTop_toBottomOf="@id/layout_safe_main_add_safe" />
+                    app:layout_constraintTop_toBottomOf="@id/layout_safe_main_add_safe"
+                    tools:drawableStart="@drawable/ic_recover_safe" />
 
                 <View
                     android:id="@+id/layout_safe_main_navigation_safe_creation_divider"
@@ -253,8 +253,8 @@
                     android:id="@+id/layout_safe_main_account_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:layout_constraintTop_toBottomOf="@id/layout_safe_main_navigation_safe_creation_divider"
                     android:layout_marginTop="8dp"
+                    app:layout_constraintTop_toBottomOf="@id/layout_safe_main_navigation_safe_creation_divider"
                     app:layout_goneMarginTop="16dp">
 
                     <TextView
@@ -262,10 +262,10 @@
                         style="@style/NavigationText"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:drawableStart="@drawable/ic_settings_account"
                         android:text="@string/my_account"
                         android:visibility="gone"
-                        tools:visibility="visible"/>
+                        tools:drawableStart="@drawable/ic_settings_account"
+                        tools:visibility="visible" />
                 </FrameLayout>
 
                 <TextView
@@ -273,27 +273,27 @@
                     style="@style/NavigationText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:drawableStart="@drawable/ic_tokens"
                     android:text="@string/manage_tokens"
-                    app:layout_constraintTop_toBottomOf="@id/layout_safe_main_account_container" />
+                    app:layout_constraintTop_toBottomOf="@id/layout_safe_main_account_container"
+                    tools:drawableStart="@drawable/ic_tokens" />
 
                 <TextView
                     android:id="@+id/layout_safe_main_address_book"
                     style="@style/NavigationText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:drawableStart="@drawable/ic_settings_address_book"
                     android:text="@string/address_book"
-                    app:layout_constraintTop_toBottomOf="@id/layout_safe_main_tokens" />
+                    app:layout_constraintTop_toBottomOf="@id/layout_safe_main_tokens"
+                    tools:drawableStart="@drawable/ic_settings_address_book" />
 
                 <TextView
                     android:id="@+id/layout_safe_main_general_settings"
                     style="@style/NavigationText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:drawableStart="@drawable/ic_general_settings"
                     android:text="@string/settings"
-                    app:layout_constraintTop_toBottomOf="@id/layout_safe_main_address_book" />
+                    app:layout_constraintTop_toBottomOf="@id/layout_safe_main_address_book"
+                    tools:drawableStart="@drawable/ic_general_settings" />
 
 
                 <!-- Container to hide this when not in Debug Mode (else it is controlled by ContraintGroup) -->
@@ -308,9 +308,9 @@
                         style="@style/NavigationText"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:drawableStart="@drawable/ic_settings_debug"
                         android:text="@string/debug_settings"
-                        android:visibility="gone" />
+                        android:visibility="gone"
+                        tools:drawableStart="@drawable/ic_settings_debug" />
                 </FrameLayout>
 
                 <android.support.constraint.Group


### PR DESCRIPTION
Closes WA-487.

Changes proposed in this pull request:
- Add new extension function to set (vector) drawable resources in a backwards compatibility fashion.
- Replace all direct usages of vector resources in TextViews with the new extension function.

@gnosis/mobile-devs
