### PR TITLE
Switch to R8

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,6 @@
 steps:
-
   - label: ':the_horns: UI Tests'
     command: 'ci/run_ui_tests.sh'
+
+  - label: ':eyes: Obfuscate/Minify build'
+    command: 'ci/transform_with_R8.sh'

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -27,7 +27,7 @@ ext {
             koptional                 : '1.2.0',
             material                  : '1.0.0',
             material_progressbar      : '1.4.2',
-            moshi                     : '1.6.0',
+            moshi                     : '1.8.0',
             multidex                  : '2.0.1',
             okhttp                    : '3.11.0',
             okio                      : '1.15.0',

--- a/ci/google-services.json.sample
+++ b/ci/google-services.json.sample
@@ -36,6 +36,68 @@
           "status": 2
         }
       }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:1:android:1",
+        "android_client_info": {
+          "package_name": "pm.gnosis.heimdall.dev"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "1234-somefakeid.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "SomeFakeApiKey"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:1:android:1",
+        "android_client_info": {
+          "package_name": "pm.gnosis.heimdall"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "1234-somefakeid.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "SomeFakeApiKey"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
     }
   ],
   "configuration_version": "1"

--- a/ci/transform_with_R8.sh
+++ b/ci/transform_with_R8.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# fail if any commands fails
+set -e
+
+cp ci/google-services.json.sample app/google-services.json
+./gradlew clean --stacktrace
+./gradlew :app:transformClassesAndResourcesWithR8ForRelease --stacktrace

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,4 @@ org.gradle.jvmargs=-Xmx8g
 # org.gradle.parallel=true
 android.enableJetifier=true
 android.useAndroidX=true
+android.enableR8 = true


### PR DESCRIPTION
Changes proposed in this pull request:
- Switch to R8
- Update Moshi
- Buildkite now requires R8 (switching to Proguard will make the build fail)

@gnosis/mobile-devs
