### PR TITLE
Adjust transaction list headers (#370)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -275,6 +275,10 @@ dependencies {
     testImplementation "com.github.gnosis.svalinn-kotlin:utils-testing:$versions.svalinn"
     testImplementation "org.mockito:mockito-core:$versions.mockito"
     testImplementation "org.mockito:mockito-inline:$versions.mockito"
+    testImplementation "org.powermock:powermock-module-junit4:$versions.powermock"
+    testImplementation "org.powermock:powermock-api-mockito2:$versions.powermock"
+    testImplementation "org.powermock:powermock-core:$versions.powermock"
+    testImplementation "org.powermock:powermock-module-junit4-rule:$versions.powermock"
 
     // UI tests
     androidTestImplementation "org.mockito:mockito-android:$versions.mockito"

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsAdapter.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsAdapter.kt
@@ -1,12 +1,12 @@
 package pm.gnosis.heimdall.ui.safe.details.transactions
 
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.OnLifecycleEvent
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.DrawableRes
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.OnLifecycleEvent
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
@@ -69,7 +69,7 @@ class SafeTransactionsAdapter @Inject constructor(
     class HeaderViewHolder(itemView: View) : LifecycleViewHolder<SafeTransactionsContract.AdapterEntry>(itemView) {
         override fun bind(data: SafeTransactionsContract.AdapterEntry, payloads: List<Any>) {
             (data as? Header)?.apply {
-                itemView.layout_adapter_entry_header_title.text = itemView.context.getString(titleRes)
+                itemView.layout_adapter_entry_header_title.text = title
             }
         }
     }

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsContract.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsContract.kt
@@ -1,9 +1,8 @@
 package pm.gnosis.heimdall.ui.safe.details.transactions
 
-import androidx.lifecycle.ViewModel
 import android.content.Intent
 import androidx.annotation.IdRes
-import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
 import io.reactivex.Flowable
 import io.reactivex.Observable
 import io.reactivex.Single
@@ -29,7 +28,7 @@ abstract class SafeTransactionsContract : ViewModel() {
     abstract fun transactionSelected(id: String): Single<Intent>
 
     sealed class AdapterEntry(@IdRes val type: Int) {
-        data class Header(@StringRes val titleRes: Int): AdapterEntry(R.id.adapter_entry_header)
+        data class Header(val title: String): AdapterEntry(R.id.adapter_entry_header)
         data class Transaction(val id: String): AdapterEntry(R.id.adapter_entry_transaction)
     }
 }

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsViewModel.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsViewModel.kt
@@ -14,6 +14,7 @@ import pm.gnosis.heimdall.di.ApplicationContext
 import pm.gnosis.heimdall.ui.base.Adapter
 import pm.gnosis.heimdall.ui.transactions.view.status.TransactionStatusActivity
 import pm.gnosis.heimdall.utils.DateTimeUtils
+import pm.gnosis.heimdall.utils.formatAsDate
 import pm.gnosis.heimdall.utils.scanToAdapterData
 import pm.gnosis.model.Solidity
 import pm.gnosis.svalinn.common.utils.Result
@@ -44,21 +45,21 @@ class SafeTransactionsViewModel @Inject constructor(
                     val currentTime = System.currentTimeMillis()
                     val combined = ArrayList<AdapterEntry>((pending.size + submitted.size) * 2)
                     if (pending.isNotEmpty()) {
-                        combined += AdapterEntry.Header(R.string.header_pending)
+                        combined += AdapterEntry.Header(context.getString(R.string.header_pending))
                         pending.forEach { combined += AdapterEntry.Transaction(it.id) }
                     }
-                    var lastHeaderRes = 0
+                    var lastHeaderTitle = ""
                     submitted.forEach {
                         val timeDiff = currentTime - it.timestamp
-                        val headerRes = when {
-                            timeDiff < DateTimeUtils.DAY_IN_MS -> R.string.header_today
-                            timeDiff < 2 * DateTimeUtils.DAY_IN_MS -> R.string.header_yesterday
-                            lastHeaderRes == 0 || lastHeaderRes == R.string.header_submitted -> R.string.header_submitted // First header should never be "older"
-                            else -> R.string.header_older
+                        val headerTitle = when {
+                            timeDiff < DateTimeUtils.DAY_IN_MS -> context.getString(R.string.header_today)
+                            timeDiff < 2 * DateTimeUtils.DAY_IN_MS -> context.getString(R.string.header_yesterday)
+                            lastHeaderTitle.isBlank() || lastHeaderTitle == context.getString(R.string.header_submitted) -> context.getString(R.string.header_submitted) // First header should never be "older"
+                            else -> context.formatAsDate(it.timestamp)
                         }
-                        if (lastHeaderRes != headerRes && headerRes != 0) {
-                            combined += AdapterEntry.Header(headerRes)
-                            lastHeaderRes = headerRes
+                        if (lastHeaderTitle != headerTitle && headerTitle.isNotBlank()) {
+                            combined += AdapterEntry.Header(headerTitle)
+                            lastHeaderTitle = headerTitle
                         }
                         combined += AdapterEntry.Transaction(it.id)
                     }

--- a/app/src/main/java/pm/gnosis/heimdall/ui/transactions/TransactionSubmissionConfirmationDialog.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/transactions/TransactionSubmissionConfirmationDialog.kt
@@ -29,7 +29,7 @@ class TransactionSubmissionConfirmationDialog : BaseDialog() {
         val dialog = super.onCreateDialog(savedInstanceState)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             with(dialog) {
-                window.statusBarColor = context!!.getColorCompat(R.color.white)
+                window.statusBarColor = context.getColorCompat(R.color.white)
                 window.decorView.systemUiVisibility = SYSTEM_UI_FLAG_LAYOUT_STABLE
 
                 if (Build.VERSION.SDK_INT >= 26) {

--- a/app/src/main/java/pm/gnosis/heimdall/utils/DateTimeUtils.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/utils/DateTimeUtils.kt
@@ -67,4 +67,20 @@ object DateTimeUtils {
     }
 }
 
-fun Context.formatAsLongDate(referenceTime: Long): String = DateTimeUtils.getLongTimeString(this, referenceTime)
+fun Context.formatAsLongDate(referenceTime: Long): String {
+    val now = System.currentTimeMillis()
+    val diff = now - referenceTime
+    if (diff < DateUtils.MINUTE_IN_MILLIS) {
+        return this.getString(R.string.just_a_moment_ago)
+    }
+    return if (diff > DateUtils.DAY_IN_MILLIS)
+        DateUtils.formatDateTime(this, referenceTime, DateUtils.FORMAT_SHOW_TIME)
+    else
+        DateUtils.getRelativeTimeSpanString(referenceTime, now, DateUtils.SECOND_IN_MILLIS).toString() + ", " + DateUtils.formatDateTime(
+            this,
+            referenceTime,
+            DateUtils.FORMAT_SHOW_TIME
+        )
+}
+
+fun Context.formatAsDate(referenceTime: Long): String = DateUtils.formatDateTime(this, referenceTime, DateUtils.FORMAT_SHOW_DATE)

--- a/app/src/main/res/layout/include_transaction_submit_info.xml
+++ b/app/src/main/res/layout/include_transaction_submit_info.xml
@@ -76,9 +76,10 @@
 
         <TextView
             android:id="@+id/include_transaction_submit_info_data_fees_info"
+            style="@style/NormalText"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
+            android:layout_marginStart="4dp"
             android:layout_marginBottom="8dp"
             android:paddingBottom="12dp"
             android:text="@string/tip_link"

--- a/app/src/main/res/layout/layout_create_asset_transfer.xml
+++ b/app/src/main/res/layout/layout_create_asset_transfer.xml
@@ -281,9 +281,10 @@
 
             <TextView
                 android:id="@+id/layout_create_asset_transfer_fees_info"
+                style="@style/NormalText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
+                android:layout_marginStart="4dp"
                 android:layout_marginBottom="8dp"
                 android:paddingBottom="12dp"
                 android:text="@string/tip_link"

--- a/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/AdapterEntryHeaders.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/AdapterEntryHeaders.kt
@@ -1,0 +1,7 @@
+package pm.gnosis.heimdall.ui.safe.details.transactions
+
+const val PENDING = "pending"
+const val SUBMITTED = "submitted"
+const val TODAY = "today"
+const val YESTERDAY = "yesterday"
+const val DATE = " date"

--- a/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsAdapterHeaderViewHolderTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsAdapterHeaderViewHolderTest.kt
@@ -25,6 +25,7 @@ import pm.gnosis.heimdall.data.repositories.*
 import pm.gnosis.heimdall.data.repositories.models.ERC20Token
 import pm.gnosis.heimdall.data.repositories.models.SafeTransaction
 import pm.gnosis.heimdall.helpers.AddressHelper
+import pm.gnosis.heimdall.ui.safe.details.transactions.test.SUBMITTED
 import pm.gnosis.model.Solidity
 import pm.gnosis.models.AddressBookEntry
 import pm.gnosis.models.Transaction

--- a/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsAdapterHeaderViewHolderTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsAdapterHeaderViewHolderTest.kt
@@ -18,7 +18,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.BDDMockito.*
 import org.mockito.Mock
-import org.mockito.Mockito
 import org.mockito.junit.MockitoJUnitRunner
 import pm.gnosis.blockies.BlockiesImageView
 import pm.gnosis.heimdall.R
@@ -322,7 +321,7 @@ class SafeTransactionsAdapterHeaderViewHolderTest {
         context.mockGetString()
         itemView.mockFindViewById(R.id.layout_safe_transactions_item_timestamp, timestampTextView)
 
-        viewHolder.bind(SafeTransactionsContract.AdapterEntry.Header(R.string.header_submitted), emptyList())
+        viewHolder.bind(SafeTransactionsContract.AdapterEntry.Header(SUBMITTED), emptyList())
 
         then(timestampTextView).should().text = R.string.loading.toString()
 

--- a/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsAdapterTransactionViewHolderTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsAdapterTransactionViewHolderTest.kt
@@ -6,13 +6,11 @@ import android.widget.TextView
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import pm.gnosis.heimdall.R
 import pm.gnosis.tests.utils.mockFindViewById
-import pm.gnosis.tests.utils.mockGetString
 
 @RunWith(MockitoJUnitRunner::class)
 class SafeTransactionsAdapterTransactionViewHolderTest {
@@ -35,13 +33,11 @@ class SafeTransactionsAdapterTransactionViewHolderTest {
 
     @Test
     fun bindHeaderEntry() {
-        context.mockGetString()
-        given(itemView.context).willReturn(context)
         itemView.mockFindViewById(R.id.layout_adapter_entry_header_title, headerTextView)
 
-        viewHolder.bind(SafeTransactionsContract.AdapterEntry.Header(R.string.header_submitted), emptyList())
+        viewHolder.bind(SafeTransactionsContract.AdapterEntry.Header(SUBMITTED), emptyList())
 
-        then(headerTextView).should().text = R.string.header_submitted.toString()
+        then(headerTextView).should().text = SUBMITTED
         then(headerTextView).shouldHaveNoMoreInteractions()
     }
 

--- a/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsAdapterTransactionViewHolderTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsAdapterTransactionViewHolderTest.kt
@@ -10,6 +10,7 @@ import org.mockito.BDDMockito.then
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import pm.gnosis.heimdall.R
+import pm.gnosis.heimdall.ui.safe.details.transactions.test.SUBMITTED
 import pm.gnosis.tests.utils.mockFindViewById
 
 @RunWith(MockitoJUnitRunner::class)

--- a/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsViewModelTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsViewModelTest.kt
@@ -2,6 +2,7 @@ package pm.gnosis.heimdall.ui.safe.details.transactions
 
 import android.content.Context
 import android.content.Intent
+import android.text.format.DateUtils
 import io.reactivex.Flowable
 import io.reactivex.Observable
 import io.reactivex.Single
@@ -16,7 +17,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.BDDMockito.*
 import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
+import org.powermock.api.mockito.PowerMockito
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
 import pm.gnosis.heimdall.R
 import pm.gnosis.heimdall.data.repositories.*
 import pm.gnosis.heimdall.data.repositories.TransactionExecutionRepository.PublishStatus
@@ -33,7 +36,9 @@ import pm.gnosis.tests.utils.MockUtils
 import pm.gnosis.utils.asEthereumAddress
 import java.math.BigInteger
 
-@RunWith(MockitoJUnitRunner::class)
+
+@RunWith(PowerMockRunner::class)
+@PrepareForTest(DateUtils::class)
 class SafeTransactionsViewModelTest {
 
     @JvmField
@@ -61,7 +66,16 @@ class SafeTransactionsViewModelTest {
 
     @Before
     fun setup() {
+
+        PowerMockito.mockStatic(DateUtils::class.java)
+        given(DateUtils.formatDateTime(any(), anyLong(), anyInt())).willReturn(DATE)
+
         viewModel = SafeTransactionsViewModel(context, safeRepository, safeTransactionRepository, tokenRepository, detailsRepository)
+
+        given(context.getString(R.string.header_pending)).willReturn(PENDING)
+        given(context.getString(R.string.header_submitted)).willReturn(SUBMITTED)
+        given(context.getString(R.string.header_today)).willReturn(TODAY)
+        given(context.getString(R.string.header_yesterday)).willReturn(YESTERDAY)
     }
 
     @Test
@@ -92,7 +106,7 @@ class SafeTransactionsViewModelTest {
         subscriber.assertValueCount(2).assertValueAt(1, {
             it is DataResult && it.data.parentId == currentId && it.data.diff != null &&
                     it.data.entries == listOf(
-                SafeTransactionsContract.AdapterEntry.Header(R.string.header_pending),
+                SafeTransactionsContract.AdapterEntry.Header(PENDING),
                 SafeTransactionsContract.AdapterEntry.Transaction("id_1")
             )
         }).assertNoErrors()
@@ -110,13 +124,13 @@ class SafeTransactionsViewModelTest {
         subscriber.assertValueCount(3).assertValueAt(2, {
             it is DataResult && it.data.parentId == currentId &&
                     it.data.entries == listOf(
-                SafeTransactionsContract.AdapterEntry.Header(R.string.header_pending),
+                SafeTransactionsContract.AdapterEntry.Header(PENDING),
                 SafeTransactionsContract.AdapterEntry.Transaction("id_1"),
-                SafeTransactionsContract.AdapterEntry.Header(R.string.header_today),
+                SafeTransactionsContract.AdapterEntry.Header(TODAY),
                 SafeTransactionsContract.AdapterEntry.Transaction("id_2"),
-                SafeTransactionsContract.AdapterEntry.Header(R.string.header_yesterday),
+                SafeTransactionsContract.AdapterEntry.Header(YESTERDAY),
                 SafeTransactionsContract.AdapterEntry.Transaction("id_3"),
-                SafeTransactionsContract.AdapterEntry.Header(R.string.header_older),
+                SafeTransactionsContract.AdapterEntry.Header(DATE),
                 SafeTransactionsContract.AdapterEntry.Transaction("id_4")
             )
         }).assertNoErrors()
@@ -132,9 +146,9 @@ class SafeTransactionsViewModelTest {
         subscriber.assertValueCount(4).assertValueAt(3, {
             it is DataResult && it.data.parentId == currentId &&
                     it.data.entries == listOf(
-                SafeTransactionsContract.AdapterEntry.Header(R.string.header_pending),
+                SafeTransactionsContract.AdapterEntry.Header(PENDING),
                 SafeTransactionsContract.AdapterEntry.Transaction("id_1"),
-                SafeTransactionsContract.AdapterEntry.Header(R.string.header_submitted),
+                SafeTransactionsContract.AdapterEntry.Header(SUBMITTED),
                 SafeTransactionsContract.AdapterEntry.Transaction("id_4")
             )
         }).assertNoErrors()
@@ -146,7 +160,7 @@ class SafeTransactionsViewModelTest {
         subscriber.assertValueCount(5).assertValueAt(4, {
             it is DataResult && it.data.parentId == currentId &&
                     it.data.entries == listOf(
-                SafeTransactionsContract.AdapterEntry.Header(R.string.header_submitted),
+                SafeTransactionsContract.AdapterEntry.Header(SUBMITTED),
                 SafeTransactionsContract.AdapterEntry.Transaction("id_4")
             )
         }).assertNoErrors()
@@ -164,7 +178,7 @@ class SafeTransactionsViewModelTest {
         cachedSubscriber.assertValueCount(1).assertValueAt(0, {
             it is DataResult && it.data.parentId == currentId &&
                     it.data.entries == listOf(
-                SafeTransactionsContract.AdapterEntry.Header(R.string.header_submitted),
+                SafeTransactionsContract.AdapterEntry.Header(SUBMITTED),
                 SafeTransactionsContract.AdapterEntry.Transaction("id_4")
             )
         }).assertNoErrors()
@@ -172,16 +186,18 @@ class SafeTransactionsViewModelTest {
         currentId = (cachedSubscriber.values().last() as DataResult).data.id
 
         pendingProcessor.onNext(emptyList())
-        submittedProcessor.onNext(listOf(
-            TransactionStatus("id_4", System.currentTimeMillis() - (5 * DateTimeUtils.DAY_IN_MS), false),
-            TransactionStatus("id_5", System.currentTimeMillis() - (6 * DateTimeUtils.DAY_IN_MS), false),
-            TransactionStatus("id_6", System.currentTimeMillis() - (7 * DateTimeUtils.DAY_IN_MS), false)
-        ))
+        submittedProcessor.onNext(
+            listOf(
+                TransactionStatus("id_4", System.currentTimeMillis() - (5 * DateTimeUtils.DAY_IN_MS), false),
+                TransactionStatus("id_5", System.currentTimeMillis() - (6 * DateTimeUtils.DAY_IN_MS), false),
+                TransactionStatus("id_6", System.currentTimeMillis() - (7 * DateTimeUtils.DAY_IN_MS), false)
+            )
+        )
 
         cachedSubscriber.assertValueCount(2).assertValueAt(1, {
             it is DataResult && it.data.parentId == currentId &&
                     it.data.entries == listOf(
-                SafeTransactionsContract.AdapterEntry.Header(R.string.header_submitted),
+                SafeTransactionsContract.AdapterEntry.Header(SUBMITTED),
                 SafeTransactionsContract.AdapterEntry.Transaction("id_4"),
                 SafeTransactionsContract.AdapterEntry.Transaction("id_5"),
                 SafeTransactionsContract.AdapterEntry.Transaction("id_6")

--- a/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsViewModelTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsViewModelTest.kt
@@ -26,6 +26,7 @@ import pm.gnosis.heimdall.data.repositories.TransactionExecutionRepository.Publi
 import pm.gnosis.heimdall.data.repositories.models.ERC20Token
 import pm.gnosis.heimdall.data.repositories.models.TransactionStatus
 import pm.gnosis.heimdall.ui.base.Adapter
+import pm.gnosis.heimdall.ui.safe.details.transactions.test.*
 import pm.gnosis.heimdall.utils.DateTimeUtils
 import pm.gnosis.model.Solidity
 import pm.gnosis.svalinn.common.utils.DataResult

--- a/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/test/AdapterEntryHeaders.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/test/AdapterEntryHeaders.kt
@@ -1,4 +1,4 @@
-package pm.gnosis.heimdall.ui.safe.details.transactions
+package pm.gnosis.heimdall.ui.safe.details.transactions.test
 
 const val PENDING = "pending"
 const val SUBMITTED = "submitted"

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -49,5 +49,6 @@ ext {
             espresso                  : '3.1.1',
             junit                     : '4.12',
             mockito                   : '2.18.3',
+            powermock                 : '2.0.2',
     ]
 }


### PR DESCRIPTION
Closes #370: Adjust transaction list headers

Changes proposed in this pull request:
- the header between entries correspond to the data (no grouping of multiple dates)

@gnosis/mobile-devs
