### PR TITLE
Show transaction confirmation screen after transaction has been submi…

### DIFF
--- a/app/src/main/java/pm/gnosis/heimdall/ui/transactions/TransactionSubmissionConfirmationDialog.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/transactions/TransactionSubmissionConfirmationDialog.kt
@@ -1,45 +1,62 @@
 package pm.gnosis.heimdall.ui.transactions
 
 import android.app.Dialog
-import android.content.Context
 import android.os.Build
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
 import android.view.View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+import android.view.ViewGroup
 import kotlinx.android.synthetic.main.layout_safe_transaction_confirmation.*
 import pm.gnosis.heimdall.R
+import pm.gnosis.heimdall.ui.dialogs.base.BaseDialog
 import pm.gnosis.heimdall.ui.safe.main.SafeMainActivity
 import pm.gnosis.svalinn.common.utils.getColorCompat
 
 
-class TransactionSubmissionConfirmationDialog(context: Context) : Dialog(context, R.style.FullScreenDialogStyle) {
+class TransactionSubmissionConfirmationDialog : BaseDialog() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setStyle(STYLE_NO_TITLE, R.style.FullScreenDialogStyle)
+    }
 
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.layout_safe_transaction_confirmation, container, false)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            with(dialog) {
+                window.statusBarColor = context!!.getColorCompat(R.color.white)
+                window.decorView.systemUiVisibility = SYSTEM_UI_FLAG_LAYOUT_STABLE
 
-            window.statusBarColor = context.getColorCompat(R.color.white)
-            window.decorView.systemUiVisibility = SYSTEM_UI_FLAG_LAYOUT_STABLE
-
-            if (Build.VERSION.SDK_INT >= 26) {
-                window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
-            } else if (Build.VERSION.SDK_INT >= 23) {
-                window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+                if (Build.VERSION.SDK_INT >= 26) {
+                    window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+                } else if (Build.VERSION.SDK_INT >= 23) {
+                    window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+                }
             }
         }
+        return dialog
+    }
 
-        setContentView(R.layout.layout_safe_transaction_confirmation)
-
+    override fun onStart() {
+        super.onStart()
         congratulations_continue.setOnClickListener {
-            context.startActivity(
+            startActivity(
                 SafeMainActivity.createIntent(
-                    context,
+                    context!!,
                     null,
                     R.string.tab_title_transactions
                 )
             )
             dismiss()
         }
+    }
+
+    companion object {
+        fun create() = TransactionSubmissionConfirmationDialog()
     }
 }

--- a/app/src/main/java/pm/gnosis/heimdall/ui/transactions/TransactionSubmissionConfirmationDialog.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/transactions/TransactionSubmissionConfirmationDialog.kt
@@ -1,0 +1,45 @@
+package pm.gnosis.heimdall.ui.transactions
+
+import android.app.Dialog
+import android.content.Context
+import android.os.Build
+import android.os.Bundle
+import android.view.View
+import android.view.View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+import kotlinx.android.synthetic.main.layout_safe_transaction_confirmation.*
+import pm.gnosis.heimdall.R
+import pm.gnosis.heimdall.ui.safe.main.SafeMainActivity
+import pm.gnosis.svalinn.common.utils.getColorCompat
+
+
+class TransactionSubmissionConfirmationDialog(context: Context) : Dialog(context, R.style.FullScreenDialogStyle) {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+
+            window.statusBarColor = context.getColorCompat(R.color.white)
+            window.decorView.systemUiVisibility = SYSTEM_UI_FLAG_LAYOUT_STABLE
+
+            if (Build.VERSION.SDK_INT >= 26) {
+                window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+            } else if (Build.VERSION.SDK_INT >= 23) {
+                window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+            }
+        }
+
+        setContentView(R.layout.layout_safe_transaction_confirmation)
+
+        congratulations_continue.setOnClickListener {
+            context.startActivity(
+                SafeMainActivity.createIntent(
+                    context,
+                    null,
+                    R.string.tab_title_transactions
+                )
+            )
+            dismiss()
+        }
+    }
+}

--- a/app/src/main/java/pm/gnosis/heimdall/ui/transactions/view/review/ReviewTransactionActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/transactions/view/review/ReviewTransactionActivity.kt
@@ -63,7 +63,7 @@ class ReviewTransactionActivity : ViewModelActivity<ReviewTransactionContract>()
             return
         }
 
-        val referenceId = if(intent.hasExtra(EXTRA_REFERENCE_ID)) intent.getLongExtra(EXTRA_REFERENCE_ID, 0) else null
+        val referenceId = if (intent.hasExtra(EXTRA_REFERENCE_ID)) intent.getLongExtra(EXTRA_REFERENCE_ID, 0) else null
         viewModel.setup(safeAddress, referenceId)
         infoViewHelper.bind(layout_review_transaction_transaction_info)
     }
@@ -115,7 +115,7 @@ class ReviewTransactionActivity : ViewModelActivity<ReviewTransactionContract>()
                 setupViewHolder(update.viewHolder)
             is SubmitTransactionHelper.ViewUpdate.TransactionSubmitted -> {
                 if (update.success) {
-                    TransactionSubmissionConfirmationDialog(this).show()
+                    TransactionSubmissionConfirmationDialog.create().show(supportFragmentManager, null)
                 } else {
                     infoViewHelper.toggleReadyState(true)
                 }

--- a/app/src/main/java/pm/gnosis/heimdall/ui/transactions/view/review/ReviewTransactionActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/transactions/view/review/ReviewTransactionActivity.kt
@@ -17,8 +17,8 @@ import pm.gnosis.heimdall.di.components.ViewComponent
 import pm.gnosis.heimdall.helpers.ToolbarHelper
 import pm.gnosis.heimdall.reporting.ScreenId
 import pm.gnosis.heimdall.ui.base.ViewModelActivity
-import pm.gnosis.heimdall.ui.safe.main.SafeMainActivity
 import pm.gnosis.heimdall.ui.security.unlock.UnlockDialog
+import pm.gnosis.heimdall.ui.transactions.TransactionSubmissionConfirmationDialog
 import pm.gnosis.heimdall.ui.transactions.view.TransactionInfoViewHolder
 import pm.gnosis.heimdall.ui.transactions.view.helpers.SubmitTransactionHelper
 import pm.gnosis.heimdall.ui.transactions.view.helpers.SubmitTransactionHelper.Events
@@ -115,13 +115,7 @@ class ReviewTransactionActivity : ViewModelActivity<ReviewTransactionContract>()
                 setupViewHolder(update.viewHolder)
             is SubmitTransactionHelper.ViewUpdate.TransactionSubmitted -> {
                 if (update.success) {
-                    startActivity(
-                        SafeMainActivity.createIntent(
-                            this,
-                            null,
-                            R.string.tab_title_transactions
-                        )
-                    )
+                    TransactionSubmissionConfirmationDialog(this).show()
                 } else {
                     infoViewHelper.toggleReadyState(true)
                 }

--- a/app/src/main/res/drawable/ic_congratulations.xml
+++ b/app/src/main/res/drawable/ic_congratulations.xml
@@ -1,0 +1,26 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+  <path
+      android:pathData="M50,0.227C77.434,0.227 99.773,22.566 99.773,50c0,27.434 -22.339,49.773 -49.773,49.773C22.566,99.773 0.227,77.434 0.227,50 0.227,22.566 22.566,0.227 50,0.227zM50,5.227C25.327,5.227 5.227,25.327 5.227,50c0,24.673 20.1,44.773 44.773,44.773 24.673,0 44.773,-20.1 44.773,-44.773 0,-24.673 -20.1,-44.773 -44.773,-44.773z"
+      android:fillColor="#B9BDCD"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="M74.55,35.551l3.627,3.443 -32.794,34.541 -23.56,-24.816 3.626,-3.443 19.934,20.997z"
+      android:fillType="nonZero">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startY="62.261353"
+          android:startX="53.643288"
+          android:endY="52.354744"
+          android:endX="38.509987"
+          android:type="linear">
+        <item android:offset="0" android:color="#FF34AAFD"/>
+        <item android:offset="1" android:color="#FF00CFEE"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+</vector>

--- a/app/src/main/res/layout/layout_safe_transaction_confirmation.xml
+++ b/app/src/main/res/layout/layout_safe_transaction_confirmation.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@color/white"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/congratulations_title"
+        style="@style/WhiteTheme.SubtitleBold"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="16dp"
+        android:text="@string/congratulations"
+        app:layout_constraintBottom_toTopOf="@+id/congratulations_text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/congratulations_text"
+        style="@style/WhiteTheme.FlatTextCenter"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="24dp"
+        android:text="Your transaction has been submitted."
+        app:layout_constraintBottom_toTopOf="@+id/congratulations_continue"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/congratulations_continue"
+        style="@style/PrimaryButton.Blue"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="32dp"
+        android:layout_marginBottom="8dp"
+        android:text="@string/continue_text"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/congratulations_check"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="18dp"
+        app:layout_constraintBottom_toTopOf="@+id/congratulations_title"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:srcCompat="@drawable/ic_congratulations" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -53,6 +53,13 @@
         <item name="android:textColor">@color/azure</item>
     </style>
 
+    <style name="FullScreenDialogStyle" parent="WhiteTheme">
+        <item name="android:windowTranslucentStatus">false</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowFullscreen">false</item>
+        <item name="android:windowIsFloating">false</item>
+    </style>
+
     <style name="TabLayout" parent="Widget.Design.TabLayout">
         <item name="android:background">@color/white</item>
         <item name="tabIndicatorColor">@color/azure</item>


### PR DESCRIPTION
Closes #367: Show transaction confirmation screen after transaction has been submitted

Changes proposed in this pull request:
- transaction confirmation screen

@gnosis/mobile-devs
