### PR TITLE
Closes #228: Prevent flashing on fresh start

### DIFF
--- a/app/src/main/java/pm/gnosis/heimdall/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/splash/SplashActivity.kt
@@ -14,6 +14,7 @@ import pm.gnosis.heimdall.reporting.ScreenId
 import pm.gnosis.heimdall.ui.base.BaseActivity
 import pm.gnosis.heimdall.ui.onboarding.OnboardingIntroActivity
 import pm.gnosis.heimdall.ui.safe.main.SafeMainActivity
+import pm.gnosis.heimdall.ui.security.unlock.UnlockActivity
 import pm.gnosis.svalinn.common.utils.startActivity
 import timber.log.Timber
 import javax.inject.Inject
@@ -43,12 +44,17 @@ class SplashActivity : BaseActivity() {
     private fun handleAction(action: ViewAction) {
         when (action) {
             is StartMain -> startMain()
+            is StartUnlock -> startUnlock()
             is StartPasswordSetup -> startPasswordSetup()
         }
     }
 
     private fun startMain() {
         startActivity(SafeMainActivity.createIntent(this).apply { addFlags(FLAG_ACTIVITY_NO_ANIMATION) }, clearStack = true)
+    }
+
+    private fun startUnlock() {
+        startActivity(UnlockActivity.createIntent(this))
     }
 
     private fun startPasswordSetup() {

--- a/app/src/main/java/pm/gnosis/heimdall/ui/splash/SplashContract.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/splash/SplashContract.kt
@@ -8,5 +8,6 @@ abstract class SplashContract : ViewModel() {
 }
 
 sealed class ViewAction
-class StartMain : ViewAction()
-class StartPasswordSetup : ViewAction()
+object StartMain : ViewAction()
+object StartPasswordSetup : ViewAction()
+object StartUnlock : ViewAction()

--- a/app/src/main/java/pm/gnosis/heimdall/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/splash/SplashViewModel.kt
@@ -2,7 +2,6 @@ package pm.gnosis.heimdall.ui.splash
 
 import android.arch.persistence.room.EmptyResultSetException
 import io.reactivex.Single
-import pm.gnosis.heimdall.data.repositories.TokenRepository
 import pm.gnosis.svalinn.accounts.base.repositories.AccountsRepository
 import pm.gnosis.svalinn.security.EncryptionManager
 import java.util.concurrent.TimeUnit

--- a/app/src/test/java/pm/gnosis/heimdall/ui/splash/SplashViewModelTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/splash/SplashViewModelTest.kt
@@ -11,7 +11,6 @@ import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import pm.gnosis.heimdall.data.repositories.TokenRepository
 import pm.gnosis.model.Solidity
 import pm.gnosis.svalinn.accounts.base.models.Account
 import pm.gnosis.svalinn.accounts.base.repositories.AccountsRepository


### PR DESCRIPTION
Closes #228.

Changes proposed in this pull request:
- If app is locked on splash start unlock screen to prevent "white flash"

@gnosis/mobile-devs
