### PR TITLE
Update dependencies. Using new Android Tools Gradle Plugin.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ android:
     - tools
 
     # The BuildTools version used by your project
-    - build-tools-27.0.3
+    - build-tools-28.0.3
 
     # The SDK version used to compile your project
-    - android-27
+    - android-28
 
     - extra-android-m2repository
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ subprojects {
         if (project.hasProperty("android")) {
             android {
                 compileSdkVersion 28
-                buildToolsVersion "28.0.2"
+                buildToolsVersion "28.0.3"
 
                 defaultConfig {
                     minSdkVersion 19

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -1,10 +1,10 @@
 ext {
     versions = [
             // Plug-Ins
-            android_tools         : '3.1.4',
+            android_tools         : '3.2.0',
             fabric                : '1.+',
-            google_services       : '3.3.0',
-            kotlin                : '1.2.61',
+            google_services       : '4.1.0',
+            kotlin                : '1.2.71',
             jacoco                : '0.7.9',
 
             // Runtime dependencies
@@ -36,7 +36,7 @@ ext {
             rxjava                : '2.2.1',
             rxkotlin              : '2.3.0',
             spongycastle          : '1.58.0.0',
-            svalinn               : 'v0.6.0',
+            svalinn               : 'v0.6.2',
             timber                : '4.7.1',
             zxing                 : '3.3.1',
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Kotlin (1.2.61 -> 1.2.71)
- Android Tools Gradle Plugin (3.1.4 -> 3.2.0)
- Google Services Gradle Plugin (3.3.0 -> 4.1.0)
- Build Tools (28.0.2 -> 28.0.3)

@gnosis/mobile-devs
