### PR TITLE
Do not show recovery options when Safe creation is pending

### DIFF
--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/main/SafeMainActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/main/SafeMainActivity.kt
@@ -364,6 +364,8 @@ class SafeMainActivity : ViewModelActivity<SafeMainContract>() {
         layout_safe_main_toolbar_overflow.visible(selectedSafe != null)
         val extendedMenu = selectedSafe is Safe
         popupMenu.menu.findItem(R.id.safe_details_menu_sync).isVisible = extendedMenu
+        popupMenu.menu.findItem(R.id.safe_details_menu_replace_recovery_phrase).isVisible = extendedMenu
+        popupMenu.menu.findItem(R.id.safe_details_menu_replace_browser_extension).isVisible = extendedMenu
     }
 
     private fun renameSafe(safe: AbstractSafe) {


### PR DESCRIPTION
Closes #252

Changes proposed in this pull request:
- Hide "Replace recovery phrase" and "Replace browser extension" if the safe is not created yet

@gnosis/mobile-devs
