### PR TITLE
Added additional rules to keep JsonQualifier annotations

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -66,6 +66,9 @@
 }
 -keepnames @com.squareup.moshi.JsonClass class *
 
+-keep @interface pm.gnosis.heimdall.data.adapters.HexNumber
+-keep @interface pm.gnosis.heimdall.data.adapters.DecimalNumber
+
 ####################################################################################################
 # Retrofit
 ####################################################################################################


### PR DESCRIPTION
Changes proposed in this pull request:
- Added proguard rules to keep JsonQualifier annotations
- see https://github.com/square/moshi/issues/799

@gnosis/mobile-devs
