### PR TITLE
Closes #63: Enable password stretching and hardware encryption

### DIFF
--- a/app/src/main/java/pm/gnosis/heimdall/di/modules/ApplicationModule.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/di/modules/ApplicationModule.kt
@@ -38,8 +38,10 @@ import pm.gnosis.svalinn.common.utils.QrCodeGenerator
 import pm.gnosis.svalinn.common.utils.ZxingQrCodeGenerator
 import pm.gnosis.svalinn.security.EncryptionManager
 import pm.gnosis.svalinn.security.FingerprintHelper
+import pm.gnosis.svalinn.security.KeyStorage
 import pm.gnosis.svalinn.security.impls.AesEncryptionManager
 import pm.gnosis.svalinn.security.impls.AndroidFingerprintHelper
+import pm.gnosis.svalinn.security.impls.AndroidKeyStorage
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -185,12 +187,19 @@ class ApplicationModule(private val application: Application) {
 
     @Provides
     @Singleton
+    fun providesKeyStorage(@ApplicationContext context: Context): KeyStorage =
+        AndroidKeyStorage(context)
+
+    @Provides
+    @Singleton
     fun providesEncryptionManager(
         application: Application,
         preferencesManager: PreferencesManager,
-        fingerprintHelper: FingerprintHelper
+        fingerprintHelper: FingerprintHelper,
+        keyStorage: KeyStorage
     ): EncryptionManager =
-        AesEncryptionManager(application, preferencesManager, fingerprintHelper)
+        // We use 4k iterations to keep the memory used during password setup below 16mb (theoretical minimum vm heap for Android 4.4)
+        AesEncryptionManager(application, preferencesManager, fingerprintHelper, keyStorage, 4096)
 
     @Provides
     @Singleton

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/recover/submit/RecoveringSafeViewModel.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/recover/submit/RecoveringSafeViewModel.kt
@@ -22,8 +22,10 @@ import pm.gnosis.svalinn.accounts.base.repositories.AccountsRepository
 import pm.gnosis.svalinn.common.utils.DataResult
 import pm.gnosis.svalinn.common.utils.Result
 import pm.gnosis.svalinn.common.utils.mapToResult
+import pm.gnosis.utils.addHexPrefix
 import pm.gnosis.utils.asTransactionHash
 import pm.gnosis.utils.hexAsBigInteger
+import pm.gnosis.utils.toHexString
 import java.math.BigInteger
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -97,18 +99,24 @@ class RecoveringSafeViewModel @Inject constructor(
     override fun loadRecoveryExecuteInfo(address: Solidity.Address): Single<TransactionExecutionRepository.ExecuteInformation> =
         safeRepository.loadRecoveringSafe(address)
             .flatMap { safe ->
-                executionRepository.loadSafeExecuteState(address)
-                    .map { TransactionExecutionRepository.ExecuteInformation(
-                        safe.transactionHash!!.asTransactionHash(),
-                        buildSafeTransaction(safe),
-                        it.sender,
-                        it.requiredConfirmation,
-                        it.owners,
-                        safe.gasPrice,
-                        safe.txGas,
-                        safe.dataGas,
-                        it.balance
-                    ) }
+                val tx = buildSafeTransaction(safe)
+                executionRepository.calculateHash(address, tx, safe.gasPrice, safe.txGas, safe.dataGas)
+                    .flatMap { hash ->
+                        executionRepository.loadSafeExecuteState(address)
+                            .map {
+                                TransactionExecutionRepository.ExecuteInformation(
+                                    hash.toHexString().addHexPrefix(),
+                                    tx,
+                                    it.sender,
+                                    it.requiredConfirmation,
+                                    it.owners,
+                                    safe.gasPrice,
+                                    safe.txGas,
+                                    safe.dataGas,
+                                    it.balance
+                                )
+                            }
+                    }
             }
             .onErrorResumeNext { errorHandler.single(it) }
 
@@ -147,7 +155,8 @@ class RecoveringSafeViewModel @Inject constructor(
             .flatMap { safe ->
                 val gasCosts = (safe.txGas + safe.dataGas) * safe.gasPrice
                 // Create a fake token since only the address is necessary to load the balance
-                requestBalance(safe.address,
+                requestBalance(
+                    safe.address,
                     ERC20Token(safe.gasToken, decimals = 0, name = "", symbol = "")
                 )
                     .map { if (it < gasCosts) throw SafeCreationFundViewModel.NotEnoughFundsException() }

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -36,7 +36,7 @@ ext {
             rxjava                : '2.2.1',
             rxkotlin              : '2.3.0',
             spongycastle          : '1.58.0.0',
-            svalinn               : 'v0.5.4',
+            svalinn               : 'v0.6.0',
             timber                : '4.7.1',
             zxing                 : '3.3.1',
 


### PR DESCRIPTION
Closes #63.

Changes proposed in this pull request:
- Enable password stretching and hardware encryption (Svalinn 0.6.0)
- Don't request ExecuteInformation for stored recovery (build from stored information)

@gnosis/mobile-devs
