### PR TITLE
Use new auth endpoint

### DIFF
--- a/app/src/main/java/pm/gnosis/heimdall/data/remote/PushServiceApi.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/remote/PushServiceApi.kt
@@ -8,7 +8,7 @@ import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface PushServiceApi {
-    @POST("v1/auth/")
+    @POST("v2/auth/")
     fun auth(@Body pushServiceAuth: PushServiceAuth): Completable
 
     @POST("v1/pairing/")

--- a/app/src/main/java/pm/gnosis/heimdall/data/remote/models/push/PushServiceAuth.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/remote/models/push/PushServiceAuth.kt
@@ -6,5 +6,9 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class PushServiceAuth(
     @Json(name = "push_token") val pushToken: String,
-    @Json(name = "signature") val signature: ServiceSignature
+    @Json(name = "build_number") val buildNumber: Int,
+    @Json(name = "version_name") val versionName: String,
+    @Json(name = "client") val client: String,
+    @Json(name = "bundle") val bundle: String,
+    @Json(name = "signatures") val signatures: List<ServiceSignature>
 )

--- a/app/src/main/java/pm/gnosis/heimdall/ui/security/unlock/UnlockViewModel.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/security/unlock/UnlockViewModel.kt
@@ -46,5 +46,5 @@ class UnlockViewModel @Inject constructor(
                 State.UNLOCKED
             }.toObservable().mapToResult()
 
-    override fun syncPushAuthentication() = pushServiceRepository.syncAuthentication()
+    override fun syncPushAuthentication() = pushServiceRepository.syncAuthentication(true)
 }


### PR DESCRIPTION
Closes #348.

Changes proposed in this pull request:
- Use v2 of auth endpoint

@gnosis/mobile-devs
