### PR TITLE
Send gas token in push

### DIFF
--- a/app/src/main/java/pm/gnosis/heimdall/data/repositories/PushServiceRepository.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/repositories/PushServiceRepository.kt
@@ -25,6 +25,7 @@ interface PushServiceRepository {
         dataGas: BigInteger,
         operationalGas: BigInteger,
         gasPrice: BigInteger,
+        gasToken: Solidity.Address,
         targets: Set<Solidity.Address>
     ): Completable
 

--- a/app/src/main/java/pm/gnosis/heimdall/data/repositories/impls/DefaultPushServiceRepository.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/repositories/impls/DefaultPushServiceRepository.kt
@@ -144,12 +144,13 @@ class DefaultPushServiceRepository @Inject constructor(
         dataGas: BigInteger,
         operationalGas: BigInteger,
         gasPrice: BigInteger,
+        gasToken: Solidity.Address,
         targets: Set<Solidity.Address>
     ): Completable =
         Single.fromCallable {
             ServiceMessage.RequestConfirmation(
                 hash = hash,
-                safe = safeAddress.asEthereumAddressString(),
+                safe = safeAddress.asEthereumAddressChecksumString(),
                 to = transaction.wrapped.address.asEthereumAddressChecksumString(),
                 value = transaction.wrapped.value?.value?.asDecimalString() ?: "0",
                 data = transaction.wrapped.data ?: "",
@@ -158,7 +159,7 @@ class DefaultPushServiceRepository @Inject constructor(
                 dataGas = dataGas.asDecimalString(),
                 operationalGas = operationalGas.asDecimalString(),
                 gasPrice = gasPrice.asDecimalString(),
-                gasToken = "0",
+                gasToken = gasToken.asEthereumAddressChecksumString(),
                 refundReceiver = "0",
                 nonce = transaction.wrapped.nonce?.asDecimalString() ?: "0"
             )

--- a/app/src/main/java/pm/gnosis/heimdall/ui/transactions/view/helpers/SubmitTransactionHelper.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/transactions/view/helpers/SubmitTransactionHelper.kt
@@ -208,6 +208,7 @@ class DefaultSubmitTransactionHelper @Inject constructor(
                                 params.dataGas,
                                 params.operationalGas,
                                 params.gasPrice,
+                                params.gasToken,
                                 targets.toSet()
                             )
 

--- a/app/src/test/java/pm/gnosis/heimdall/data/repositories/impls/DefaultPushServiceRepositoryTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/data/repositories/impls/DefaultPushServiceRepositoryTest.kt
@@ -762,7 +762,7 @@ class DefaultPushServiceRepositoryTest {
             dataGas = "10",
             operationalGas = "10",
             gasPrice = "10",
-            gasToken = "0",
+            gasToken = "0x00000000000000000000000000000000DeaDBeef",
             refundReceiver = "0",
             nonce = "0"
         )
@@ -783,7 +783,8 @@ class DefaultPushServiceRepositoryTest {
             txGas = 10.toBigInteger(),
             dataGas = 10.toBigInteger(),
             operationalGas = 10.toBigInteger(),
-            gasPrice = 10.toBigInteger()
+            gasPrice = 10.toBigInteger(),
+            gasToken = "0xdeadbeef".asEthereumAddress()!!
         ).subscribe(testObserver)
 
         then(moshiMock).should().adapter(ServiceMessage.RequestConfirmation::class.java)
@@ -819,7 +820,7 @@ class DefaultPushServiceRepositoryTest {
             dataGas = "10",
             operationalGas = "10",
             gasPrice = "10",
-            gasToken = "0",
+            gasToken = "0x0000000000000000000000000000000000000000",
             refundReceiver = "0",
             nonce = "0"
         )
@@ -841,7 +842,8 @@ class DefaultPushServiceRepositoryTest {
             txGas = 10.toBigInteger(),
             dataGas = 10.toBigInteger(),
             operationalGas = 10.toBigInteger(),
-            gasPrice = 10.toBigInteger()
+            gasPrice = 10.toBigInteger(),
+            gasToken = "0x0".asEthereumAddress()!!
         ).subscribe(testObserver)
 
         then(moshiMock).should().adapter(ServiceMessage.RequestConfirmation::class.java)
@@ -877,7 +879,7 @@ class DefaultPushServiceRepositoryTest {
             dataGas = "10",
             operationalGas = "10",
             gasPrice = "10",
-            gasToken = "0",
+            gasToken = "0x0000000000000000000000000000000000000000",
             refundReceiver = "0",
             nonce = "0"
         )
@@ -898,7 +900,8 @@ class DefaultPushServiceRepositoryTest {
             txGas = 10.toBigInteger(),
             dataGas = 10.toBigInteger(),
             operationalGas = 10.toBigInteger(),
-            gasPrice = 10.toBigInteger()
+            gasPrice = 10.toBigInteger(),
+            gasToken = "0x0".asEthereumAddress()!!
         ).subscribe(testObserver)
 
         then(moshiMock).should().adapter(ServiceMessage.RequestConfirmation::class.java)
@@ -926,7 +929,7 @@ class DefaultPushServiceRepositoryTest {
             dataGas = "10",
             operationalGas = "10",
             gasPrice = "10",
-            gasToken = "0",
+            gasToken = "0x0000000000000000000000000000000000000000",
             refundReceiver = "0",
             nonce = "0"
         )
@@ -946,7 +949,8 @@ class DefaultPushServiceRepositoryTest {
             txGas = 10.toBigInteger(),
             dataGas = 10.toBigInteger(),
             operationalGas = 10.toBigInteger(),
-            gasPrice = 10.toBigInteger()
+            gasPrice = 10.toBigInteger(),
+            gasToken = "0x0".asEthereumAddress()!!
         ).subscribe(testObserver)
 
         then(moshiMock).should().adapter(ServiceMessage.RequestConfirmation::class.java)

--- a/app/src/test/java/pm/gnosis/heimdall/ui/transactions/view/helpers/DefaultSubmitTransactionHelperTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/transactions/view/helpers/DefaultSubmitTransactionHelperTest.kt
@@ -242,6 +242,7 @@ class DefaultSubmitTransactionHelperTest {
                 MockUtils.any(),
                 MockUtils.any(),
                 MockUtils.any(),
+                MockUtils.any(),
                 anySet()
             )
         )
@@ -260,6 +261,7 @@ class DefaultSubmitTransactionHelperTest {
                 info.dataGas,
                 info.operationalGas,
                 info.gasPrice,
+                info.gasToken,
                 setOf(TEST_OWNERS[0], TEST_OWNERS[1])
             )
 
@@ -273,6 +275,7 @@ class DefaultSubmitTransactionHelperTest {
         given(
             signaturePushRepository.requestConfirmations(
                 anyString(),
+                MockUtils.any(),
                 MockUtils.any(),
                 MockUtils.any(),
                 MockUtils.any(),
@@ -296,6 +299,7 @@ class DefaultSubmitTransactionHelperTest {
                 info.dataGas,
                 info.operationalGas,
                 info.gasPrice,
+                info.gasToken,
                 setOf(TEST_OWNERS[1])
             )
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Set correct gasToken in requestConfirmation push message

@gnosis/mobile-devs
