### PR TITLE
Fix casting from array to map

### DIFF
--- a/app/src/main/java/pm/gnosis/heimdall/ui/transactions/view/helpers/SubmitTransactionHelper.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/transactions/view/helpers/SubmitTransactionHelper.kt
@@ -172,6 +172,7 @@ class DefaultSubmitTransactionHelper @Inject constructor(
                 @Suppress("UNCHECKED_CAST")
                 results.associate { entry -> (entry as Pair<Solidity.Address, Signature>) }
             }
+                .onErrorReturn { emptyMap() }
         } ?: Single.just(emptyMap()))
             .flatMapObservable {
                 signatureStore.flatMapInfo(

--- a/app/src/main/java/pm/gnosis/heimdall/ui/transactions/view/helpers/SubmitTransactionHelper.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/transactions/view/helpers/SubmitTransactionHelper.kt
@@ -170,7 +170,7 @@ class DefaultSubmitTransactionHelper @Inject constructor(
                 }
             ) { results ->
                 @Suppress("UNCHECKED_CAST")
-                (results as? Array<Pair<Solidity.Address, Signature>>)?.toMap() ?: emptyMap()
+                results.associate { entry -> (entry as Pair<Solidity.Address, Signature>) }
             }
         } ?: Single.just(emptyMap()))
             .flatMapObservable {

--- a/app/src/test/java/pm/gnosis/heimdall/ui/transactions/view/helpers/DefaultSubmitTransactionHelperTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/transactions/view/helpers/DefaultSubmitTransactionHelperTest.kt
@@ -699,7 +699,9 @@ class DefaultSubmitTransactionHelperTest {
         testObserver.assertUpdates(updates)
         testSingleFactory.assertCount(1)
 
-        then(signatureStore).should().flatMapInfo(MockUtils.eq(TEST_SAFE), MockUtils.eq(info), MockUtils.eq(emptyMap()))
+        then(signatureStore).should().flatMapInfo(
+            MockUtils.eq(TEST_SAFE), MockUtils.eq(info), MockUtils.eq(mapOf(Solidity.Address(BigInteger.ONE) to TEST_SIGNATURE))
+        )
     }
 
     private fun loadExecutionInfo(transaction: SafeTransaction) =

--- a/app/src/test/java/pm/gnosis/heimdall/ui/transactions/view/helpers/DefaultSubmitTransactionHelperTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/transactions/view/helpers/DefaultSubmitTransactionHelperTest.kt
@@ -574,6 +574,8 @@ class DefaultSubmitTransactionHelperTest {
         signatureSubject.onNext(mapOf(TEST_OWNERS[0] to TEST_SIGNATURE))
         updates += { it == DataResult(SubmitTransactionHelper.ViewUpdate.Confirmations(true)) }
         testObserver.assertUpdates(updates)
+
+        then(signatureStore).should().flatMapInfo(MockUtils.eq(TEST_SAFE), MockUtils.eq(info), MockUtils.eq(mapOf(TEST_OWNERS[0] to TEST_SIGNATURE)))
     }
 
     @Test
@@ -634,6 +636,8 @@ class DefaultSubmitTransactionHelperTest {
         updates += { it == DataResult(SubmitTransactionHelper.ViewUpdate.Confirmations(false)) }
         testObserver.assertUpdates(updates)
         testSingleFactory.assertCount(1)
+
+        then(signatureStore).should().flatMapInfo(MockUtils.eq(TEST_SAFE), MockUtils.eq(info), MockUtils.eq(emptyMap()))
     }
 
     @Test
@@ -694,6 +698,8 @@ class DefaultSubmitTransactionHelperTest {
         updates += { it == DataResult(SubmitTransactionHelper.ViewUpdate.Confirmations(false)) }
         testObserver.assertUpdates(updates)
         testSingleFactory.assertCount(1)
+
+        then(signatureStore).should().flatMapInfo(MockUtils.eq(TEST_SAFE), MockUtils.eq(info), MockUtils.eq(emptyMap()))
     }
 
     private fun loadExecutionInfo(transaction: SafeTransaction) =

--- a/app/src/test/java/pm/gnosis/heimdall/ui/transactions/view/helpers/DefaultSubmitTransactionHelperTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/transactions/view/helpers/DefaultSubmitTransactionHelperTest.kt
@@ -34,6 +34,7 @@ import pm.gnosis.tests.utils.MockUtils
 import pm.gnosis.tests.utils.TestSingleFactory
 import pm.gnosis.utils.asEthereumAddress
 import pm.gnosis.utils.hexToByteArray
+import java.lang.IllegalStateException
 import java.math.BigInteger
 import java.util.concurrent.TimeoutException
 
@@ -517,6 +518,182 @@ class DefaultSubmitTransactionHelperTest {
         signatureSubject.onNext(emptyMap())
         updates += { it == DataResult(SubmitTransactionHelper.ViewUpdate.Confirmations(true)) }
         testObserver.assertUpdates(updates)
+    }
+
+    @Test
+    fun initialSignatures() {
+        given(tokenRepository.loadToken(MockUtils.any())).willReturn(Single.just(ERC20Token.ETHER_TOKEN))
+        val signatureSubject = PublishSubject.create<Map<Solidity.Address, Signature>>()
+        given(signatureStore.flatMapInfo(MockUtils.any(), MockUtils.any(), MockUtils.any())).willReturn(signatureSubject)
+        val pushMessageSubject = PublishSubject.create<PushServiceRepository.TransactionResponse>()
+        given(signaturePushRepository.observe(anyString())).willReturn(pushMessageSubject)
+        given(
+            relayRepositoryMock.checkConfirmation(
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any()
+            )
+        ).willReturn(Single.just(TEST_OWNERS[0] to TEST_SIGNATURE))
+
+        submitTransactionHelper.setup(TEST_SAFE, ::loadExecutionInfo)
+        val retryEvents = PublishSubject.create<Unit>()
+        val requestEvents = PublishSubject.create<Unit>()
+        val submitEvents = PublishSubject.create<Unit>()
+        val events = SubmitTransactionHelper.Events(
+            retryEvents, requestEvents, submitEvents
+        )
+        val testObserver = TestObserver<Result<SubmitTransactionHelper.ViewUpdate>>()
+
+        val info = TransactionExecutionRepository.ExecuteInformation(
+            TEST_TRANSACTION_HASH, TEST_TRANSACTION,
+            TEST_OWNERS[2], TEST_OWNERS.size - 1, TEST_OWNERS, TEST_VERSION,
+            TEST_ETHER_TOKEN, BigInteger.ONE, BigInteger.TEN, BigInteger.ZERO, BigInteger.ZERO,
+            Wei.ether("23").value
+        )
+        given(relayRepositoryMock.loadExecuteInformation(MockUtils.any(), MockUtils.any(), MockUtils.any()))
+            .willReturn(Single.just(info))
+
+        val initialSignatures = setOf(TEST_SIGNATURE)
+
+        submitTransactionHelper.observe(events, TransactionData.AssetTransfer(TEST_ETHER_TOKEN, TEST_ETH_AMOUNT, TEST_ADDRESS), initialSignatures)
+            .subscribe(testObserver)
+
+        val updates = mutableListOf<((Result<SubmitTransactionHelper.ViewUpdate>) -> Boolean)>({
+            ((it as? DataResult)?.data as? SubmitTransactionHelper.ViewUpdate.TransactionInfo)?.viewHolder == transactionViewHolder
+        })
+        updates += {
+            it == DataResult(SubmitTransactionHelper.ViewUpdate.Estimate(BigInteger.TEN, Wei.ether("23").value, ERC20Token.ETHER_TOKEN, true))
+        }
+        testObserver.assertUpdates(updates)
+
+        signatureSubject.onNext(mapOf(TEST_OWNERS[0] to TEST_SIGNATURE))
+        updates += { it == DataResult(SubmitTransactionHelper.ViewUpdate.Confirmations(true)) }
+        testObserver.assertUpdates(updates)
+    }
+
+    @Test
+    fun initialSignaturesCheckError() {
+        given(tokenRepository.loadToken(MockUtils.any())).willReturn(Single.just(ERC20Token.ETHER_TOKEN))
+        val signatureSubject = PublishSubject.create<Map<Solidity.Address, Signature>>()
+        given(signatureStore.flatMapInfo(MockUtils.any(), MockUtils.any(), MockUtils.any())).willReturn(signatureSubject)
+        // Return a single that will not emit an value
+        val testSingleFactory = TestSingleFactory<Map<Solidity.Address, Signature>>()
+        given(signatureStore.load()).willReturn(testSingleFactory.get())
+        val pushMessageSubject = PublishSubject.create<PushServiceRepository.TransactionResponse>()
+        given(signaturePushRepository.observe(anyString())).willReturn(pushMessageSubject)
+        given(
+            relayRepositoryMock.checkConfirmation(
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any()
+            )
+        ).willReturn(Single.error(IllegalStateException()))
+
+        submitTransactionHelper.setup(TEST_SAFE, ::loadExecutionInfo)
+        val retryEvents = PublishSubject.create<Unit>()
+        val requestEvents = PublishSubject.create<Unit>()
+        val submitEvents = PublishSubject.create<Unit>()
+        val events = SubmitTransactionHelper.Events(
+            retryEvents, requestEvents, submitEvents
+        )
+        val testObserver = TestObserver<Result<SubmitTransactionHelper.ViewUpdate>>()
+
+        val info = TransactionExecutionRepository.ExecuteInformation(
+            TEST_TRANSACTION_HASH, TEST_TRANSACTION,
+            TEST_OWNERS[2], TEST_OWNERS.size - 1, TEST_OWNERS, TEST_VERSION,
+            TEST_ETHER_TOKEN, BigInteger.ONE, BigInteger.TEN, BigInteger.ZERO, BigInteger.ZERO,
+            Wei.ether("23").value
+        )
+        given(relayRepositoryMock.loadExecuteInformation(MockUtils.any(), MockUtils.any(), MockUtils.any()))
+            .willReturn(Single.just(info))
+
+        val initialSignatures = setOf(TEST_SIGNATURE)
+
+        submitTransactionHelper.observe(events, TransactionData.AssetTransfer(TEST_ETHER_TOKEN, TEST_ETH_AMOUNT, TEST_ADDRESS), initialSignatures)
+            .subscribe(testObserver)
+
+        val updates = mutableListOf<((Result<SubmitTransactionHelper.ViewUpdate>) -> Boolean)>({
+            ((it as? DataResult)?.data as? SubmitTransactionHelper.ViewUpdate.TransactionInfo)?.viewHolder == transactionViewHolder
+        })
+        updates += {
+            it == DataResult(SubmitTransactionHelper.ViewUpdate.Estimate(BigInteger.TEN, Wei.ether("23").value, ERC20Token.ETHER_TOKEN, true))
+        }
+        testObserver.assertUpdates(updates)
+
+        signatureSubject.onNext(emptyMap())
+        updates += { it == DataResult(SubmitTransactionHelper.ViewUpdate.Confirmations(false)) }
+        testObserver.assertUpdates(updates)
+        testSingleFactory.assertCount(1)
+    }
+
+    @Test
+    fun initialSignaturesUnknownOwner() {
+        given(tokenRepository.loadToken(MockUtils.any())).willReturn(Single.just(ERC20Token.ETHER_TOKEN))
+        val signatureSubject = PublishSubject.create<Map<Solidity.Address, Signature>>()
+        given(signatureStore.flatMapInfo(MockUtils.any(), MockUtils.any(), MockUtils.any())).willReturn(signatureSubject)
+        // Return a single that will not emit an value
+        val testSingleFactory = TestSingleFactory<Map<Solidity.Address, Signature>>()
+        given(signatureStore.load()).willReturn(testSingleFactory.get())
+        val pushMessageSubject = PublishSubject.create<PushServiceRepository.TransactionResponse>()
+        given(signaturePushRepository.observe(anyString())).willReturn(pushMessageSubject)
+        given(
+            relayRepositoryMock.checkConfirmation(
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any()
+            )
+        ).willReturn(Single.just(Solidity.Address(BigInteger.ONE) to TEST_SIGNATURE))
+
+        submitTransactionHelper.setup(TEST_SAFE, ::loadExecutionInfo)
+        val retryEvents = PublishSubject.create<Unit>()
+        val requestEvents = PublishSubject.create<Unit>()
+        val submitEvents = PublishSubject.create<Unit>()
+        val events = SubmitTransactionHelper.Events(
+            retryEvents, requestEvents, submitEvents
+        )
+        val testObserver = TestObserver<Result<SubmitTransactionHelper.ViewUpdate>>()
+
+        val info = TransactionExecutionRepository.ExecuteInformation(
+            TEST_TRANSACTION_HASH, TEST_TRANSACTION,
+            TEST_OWNERS[2], TEST_OWNERS.size - 1, TEST_OWNERS, TEST_VERSION,
+            TEST_ETHER_TOKEN, BigInteger.ONE, BigInteger.TEN, BigInteger.ZERO, BigInteger.ZERO,
+            Wei.ether("23").value
+        )
+        given(relayRepositoryMock.loadExecuteInformation(MockUtils.any(), MockUtils.any(), MockUtils.any()))
+            .willReturn(Single.just(info))
+
+        val initialSignatures = setOf(TEST_SIGNATURE)
+
+        submitTransactionHelper.observe(events, TransactionData.AssetTransfer(TEST_ETHER_TOKEN, TEST_ETH_AMOUNT, TEST_ADDRESS), initialSignatures)
+            .subscribe(testObserver)
+
+        val updates = mutableListOf<((Result<SubmitTransactionHelper.ViewUpdate>) -> Boolean)>({
+            ((it as? DataResult)?.data as? SubmitTransactionHelper.ViewUpdate.TransactionInfo)?.viewHolder == transactionViewHolder
+        })
+        updates += {
+            it == DataResult(SubmitTransactionHelper.ViewUpdate.Estimate(BigInteger.TEN, Wei.ether("23").value, ERC20Token.ETHER_TOKEN, true))
+        }
+        testObserver.assertUpdates(updates)
+
+        signatureSubject.onNext(emptyMap())
+        updates += { it == DataResult(SubmitTransactionHelper.ViewUpdate.Confirmations(false)) }
+        testObserver.assertUpdates(updates)
+        testSingleFactory.assertCount(1)
     }
 
     private fun loadExecutionInfo(transaction: SafeTransaction) =


### PR DESCRIPTION
Changes proposed in this pull request:
- Instead of casting to array and converting to map, we map the array. This is possible since we know the expected datatypes

@gnosis/mobile-devs
