### PR TITLE
Feature/issue 369

### DIFF
--- a/app/src/main/java/pm/gnosis/heimdall/data/db/ApplicationDb.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/db/ApplicationDb.kt
@@ -3,27 +3,44 @@ package pm.gnosis.heimdall.data.db
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import pm.gnosis.heimdall.data.db.daos.AddressBookDao
 import pm.gnosis.heimdall.data.db.daos.DescriptionsDao
 import pm.gnosis.heimdall.data.db.daos.ERC20TokenDao
 import pm.gnosis.heimdall.data.db.daos.GnosisSafeDao
 import pm.gnosis.heimdall.data.db.models.*
+import pm.gnosis.svalinn.security.db.EncryptedByteArray
 
 @Database(
     entities = [
         AddressBookEntryDb::class,
         ERC20TokenDb::class,
+        GnosisSafeOwnerDb::class,
         GnosisSafeDb::class,
         PendingGnosisSafeDb::class,
         RecoveringGnosisSafeDb::class,
         TransactionDescriptionDb::class,
         TransactionPublishStatusDb::class
-    ], version = 1
+    ], version = 2
 )
-@TypeConverters(BigIntegerConverter::class, SolidityAddressConverter::class, WeiConverter::class)
+@TypeConverters(BigIntegerConverter::class, SolidityAddressConverter::class, WeiConverter::class, EncryptedByteArray.Converter::class)
 abstract class ApplicationDb : RoomDatabase() {
     companion object {
         const val DB_NAME = "gnosis-safe-db"
+
+        val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    """CREATE TABLE `${GnosisSafeOwnerDb.TABLE_NAME}`
+                            (`${GnosisSafeOwnerDb.COL_PRIVATE_KEY}` TEXT,
+                            `${GnosisSafeOwnerDb.COL_ADDRESS}` TEXT,
+                            `${GnosisSafeOwnerDb.COL_SAFE_ADDRESS}` TEXT,
+                            PRIMARY KEY(`${GnosisSafeOwnerDb.COL_PRIVATE_KEY}`))"""
+                )
+            }
+        }
+
     }
 
     abstract fun addressBookDao(): AddressBookDao

--- a/app/src/main/java/pm/gnosis/heimdall/data/db/ApplicationDb.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/db/ApplicationDb.kt
@@ -16,7 +16,7 @@ import pm.gnosis.svalinn.security.db.EncryptedByteArray
     entities = [
         AddressBookEntryDb::class,
         ERC20TokenDb::class,
-        GnosisSafeOwnerDb::class,
+        GnosisSafeInfoDb::class,
         GnosisSafeDb::class,
         PendingGnosisSafeDb::class,
         RecoveringGnosisSafeDb::class,
@@ -32,11 +32,11 @@ abstract class ApplicationDb : RoomDatabase() {
         val MIGRATION_1_2 = object : Migration(1, 2) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL(
-                    """CREATE TABLE `${GnosisSafeOwnerDb.TABLE_NAME}`
-                            (`${GnosisSafeOwnerDb.COL_PRIVATE_KEY}` TEXT,
-                            `${GnosisSafeOwnerDb.COL_ADDRESS}` TEXT,
-                            `${GnosisSafeOwnerDb.COL_SAFE_ADDRESS}` TEXT,
-                            PRIMARY KEY(`${GnosisSafeOwnerDb.COL_PRIVATE_KEY}`))"""
+                    """CREATE TABLE `${GnosisSafeInfoDb.TABLE_NAME}`
+                            (`${GnosisSafeInfoDb.COL_SAFE_ADDRESS}` TEXT,
+                            `${GnosisSafeInfoDb.COL_OWNER_ADDRESS}` TEXT,
+                            `${GnosisSafeInfoDb.COL_OWNER_PRIVATE_KEY}` TEXT,
+                            PRIMARY KEY(`${GnosisSafeInfoDb.COL_SAFE_ADDRESS}`))"""
                 )
             }
         }

--- a/app/src/main/java/pm/gnosis/heimdall/data/db/SolidityAddressConverter.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/db/SolidityAddressConverter.kt
@@ -7,8 +7,8 @@ import pm.gnosis.utils.asEthereumAddressString
 
 class SolidityAddressConverter {
     @TypeConverter
-    fun fromHexString(address: String) = address.asEthereumAddress()!!
+    fun fromHexString(address: String?) = address?.asEthereumAddress()!!
 
     @TypeConverter
-    fun toHexString(address: Solidity.Address): String = address.asEthereumAddressString()
+    fun toHexString(address: Solidity.Address?): String? = address?.asEthereumAddressString()
 }

--- a/app/src/main/java/pm/gnosis/heimdall/data/db/SolidityAddressConverter.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/db/SolidityAddressConverter.kt
@@ -7,8 +7,8 @@ import pm.gnosis.utils.asEthereumAddressString
 
 class SolidityAddressConverter {
     @TypeConverter
-    fun fromHexString(address: String?) = address?.asEthereumAddress()!!
+    fun fromHexString(address: String) = address.asEthereumAddress()!!
 
     @TypeConverter
-    fun toHexString(address: Solidity.Address?): String? = address?.asEthereumAddressString()
+    fun toHexString(address: Solidity.Address): String = address.asEthereumAddressString()
 }

--- a/app/src/main/java/pm/gnosis/heimdall/data/db/daos/GnosisSafeDao.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/db/daos/GnosisSafeDao.kt
@@ -2,8 +2,10 @@ package pm.gnosis.heimdall.data.db.daos
 
 import androidx.room.*
 import io.reactivex.Flowable
+import io.reactivex.Maybe
 import io.reactivex.Single
 import pm.gnosis.heimdall.data.db.models.GnosisSafeDb
+import pm.gnosis.heimdall.data.db.models.GnosisSafeOwnerDb
 import pm.gnosis.heimdall.data.db.models.PendingGnosisSafeDb
 import pm.gnosis.heimdall.data.db.models.RecoveringGnosisSafeDb
 import pm.gnosis.model.Solidity
@@ -32,6 +34,16 @@ interface GnosisSafeDao {
 
     @Update
     fun updateSafe(safe: GnosisSafeDb)
+
+    // Safe owner
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertOwner(owner: GnosisSafeOwnerDb)
+
+    @Query("UPDATE ${GnosisSafeOwnerDb.TABLE_NAME} SET ${GnosisSafeOwnerDb.COL_SAFE_ADDRESS} = :safeAddress WHERE ${GnosisSafeOwnerDb.COL_ADDRESS} = :ownerAddress")
+    fun assignOwnerToSafe(ownerAddress: Solidity.Address, safeAddress: Solidity.Address)
+
+    @Query("SELECT * FROM ${GnosisSafeOwnerDb.TABLE_NAME} WHERE ${GnosisSafeOwnerDb.COL_SAFE_ADDRESS} = :safeAddress")
+    fun loadSafeOwner(safeAddress: Solidity.Address): Maybe<GnosisSafeOwnerDb>
 
     // Pending Safes
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/pm/gnosis/heimdall/data/db/daos/GnosisSafeDao.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/db/daos/GnosisSafeDao.kt
@@ -43,7 +43,7 @@ interface GnosisSafeDao {
     fun assignOwnerToSafe(ownerAddress: Solidity.Address, safeAddress: Solidity.Address)
 
     @Query("SELECT * FROM ${GnosisSafeOwnerDb.TABLE_NAME} WHERE ${GnosisSafeOwnerDb.COL_SAFE_ADDRESS} = :safeAddress")
-    fun loadSafeOwner(safeAddress: Solidity.Address): Maybe<GnosisSafeOwnerDb>
+    fun loadSafeOwner(safeAddress: Solidity.Address): Single<GnosisSafeOwnerDb>
 
     // Pending Safes
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/pm/gnosis/heimdall/data/db/daos/GnosisSafeDao.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/db/daos/GnosisSafeDao.kt
@@ -2,10 +2,9 @@ package pm.gnosis.heimdall.data.db.daos
 
 import androidx.room.*
 import io.reactivex.Flowable
-import io.reactivex.Maybe
 import io.reactivex.Single
 import pm.gnosis.heimdall.data.db.models.GnosisSafeDb
-import pm.gnosis.heimdall.data.db.models.GnosisSafeOwnerDb
+import pm.gnosis.heimdall.data.db.models.GnosisSafeInfoDb
 import pm.gnosis.heimdall.data.db.models.PendingGnosisSafeDb
 import pm.gnosis.heimdall.data.db.models.RecoveringGnosisSafeDb
 import pm.gnosis.model.Solidity
@@ -37,13 +36,13 @@ interface GnosisSafeDao {
 
     // Safe owner
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertOwner(owner: GnosisSafeOwnerDb)
+    fun insertSafeInfo(safeInfo: GnosisSafeInfoDb)
 
-    @Query("UPDATE ${GnosisSafeOwnerDb.TABLE_NAME} SET ${GnosisSafeOwnerDb.COL_SAFE_ADDRESS} = :safeAddress WHERE ${GnosisSafeOwnerDb.COL_ADDRESS} = :ownerAddress")
-    fun assignOwnerToSafe(ownerAddress: Solidity.Address, safeAddress: Solidity.Address)
+    @Query("DELETE FROM ${GnosisSafeInfoDb.TABLE_NAME} WHERE ${GnosisSafeInfoDb.COL_SAFE_ADDRESS} = :safeAddress")
+    fun removeSafeInfo(safeAddress: Solidity.Address)
 
-    @Query("SELECT * FROM ${GnosisSafeOwnerDb.TABLE_NAME} WHERE ${GnosisSafeOwnerDb.COL_SAFE_ADDRESS} = :safeAddress")
-    fun loadSafeOwner(safeAddress: Solidity.Address): Single<GnosisSafeOwnerDb>
+    @Query("SELECT * FROM ${GnosisSafeInfoDb.TABLE_NAME} WHERE ${GnosisSafeInfoDb.COL_SAFE_ADDRESS} = :safeAddress")
+    fun loadSafeInfo(safeAddress: Solidity.Address): Single<GnosisSafeInfoDb>
 
     // Pending Safes
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/pm/gnosis/heimdall/data/db/models/GnosisSafeDb.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/db/models/GnosisSafeDb.kt
@@ -27,37 +27,25 @@ fun Safe.toDb() = GnosisSafeDb(address)
 fun GnosisSafeDb.fromDb() = Safe(address)
 
 @Entity(
-    tableName = GnosisSafeOwnerDb.TABLE_NAME,
-    foreignKeys = [
-        ForeignKey(
-            entity = GnosisSafeDb::class,
-            parentColumns = [GnosisSafeDb.COL_ADDRESS],
-            childColumns = [GnosisSafeOwnerDb.COL_SAFE_ADDRESS],
-            onUpdate = ForeignKey.NO_ACTION,
-            onDelete = ForeignKey.CASCADE,
-            deferred = true
-        )
-    ],
-    indices = [
-        Index(value = [GnosisSafeOwnerDb.COL_SAFE_ADDRESS])
-    ]
+    tableName = GnosisSafeInfoDb.TABLE_NAME
 )
-data class GnosisSafeOwnerDb(
+data class GnosisSafeInfoDb(
     @PrimaryKey
-    @ColumnInfo(name = COL_PRIVATE_KEY)
-    var privateKey: EncryptedByteArray,
-
-    @ColumnInfo(name = COL_ADDRESS)
-    val address: Solidity.Address,
-
     @ColumnInfo(name = COL_SAFE_ADDRESS)
-    val safeAddress: Solidity.Address? = null
+    val safeAddress: Solidity.Address,
+
+    @ColumnInfo(name = COL_OWNER_ADDRESS)
+    val ownerAddress: Solidity.Address,
+
+    @ColumnInfo(name = COL_OWNER_PRIVATE_KEY)
+    var ownerPrivateKey: EncryptedByteArray
+
 ) {
     companion object {
-        const val TABLE_NAME = "gnosis_safe_owners"
-        const val COL_PRIVATE_KEY = "private_key"
-        const val COL_ADDRESS = "address"
+        const val TABLE_NAME = "gnosis_safe_info"
         const val COL_SAFE_ADDRESS = "safe_address"
+        const val COL_OWNER_ADDRESS = "address"
+        const val COL_OWNER_PRIVATE_KEY = "private_key"
     }
 }
 

--- a/app/src/main/java/pm/gnosis/heimdall/data/db/models/GnosisSafeDb.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/db/models/GnosisSafeDb.kt
@@ -1,8 +1,6 @@
 package pm.gnosis.heimdall.data.db.models
 
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room.*
 import pm.gnosis.heimdall.data.repositories.TransactionExecutionRepository.Operation.Companion.fromInt
 import pm.gnosis.heimdall.data.repositories.models.PendingSafe
 import pm.gnosis.heimdall.data.repositories.models.RecoveringSafe
@@ -10,6 +8,7 @@ import pm.gnosis.heimdall.data.repositories.models.Safe
 import pm.gnosis.heimdall.data.repositories.toInt
 import pm.gnosis.model.Solidity
 import pm.gnosis.svalinn.accounts.base.models.Signature
+import pm.gnosis.svalinn.security.db.EncryptedByteArray
 import java.math.BigInteger
 
 @Entity(tableName = GnosisSafeDb.TABLE_NAME)
@@ -26,6 +25,41 @@ data class GnosisSafeDb(
 
 fun Safe.toDb() = GnosisSafeDb(address)
 fun GnosisSafeDb.fromDb() = Safe(address)
+
+@Entity(
+    tableName = GnosisSafeOwnerDb.TABLE_NAME,
+    foreignKeys = [
+        ForeignKey(
+            entity = GnosisSafeDb::class,
+            parentColumns = [GnosisSafeDb.COL_ADDRESS],
+            childColumns = [GnosisSafeOwnerDb.COL_SAFE_ADDRESS],
+            onUpdate = ForeignKey.NO_ACTION,
+            onDelete = ForeignKey.CASCADE,
+            deferred = true
+        )
+    ],
+    indices = [
+        Index(value = [GnosisSafeOwnerDb.COL_SAFE_ADDRESS])
+    ]
+)
+data class GnosisSafeOwnerDb(
+    @PrimaryKey
+    @ColumnInfo(name = COL_PRIVATE_KEY)
+    var privateKey: EncryptedByteArray,
+
+    @ColumnInfo(name = COL_ADDRESS)
+    val address: Solidity.Address,
+
+    @ColumnInfo(name = COL_SAFE_ADDRESS)
+    val safeAddress: Solidity.Address? = null
+) {
+    companion object {
+        const val TABLE_NAME = "gnosis_safe_owners"
+        const val COL_PRIVATE_KEY = "private_key"
+        const val COL_ADDRESS = "address"
+        const val COL_SAFE_ADDRESS = "safe_address"
+    }
+}
 
 @Entity(tableName = PendingGnosisSafeDb.TABLE_NAME)
 data class PendingGnosisSafeDb(

--- a/app/src/main/java/pm/gnosis/heimdall/data/db/models/GnosisSafeDb.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/db/models/GnosisSafeDb.kt
@@ -51,7 +51,7 @@ data class GnosisSafeOwnerDb(
     val address: Solidity.Address,
 
     @ColumnInfo(name = COL_SAFE_ADDRESS)
-    val safeAddress: Solidity.Address? = null
+    val safeAddress: Solidity.Address = Solidity.Address(BigInteger.valueOf(0))
 ) {
     companion object {
         const val TABLE_NAME = "gnosis_safe_owners"

--- a/app/src/main/java/pm/gnosis/heimdall/data/db/models/GnosisSafeDb.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/db/models/GnosisSafeDb.kt
@@ -51,7 +51,7 @@ data class GnosisSafeOwnerDb(
     val address: Solidity.Address,
 
     @ColumnInfo(name = COL_SAFE_ADDRESS)
-    val safeAddress: Solidity.Address = Solidity.Address(BigInteger.valueOf(0))
+    val safeAddress: Solidity.Address? = null
 ) {
     companion object {
         const val TABLE_NAME = "gnosis_safe_owners"

--- a/app/src/main/java/pm/gnosis/heimdall/data/repositories/GnosisSafeRepository.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/repositories/GnosisSafeRepository.kt
@@ -78,9 +78,9 @@ interface GnosisSafeRepository {
     fun observeSubmittedTransactions(address: Solidity.Address): Flowable<List<TransactionStatus>>
 
     // Safe owner
-    fun createOwner(): Single<Solidity.Address>
+    fun createOwner(): Single<Pair<Solidity.Address, ByteArray>>
 
-    fun assignOwnerToSafe(ownerAddress: Solidity.Address, safeAddress: Solidity.Address): Completable
+    fun saveOwner(safeAddress: Solidity.Address, ownerAddress: Solidity.Address, ownerKey: ByteArray): Completable
 
     fun loadOwnerAddress(safeAddress: Solidity.Address): Single<Solidity.Address>
 

--- a/app/src/main/java/pm/gnosis/heimdall/data/repositories/GnosisSafeRepository.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/repositories/GnosisSafeRepository.kt
@@ -76,4 +76,15 @@ interface GnosisSafeRepository {
     fun observePendingTransactions(address: Solidity.Address): Flowable<List<TransactionStatus>>
 
     fun observeSubmittedTransactions(address: Solidity.Address): Flowable<List<TransactionStatus>>
+
+    // Safe owner
+    fun createOwner(): Single<Solidity.Address>
+
+    fun assignOwnerToSafe(ownerAddress: Solidity.Address, safeAddress: Solidity.Address): Completable
+
+    fun loadOwnerAddress(safeAddress: Solidity.Address): Single<Solidity.Address>
+
+    fun sign(safeAddress: Solidity.Address, data: ByteArray): Single<Signature>
+
+    fun recover(data: ByteArray, signature: Signature): Single<Solidity.Address>
 }

--- a/app/src/main/java/pm/gnosis/heimdall/data/repositories/impls/DefaultGnosisSafeRepository.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/repositories/impls/DefaultGnosisSafeRepository.kt
@@ -364,7 +364,7 @@ class DefaultGnosisSafeRepository @Inject constructor(
             KeyPair.signatureToKey(data, signature.v, signature.r, signature.s).address.asBigInteger()
         }.map { Solidity.Address(it) }
     }
-    
+
     private class SafeInfoRequest(
         val balance: EthRequest<Wei>,
         val threshold: EthRequest<String>,

--- a/app/src/main/java/pm/gnosis/heimdall/di/modules/ApplicationModule.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/di/modules/ApplicationModule.kt
@@ -204,6 +204,7 @@ class ApplicationModule(private val application: Application) {
     @Singleton
     fun providesDb(@ApplicationContext context: Context) =
         Room.databaseBuilder(context, ApplicationDb::class.java, ApplicationDb.DB_NAME)
+            .addMigrations(ApplicationDb.MIGRATION_1_2)
             .build()
 
     @Provides

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/create/CreateSafeConfirmRecoveryPhraseViewModel.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/create/CreateSafeConfirmRecoveryPhraseViewModel.kt
@@ -123,7 +123,7 @@ class CreateSafeConfirmRecoveryPhraseViewModel @Inject constructor(
 
     private fun createSafeOwner() = gnosisSafeRepository.createOwner()
 
-    data class OwnerData(
+    private data class OwnerData(
         val ownerKey: ByteArray,
         val ownerAddress: Solidity.Address,
         val fullListOfOwners: List<Solidity.Address>

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/mnemonic/InputRecoveryPhraseContract.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/mnemonic/InputRecoveryPhraseContract.kt
@@ -7,6 +7,7 @@ import pm.gnosis.model.Solidity
 import pm.gnosis.svalinn.accounts.base.models.Signature
 
 abstract class InputRecoveryPhraseContract : ViewModel() {
+
     abstract fun process(input: Input, safeAddress: Solidity.Address, extensionAddress: Solidity.Address?): Observable<ViewUpdate>
 
     data class Input(
@@ -16,13 +17,28 @@ abstract class InputRecoveryPhraseContract : ViewModel() {
     )
 
     sealed class ViewUpdate {
+
         data class SafeInfoError(val error: Throwable) : ViewUpdate()
+
         object InputMnemonic : ViewUpdate()
+
         object InvalidMnemonic : ViewUpdate()
+
         object WrongMnemonic : ViewUpdate()
+
         object ValidMnemonic : ViewUpdate()
-        data class NoRecoveryNecessary(val safeAddress: Solidity.Address) : ViewUpdate()
+
+        data class NoRecoveryNecessary(
+            val safeAddress: Solidity.Address
+        ) : ViewUpdate()
+
         data class RecoverDataError(val error: Throwable) : ViewUpdate()
-        data class RecoverData(val executionInfo: TransactionExecutionRepository.ExecuteInformation, val signatures: List<Signature>) : ViewUpdate()
+
+        data class RecoverData(
+            val executionInfo: TransactionExecutionRepository.ExecuteInformation,
+            val signatures: List<Signature>,
+            val ownerAddress: Solidity.Address,
+            val ownerKey: ByteArray
+        ) : ViewUpdate()
     }
 }

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/recover/safe/RecoverSafeRecoveryPhraseViewModel.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/recover/safe/RecoverSafeRecoveryPhraseViewModel.kt
@@ -24,9 +24,11 @@ class RecoverSafeRecoveryPhraseViewModel @Inject constructor(
                             it.executionInfo,
                             it.signatures
                         )
+                            .andThen(safeRepository.saveOwner(safeAddress, it.ownerAddress, it.ownerKey))
                             .andThen(Single.just<ViewUpdate>(it))
                             .onErrorReturn(ViewUpdate::RecoverDataError)
                     }
+                    //FIXME: save owner info?
                     is ViewUpdate.NoRecoveryNecessary -> {
                         safeRepository.addSafe(safeAddress)
                             .andThen(Single.just<ViewUpdate>(it))

--- a/app/src/main/res/layout/layout_create_asset_transfer.xml
+++ b/app/src/main/res/layout/layout_create_asset_transfer.xml
@@ -306,7 +306,7 @@
                 style="@style/NormalText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
+                android:layout_marginStart="4dp"
                 android:paddingTop="12dp"
                 android:text="@string/tip_link"
                 android:textColor="@color/link"

--- a/app/src/test/java/pm/gnosis/heimdall/data/repositories/impls/DefaultGnosisSafeRepositoryTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/data/repositories/impls/DefaultGnosisSafeRepositoryTest.kt
@@ -20,8 +20,10 @@ import pm.gnosis.heimdall.data.db.daos.DescriptionsDao
 import pm.gnosis.heimdall.data.db.daos.GnosisSafeDao
 import pm.gnosis.heimdall.data.repositories.AddressBookRepository
 import pm.gnosis.heimdall.data.repositories.PushServiceRepository
+import pm.gnosis.mnemonic.Bip39
 import pm.gnosis.model.Solidity
 import pm.gnosis.svalinn.accounts.base.repositories.AccountsRepository
+import pm.gnosis.svalinn.security.EncryptionManager
 import pm.gnosis.tests.utils.ImmediateSchedulersRule
 import pm.gnosis.tests.utils.MockUtils
 import pm.gnosis.utils.asEthereumAddress
@@ -60,6 +62,12 @@ class DefaultGnosisSafeRepositoryTest {
     @Mock
     private lateinit var pushRepositoryMock: PushServiceRepository
 
+    @Mock
+    private lateinit var bip39: Bip39
+
+    @Mock
+    private lateinit var encryptionManager: EncryptionManager
+
 
     @Before
     fun setUp() {
@@ -71,7 +79,9 @@ class DefaultGnosisSafeRepositoryTest {
             accountsRepository,
             addressBookRepository,
             ethereumRepositoryMock,
-            pushRepositoryMock
+            pushRepositoryMock,
+            bip39,
+            encryptionManager
         )
     }
 

--- a/app/src/test/java/pm/gnosis/heimdall/ui/safe/create/CreateSafeConfirmRecoveryPhraseViewModelTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/safe/create/CreateSafeConfirmRecoveryPhraseViewModelTest.kt
@@ -100,6 +100,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     fun createSafe() {
         val testObserver = TestObserver.create<Solidity.Address>()
         val ownerAddress = Solidity.Address(10.toBigInteger())
+        val ownerKey = byteArrayOf(0)
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
@@ -109,7 +110,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
         var response: RelaySafeCreation? = null
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(ETHER_TOKEN))
-        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(ownerAddress))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(Pair(ownerAddress, ownerKey)))
         given(bip39Mock.mnemonicToSeed(anyString(), MockUtils.any())).willReturn(mnemonicSeed)
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(0L))).willReturn(Single.just(mnemonicAddress0 to mnemonicSeed))
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L))).willReturn(Single.just(mnemonicAddress1 to mnemonicSeed))
@@ -136,6 +137,13 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
                 MockUtils.any(),
                 MockUtils.any()
             )
+        ).willReturn(Completable.complete())
+
+        given(
+            gnosisSafeRepositoryMock.saveOwner(
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any())
         ).willReturn(Completable.complete())
 
         viewModel.setup(chromeExtensionAddress)
@@ -166,6 +174,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     fun createSafeSaveDbError() {
         val testObserver = TestObserver.create<Solidity.Address>()
         val ownerAddress = Solidity.Address(10.toBigInteger())
+        val ownerKey = byteArrayOf(0)
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
@@ -177,7 +186,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
         val exception = Exception()
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(PAYMENT_TOKEN))
-        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(ownerAddress))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(Pair(ownerAddress, ownerKey)))
         given(bip39Mock.mnemonicToSeed(anyString(), MockUtils.any())).willReturn(mnemonicSeed)
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(0L))).willReturn(Single.just(mnemonicAddress0 to mnemonicSeed))
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L))).willReturn(Single.just(mnemonicAddress1 to mnemonicSeed))
@@ -200,6 +209,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
             )
             Single.just(response!!)
         }
+
         given(
             gnosisSafeRepositoryMock.addPendingSafe(
                 MockUtils.any(),
@@ -208,6 +218,13 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
                 MockUtils.any()
             )
         ).willReturn(Completable.error(exception))
+
+        given(
+            gnosisSafeRepositoryMock.saveOwner(
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any())
+        ).willReturn(Completable.complete())
 
         viewModel.setup(chromeExtensionAddress)
         viewModel.createSafe().subscribe(testObserver)
@@ -237,6 +254,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     fun createSafeAddressesNotMatching() {
         val testObserver = TestObserver.create<Solidity.Address>()
         val ownerAddress = Solidity.Address(10.toBigInteger())
+        val ownerKey = byteArrayOf(0)
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
@@ -248,7 +266,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(ETHER_TOKEN))
         //given(accountsRepositoryMock.loadActiveAccount()).willReturn(Single.just(account))
-        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(ownerAddress))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(Pair(ownerAddress, ownerKey)))
         given(bip39Mock.mnemonicToSeed(anyString(), MockUtils.any())).willReturn(mnemonicSeed)
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(0L))).willReturn(Single.just(mnemonicAddress0 to mnemonicSeed))
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L))).willReturn(Single.just(mnemonicAddress1 to mnemonicSeed))
@@ -297,6 +315,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
 
     private fun testSafeCreationChecks(
         ownerAddress: Solidity.Address,
+        ownerKey: ByteArray,
         mnemonicAddress0: Solidity.Address,
         mnemonicAddress1: Solidity.Address,
         chromeExtensionAddress: Solidity.Address?,
@@ -309,7 +328,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
         var saltNonce: Long? = null
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(paymentToken))
-        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(ownerAddress))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(Pair(ownerAddress, ownerKey)))
         given(bip39Mock.mnemonicToSeed(anyString(), MockUtils.any())).willReturn(mnemonicSeed)
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(0L))).willReturn(Single.just(mnemonicAddress0 to mnemonicSeed))
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L))).willReturn(Single.just(mnemonicAddress1 to mnemonicSeed))
@@ -343,11 +362,12 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     fun createSafeDifferentPaymentToken() {
         val safeAddress = "ffff".asEthereumAddress()!!
         val ownerAddress = Solidity.Address(10.toBigInteger())
+        val ownerKey = byteArrayOf(0)
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, ownerKey, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
@@ -374,11 +394,12 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     fun createSafeDifferentMasterCopy() {
         val safeAddress = "ffff".asEthereumAddress()!!
         val ownerAddress = Solidity.Address(10.toBigInteger())
+        val ownerKey = byteArrayOf(0)
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, ownerKey, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
@@ -405,11 +426,12 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     fun createSafeDifferentProxyFactory() {
         val safeAddress = "ffff".asEthereumAddress()!!
         val ownerAddress = Solidity.Address(10.toBigInteger())
+        val ownerKey = byteArrayOf(0)
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, ownerKey, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
@@ -436,11 +458,12 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     fun createSafeUnknownReceiver() {
         val safeAddress = "ffff".asEthereumAddress()!!
         val ownerAddress = Solidity.Address(10.toBigInteger())
+        val ownerKey = byteArrayOf(0)
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, ownerKey, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
@@ -467,11 +490,12 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     fun createSafeInvalidSetupData() {
         val safeAddress = "ffff".asEthereumAddress()!!
         val ownerAddress = Solidity.Address(10.toBigInteger())
+        val ownerKey = byteArrayOf(0)
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, ownerKey, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
@@ -495,11 +519,12 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     fun createSafeDifferentOwnersInData() {
         val safeAddress = "ffff".asEthereumAddress()!!
         val ownerAddress = Solidity.Address(10.toBigInteger())
+        val ownerKey = byteArrayOf(0)
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, ownerKey, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
@@ -526,11 +551,12 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     fun createSafeDifferentPaymentReceiverInData() {
         val safeAddress = "ffff".asEthereumAddress()!!
         val ownerAddress = Solidity.Address(10.toBigInteger())
+        val ownerKey = byteArrayOf(0)
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, ownerKey, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
@@ -557,11 +583,12 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     fun createSafeDifferentPaymentTokenInData() {
         val safeAddress = "ffff".asEthereumAddress()!!
         val ownerAddress = Solidity.Address(10.toBigInteger())
+        val ownerKey = byteArrayOf(0)
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, ownerKey, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
@@ -588,11 +615,12 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     fun createSafeDifferentPaymentInData() {
         val safeAddress = "ffff".asEthereumAddress()!!
         val ownerAddress = Solidity.Address(10.toBigInteger())
+        val ownerKey = byteArrayOf(0)
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, ownerKey, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
@@ -619,6 +647,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     fun createSafeWithoutBrowserExtension() {
         val testObserver = TestObserver.create<Solidity.Address>()
         val ownerAddress = Solidity.Address(10.toBigInteger())
+        val ownerKey = byteArrayOf(0)
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val deployer = Solidity.Address(1234.toBigInteger())
@@ -628,7 +657,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
         var response: RelaySafeCreation? = null
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(ETHER_TOKEN))
-        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(ownerAddress))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(Pair(ownerAddress, ownerKey)))
         given(bip39Mock.mnemonicToSeed(anyString(), MockUtils.any())).willReturn(mnemonicSeed)
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(0L))).willReturn(Single.just(mnemonicAddress0 to mnemonicSeed))
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L))).willReturn(Single.just(mnemonicAddress1 to mnemonicSeed))
@@ -660,6 +689,13 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
             )
         ).willReturn(Completable.complete())
 
+        given(
+            gnosisSafeRepositoryMock.saveOwner(
+                MockUtils.any(),
+                MockUtils.any(),
+                MockUtils.any())
+        ).willReturn(Completable.complete())
+
         viewModel.setup(null)
         viewModel.createSafe().subscribe(testObserver)
 
@@ -688,6 +724,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     fun createSafeApiError() {
         val testObserver = TestObserver.create<Solidity.Address>()
         val ownerAddress = Solidity.Address(10.toBigInteger())
+        val ownerKey = byteArrayOf(0)
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
@@ -696,7 +733,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
         val exception = Exception()
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(ETHER_TOKEN))
-        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(ownerAddress))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(Pair(ownerAddress, ownerKey)))
         given(bip39Mock.mnemonicToSeed(anyString(), MockUtils.any())).willReturn(mnemonicSeed)
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(0L))).willReturn(Single.just(mnemonicAddress0 to mnemonicSeed))
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L))).willReturn(Single.just(mnemonicAddress1 to mnemonicSeed))
@@ -732,13 +769,14 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     fun createSafeFromMnemonicSeedError() {
         val testObserver = TestObserver.create<Solidity.Address>()
         val ownerAddress = Solidity.Address(10.toBigInteger())
+        val ownerKey = byteArrayOf(0)
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         val mnemonicSeed = byteArrayOf(0)
         val exception = Exception()
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(PAYMENT_TOKEN))
-        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(ownerAddress))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(Pair(ownerAddress, ownerKey)))
         given(bip39Mock.mnemonicToSeed(anyString(), MockUtils.any())).willReturn(mnemonicSeed)
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(0L))).willReturn(Single.just(mnemonicAddress0 to mnemonicSeed))
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L))).willReturn(Single.error(exception))
@@ -764,11 +802,12 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     fun createSafeMnemonicToSeedError() {
         val testObserver = TestObserver.create<Solidity.Address>()
         val ownerAddress = Solidity.Address(10.toBigInteger())
+        val ownerKey = byteArrayOf(0)
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         val exception = IllegalArgumentException()
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(PAYMENT_TOKEN))
-        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(ownerAddress))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(Pair(ownerAddress, ownerKey)))
         given(bip39Mock.mnemonicToSeed(anyString(), MockUtils.any())).willThrow(exception)
 
         // Setup parent class

--- a/app/src/test/java/pm/gnosis/heimdall/ui/safe/create/CreateSafeConfirmRecoveryPhraseViewModelTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/safe/create/CreateSafeConfirmRecoveryPhraseViewModelTest.kt
@@ -26,11 +26,12 @@ import pm.gnosis.heimdall.data.repositories.models.ERC20Token
 import pm.gnosis.mnemonic.Bip39
 import pm.gnosis.model.Solidity
 import pm.gnosis.model.SolidityBase
-import pm.gnosis.svalinn.accounts.base.models.Account
 import pm.gnosis.svalinn.accounts.base.repositories.AccountsRepository
 import pm.gnosis.tests.utils.ImmediateSchedulersRule
 import pm.gnosis.tests.utils.MockUtils
-import pm.gnosis.utils.*
+import pm.gnosis.utils.asEthereumAddress
+import pm.gnosis.utils.hexToByteArray
+import pm.gnosis.utils.toBytes
 import java.math.BigInteger
 
 @RunWith(MockitoJUnitRunner::class)
@@ -98,7 +99,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     @Test
     fun createSafe() {
         val testObserver = TestObserver.create<Solidity.Address>()
-        val account = Account(Solidity.Address(10.toBigInteger()))
+        val ownerAddress = Solidity.Address(10.toBigInteger())
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
@@ -108,14 +109,14 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
         var response: RelaySafeCreation? = null
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(ETHER_TOKEN))
-        given(accountsRepositoryMock.loadActiveAccount()).willReturn(Single.just(account))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(ownerAddress))
         given(bip39Mock.mnemonicToSeed(anyString(), MockUtils.any())).willReturn(mnemonicSeed)
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(0L))).willReturn(Single.just(mnemonicAddress0 to mnemonicSeed))
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L))).willReturn(Single.just(mnemonicAddress1 to mnemonicSeed))
         given(relayServiceApiMock.safeCreation(MockUtils.any())).willAnswer {
             val request = it.arguments.first() as RelaySafeCreationParams
             saltNonce = request.saltNonce
-            val setupData = generateSafeCreationData(listOfNotNull(account.address, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1))
+            val setupData = generateSafeCreationData(listOfNotNull(ownerAddress, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1))
             safeAddress = calculateSafeAddress(setupData, saltNonce!!)
             response = RelaySafeCreation(
                 setupData = setupData,
@@ -144,14 +145,14 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
 
         then(tokenRepositoryMock).should().loadPaymentToken()
         then(tokenRepositoryMock).shouldHaveNoMoreInteractions()
-        then(accountsRepositoryMock).should().loadActiveAccount()
+        then(gnosisSafeRepositoryMock).should().createOwner()
         then(bip39Mock).should().mnemonicToSeed(RECOVERY_PHRASE)
         then(accountsRepositoryMock).should().accountFromMnemonicSeed(mnemonicSeed, 0L)
         then(accountsRepositoryMock).should().accountFromMnemonicSeed(mnemonicSeed, 1L)
         then(relayServiceApiMock).should()
             .safeCreation(
                 RelaySafeCreationParams(
-                    listOf(account.address, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
+                    listOf(ownerAddress, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
                     2, saltNonce!!, ETHER_TOKEN.address
                 )
             )
@@ -164,7 +165,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     @Test
     fun createSafeSaveDbError() {
         val testObserver = TestObserver.create<Solidity.Address>()
-        val account = Account(Solidity.Address(10.toBigInteger()))
+        val ownerAddress = Solidity.Address(10.toBigInteger())
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
@@ -176,7 +177,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
         val exception = Exception()
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(PAYMENT_TOKEN))
-        given(accountsRepositoryMock.loadActiveAccount()).willReturn(Single.just(account))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(ownerAddress))
         given(bip39Mock.mnemonicToSeed(anyString(), MockUtils.any())).willReturn(mnemonicSeed)
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(0L))).willReturn(Single.just(mnemonicAddress0 to mnemonicSeed))
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L))).willReturn(Single.just(mnemonicAddress1 to mnemonicSeed))
@@ -184,7 +185,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
             val request = it.arguments.first() as RelaySafeCreationParams
             saltNonce = request.saltNonce
             val setupData = generateSafeCreationData(
-                listOfNotNull(account.address, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
+                listOfNotNull(ownerAddress, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
                 BigInteger.TEN, PAYMENT_TOKEN
             )
             safeAddress = calculateSafeAddress(setupData, saltNonce!!)
@@ -215,14 +216,14 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
 
         then(tokenRepositoryMock).should().loadPaymentToken()
         then(tokenRepositoryMock).shouldHaveNoMoreInteractions()
-        then(accountsRepositoryMock).should().loadActiveAccount()
+        then(gnosisSafeRepositoryMock).should().createOwner()
         then(bip39Mock).should().mnemonicToSeed(RECOVERY_PHRASE)
         then(accountsRepositoryMock).should().accountFromMnemonicSeed(mnemonicSeed, 0L)
         then(accountsRepositoryMock).should().accountFromMnemonicSeed(mnemonicSeed, 1L)
         then(relayServiceApiMock).should()
             .safeCreation(
                 RelaySafeCreationParams(
-                    listOf(account.address, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
+                    listOf(ownerAddress, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
                     2, saltNonce!!, PAYMENT_TOKEN.address
                 )
             )
@@ -235,7 +236,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     @Test
     fun createSafeAddressesNotMatching() {
         val testObserver = TestObserver.create<Solidity.Address>()
-        val account = Account(Solidity.Address(10.toBigInteger()))
+        val ownerAddress = Solidity.Address(10.toBigInteger())
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
@@ -246,7 +247,8 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
         var response: RelaySafeCreation? = null
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(ETHER_TOKEN))
-        given(accountsRepositoryMock.loadActiveAccount()).willReturn(Single.just(account))
+        //given(accountsRepositoryMock.loadActiveAccount()).willReturn(Single.just(account))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(ownerAddress))
         given(bip39Mock.mnemonicToSeed(anyString(), MockUtils.any())).willReturn(mnemonicSeed)
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(0L))).willReturn(Single.just(mnemonicAddress0 to mnemonicSeed))
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L))).willReturn(Single.just(mnemonicAddress1 to mnemonicSeed))
@@ -254,7 +256,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
             val request = it.arguments.first() as RelaySafeCreationParams
             saltNonce = request.saltNonce
             val setupData = generateSafeCreationData(
-                listOfNotNull(account.address, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
+                listOfNotNull(ownerAddress, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
                 BigInteger.ZERO, ETHER_TOKEN, FUNDER_ADDRESS
             )
             response = RelaySafeCreation(
@@ -274,14 +276,14 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
 
         then(tokenRepositoryMock).should().loadPaymentToken()
         then(tokenRepositoryMock).shouldHaveNoMoreInteractions()
-        then(accountsRepositoryMock).should().loadActiveAccount()
+        then(gnosisSafeRepositoryMock).should().createOwner()
         then(bip39Mock).should().mnemonicToSeed(RECOVERY_PHRASE)
         then(accountsRepositoryMock).should().accountFromMnemonicSeed(mnemonicSeed, 0L)
         then(accountsRepositoryMock).should().accountFromMnemonicSeed(mnemonicSeed, 1L)
         then(relayServiceApiMock).should()
             .safeCreation(
                 RelaySafeCreationParams(
-                    listOf(account.address, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
+                    listOf(ownerAddress, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
                     2, saltNonce!!, ETHER_TOKEN.address
                 )
             )
@@ -294,7 +296,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     }
 
     private fun testSafeCreationChecks(
-        account: Account,
+        ownerAddress: Solidity.Address,
         mnemonicAddress0: Solidity.Address,
         mnemonicAddress1: Solidity.Address,
         chromeExtensionAddress: Solidity.Address?,
@@ -307,7 +309,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
         var saltNonce: Long? = null
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(paymentToken))
-        given(accountsRepositoryMock.loadActiveAccount()).willReturn(Single.just(account))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(ownerAddress))
         given(bip39Mock.mnemonicToSeed(anyString(), MockUtils.any())).willReturn(mnemonicSeed)
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(0L))).willReturn(Single.just(mnemonicAddress0 to mnemonicSeed))
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L))).willReturn(Single.just(mnemonicAddress1 to mnemonicSeed))
@@ -322,13 +324,13 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
 
         then(tokenRepositoryMock).should().loadPaymentToken()
         then(tokenRepositoryMock).shouldHaveNoMoreInteractions()
-        then(accountsRepositoryMock).should().loadActiveAccount()
+        then(gnosisSafeRepositoryMock).should().createOwner()
         then(bip39Mock).should().mnemonicToSeed(RECOVERY_PHRASE)
         then(accountsRepositoryMock).should().accountFromMnemonicSeed(mnemonicSeed, 0L)
         then(accountsRepositoryMock).should().accountFromMnemonicSeed(mnemonicSeed, 1L)
         then(relayServiceApiMock).should()
             .safeCreation(RelaySafeCreationParams(
-                listOfNotNull(account.address, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
+                listOfNotNull(ownerAddress, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
                 chromeExtensionAddress?.run { 2 } ?: 1, saltNonce!!, paymentToken.address)
             )
         then(accountsRepositoryMock).shouldHaveNoMoreInteractions()
@@ -340,17 +342,17 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     @Test
     fun createSafeDifferentPaymentToken() {
         val safeAddress = "ffff".asEthereumAddress()!!
-        val account = Account(Solidity.Address(10.toBigInteger()))
+        val ownerAddress = Solidity.Address(10.toBigInteger())
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            account, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
                         setupData = generateSafeCreationData(
-                            listOfNotNull(account.address, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
+                            listOfNotNull(ownerAddress, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
                             BigInteger.ZERO, PAYMENT_TOKEN
                         ),
                         safe = safeAddress,
@@ -371,17 +373,17 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     @Test
     fun createSafeDifferentMasterCopy() {
         val safeAddress = "ffff".asEthereumAddress()!!
-        val account = Account(Solidity.Address(10.toBigInteger()))
+        val ownerAddress = Solidity.Address(10.toBigInteger())
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            account, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
                         setupData = generateSafeCreationData(
-                            listOfNotNull(account.address, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
+                            listOfNotNull(ownerAddress, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
                             BigInteger.ZERO, ETHER_TOKEN
                         ),
                         safe = safeAddress,
@@ -402,17 +404,17 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     @Test
     fun createSafeDifferentProxyFactory() {
         val safeAddress = "ffff".asEthereumAddress()!!
-        val account = Account(Solidity.Address(10.toBigInteger()))
+        val ownerAddress = Solidity.Address(10.toBigInteger())
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            account, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
                         setupData = generateSafeCreationData(
-                            listOfNotNull(account.address, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
+                            listOfNotNull(ownerAddress, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
                             BigInteger.ZERO, ETHER_TOKEN
                         ),
                         safe = safeAddress,
@@ -433,17 +435,17 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     @Test
     fun createSafeUnknownReceiver() {
         val safeAddress = "ffff".asEthereumAddress()!!
-        val account = Account(Solidity.Address(10.toBigInteger()))
+        val ownerAddress = Solidity.Address(10.toBigInteger())
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            account, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
                         setupData = generateSafeCreationData(
-                            listOfNotNull(account.address, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
+                            listOfNotNull(ownerAddress, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
                             BigInteger.ZERO, ETHER_TOKEN, PAYMENT_TOKEN.address
                         ),
                         safe = safeAddress,
@@ -464,12 +466,12 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     @Test
     fun createSafeInvalidSetupData() {
         val safeAddress = "ffff".asEthereumAddress()!!
-        val account = Account(Solidity.Address(10.toBigInteger()))
+        val ownerAddress = Solidity.Address(10.toBigInteger())
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            account, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
@@ -492,12 +494,12 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     @Test
     fun createSafeDifferentOwnersInData() {
         val safeAddress = "ffff".asEthereumAddress()!!
-        val account = Account(Solidity.Address(10.toBigInteger()))
+        val ownerAddress = Solidity.Address(10.toBigInteger())
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            account, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
@@ -523,17 +525,17 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     @Test
     fun createSafeDifferentPaymentReceiverInData() {
         val safeAddress = "ffff".asEthereumAddress()!!
-        val account = Account(Solidity.Address(10.toBigInteger()))
+        val ownerAddress = Solidity.Address(10.toBigInteger())
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            account, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
                         setupData = generateSafeCreationData(
-                            listOfNotNull(account.address, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
+                            listOfNotNull(ownerAddress, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
                             BigInteger.ZERO, ETHER_TOKEN, PAYMENT_TOKEN.address
                         ),
                         safe = safeAddress,
@@ -554,17 +556,17 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     @Test
     fun createSafeDifferentPaymentTokenInData() {
         val safeAddress = "ffff".asEthereumAddress()!!
-        val account = Account(Solidity.Address(10.toBigInteger()))
+        val ownerAddress = Solidity.Address(10.toBigInteger())
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            account, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
                         setupData = generateSafeCreationData(
-                            listOfNotNull(account.address, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
+                            listOfNotNull(ownerAddress, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
                             BigInteger.ZERO, PAYMENT_TOKEN, TX_ORIGIN_ADDRESS
                         ),
                         safe = safeAddress,
@@ -585,17 +587,17 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     @Test
     fun createSafeDifferentPaymentInData() {
         val safeAddress = "ffff".asEthereumAddress()!!
-        val account = Account(Solidity.Address(10.toBigInteger()))
+        val ownerAddress = Solidity.Address(10.toBigInteger())
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         testSafeCreationChecks(
-            account, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
+            ownerAddress, mnemonicAddress0, mnemonicAddress1, chromeExtensionAddress,
             { request ->
                 Single.just(
                     RelaySafeCreation(
                         setupData = generateSafeCreationData(
-                            listOfNotNull(account.address, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
+                            listOfNotNull(ownerAddress, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
                             BigInteger.TEN, ETHER_TOKEN, TX_ORIGIN_ADDRESS
                         ),
                         safe = safeAddress,
@@ -616,7 +618,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     @Test
     fun createSafeWithoutBrowserExtension() {
         val testObserver = TestObserver.create<Solidity.Address>()
-        val account = Account(Solidity.Address(10.toBigInteger()))
+        val ownerAddress = Solidity.Address(10.toBigInteger())
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val deployer = Solidity.Address(1234.toBigInteger())
@@ -626,7 +628,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
         var response: RelaySafeCreation? = null
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(ETHER_TOKEN))
-        given(accountsRepositoryMock.loadActiveAccount()).willReturn(Single.just(account))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(ownerAddress))
         given(bip39Mock.mnemonicToSeed(anyString(), MockUtils.any())).willReturn(mnemonicSeed)
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(0L))).willReturn(Single.just(mnemonicAddress0 to mnemonicSeed))
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L))).willReturn(Single.just(mnemonicAddress1 to mnemonicSeed))
@@ -634,7 +636,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
             val request = it.arguments.first() as RelaySafeCreationParams
             saltNonce = request.saltNonce
             val setupData = generateSafeCreationData(
-                listOfNotNull(account.address, mnemonicAddress0, mnemonicAddress1),
+                listOfNotNull(ownerAddress, mnemonicAddress0, mnemonicAddress1),
                 BigInteger.ZERO, ETHER_TOKEN, FUNDER_ADDRESS
             )
             safeAddress = calculateSafeAddress(setupData, saltNonce!!)
@@ -665,14 +667,14 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
 
         then(tokenRepositoryMock).should().loadPaymentToken()
         then(tokenRepositoryMock).shouldHaveNoMoreInteractions()
-        then(accountsRepositoryMock).should().loadActiveAccount()
+        then(gnosisSafeRepositoryMock).should().createOwner()
         then(bip39Mock).should().mnemonicToSeed(RECOVERY_PHRASE)
         then(accountsRepositoryMock).should().accountFromMnemonicSeed(mnemonicSeed, 0L)
         then(accountsRepositoryMock).should().accountFromMnemonicSeed(mnemonicSeed, 1L)
         then(relayServiceApiMock).should()
             .safeCreation(
                 RelaySafeCreationParams(
-                    listOf(account.address, mnemonicAddress0, mnemonicAddress1),
+                    listOf(ownerAddress, mnemonicAddress0, mnemonicAddress1),
                     1, saltNonce!!, ETHER_TOKEN.address
                 )
             )
@@ -685,7 +687,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     @Test
     fun createSafeApiError() {
         val testObserver = TestObserver.create<Solidity.Address>()
-        val account = Account(Solidity.Address(10.toBigInteger()))
+        val ownerAddress = Solidity.Address(10.toBigInteger())
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val mnemonicAddress1 = Solidity.Address(12.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
@@ -694,7 +696,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
         val exception = Exception()
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(ETHER_TOKEN))
-        given(accountsRepositoryMock.loadActiveAccount()).willReturn(Single.just(account))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(ownerAddress))
         given(bip39Mock.mnemonicToSeed(anyString(), MockUtils.any())).willReturn(mnemonicSeed)
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(0L))).willReturn(Single.just(mnemonicAddress0 to mnemonicSeed))
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L))).willReturn(Single.just(mnemonicAddress1 to mnemonicSeed))
@@ -709,14 +711,14 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
 
         then(tokenRepositoryMock).should().loadPaymentToken()
         then(tokenRepositoryMock).shouldHaveNoMoreInteractions()
-        then(accountsRepositoryMock).should().loadActiveAccount()
+        then(gnosisSafeRepositoryMock).should().createOwner()
         then(bip39Mock).should().mnemonicToSeed(RECOVERY_PHRASE)
         then(accountsRepositoryMock).should().accountFromMnemonicSeed(mnemonicSeed, 0L)
         then(accountsRepositoryMock).should().accountFromMnemonicSeed(mnemonicSeed, 1L)
         then(relayServiceApiMock).should()
             .safeCreation(
                 RelaySafeCreationParams(
-                    listOf(account.address, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
+                    listOf(ownerAddress, chromeExtensionAddress, mnemonicAddress0, mnemonicAddress1),
                     2, saltNonce!!, ETHER_TOKEN.address
                 )
             )
@@ -729,14 +731,14 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     @Test
     fun createSafeFromMnemonicSeedError() {
         val testObserver = TestObserver.create<Solidity.Address>()
-        val account = Account(Solidity.Address(10.toBigInteger()))
+        val ownerAddress = Solidity.Address(10.toBigInteger())
         val mnemonicAddress0 = Solidity.Address(11.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         val mnemonicSeed = byteArrayOf(0)
         val exception = Exception()
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(PAYMENT_TOKEN))
-        given(accountsRepositoryMock.loadActiveAccount()).willReturn(Single.just(account))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(ownerAddress))
         given(bip39Mock.mnemonicToSeed(anyString(), MockUtils.any())).willReturn(mnemonicSeed)
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(0L))).willReturn(Single.just(mnemonicAddress0 to mnemonicSeed))
         given(accountsRepositoryMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L))).willReturn(Single.error(exception))
@@ -746,7 +748,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
         viewModel.setup(chromeExtensionAddress)
         viewModel.createSafe().subscribe(testObserver)
 
-        then(accountsRepositoryMock).should().loadActiveAccount()
+        then(gnosisSafeRepositoryMock).should().createOwner()
         then(bip39Mock).should().mnemonicToSeed(RECOVERY_PHRASE)
         then(accountsRepositoryMock).should().accountFromMnemonicSeed(mnemonicSeed, 0L)
         then(accountsRepositoryMock).should().accountFromMnemonicSeed(mnemonicSeed, 1L)
@@ -761,12 +763,12 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
     @Test
     fun createSafeMnemonicToSeedError() {
         val testObserver = TestObserver.create<Solidity.Address>()
-        val account = Account(Solidity.Address(10.toBigInteger()))
+        val ownerAddress = Solidity.Address(10.toBigInteger())
         val chromeExtensionAddress = Solidity.Address(13.toBigInteger())
         val exception = IllegalArgumentException()
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(PAYMENT_TOKEN))
-        given(accountsRepositoryMock.loadActiveAccount()).willReturn(Single.just(account))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.just(ownerAddress))
         given(bip39Mock.mnemonicToSeed(anyString(), MockUtils.any())).willThrow(exception)
 
         // Setup parent class
@@ -774,7 +776,7 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
         viewModel.setup(chromeExtensionAddress)
         viewModel.createSafe().subscribe(testObserver)
 
-        then(accountsRepositoryMock).should().loadActiveAccount()
+        then(gnosisSafeRepositoryMock).should().createOwner()
         then(bip39Mock).should().mnemonicToSeed(RECOVERY_PHRASE)
         then(accountsRepositoryMock).shouldHaveNoMoreInteractions()
         then(bip39Mock).shouldHaveNoMoreInteractions()
@@ -791,15 +793,15 @@ class CreateSafeConfirmRecoveryPhraseViewModelTest {
         val exception = IllegalArgumentException()
 
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(PAYMENT_TOKEN))
-        given(accountsRepositoryMock.loadActiveAccount()).willReturn(Single.error(exception))
+        given(gnosisSafeRepositoryMock.createOwner()).willReturn(Single.error(exception))
 
         // Setup parent class
         viewModel.setup(RECOVERY_PHRASE)
         viewModel.setup(chromeExtensionAddress)
         viewModel.createSafe().subscribe(testObserver)
 
-        then(accountsRepositoryMock).should().loadActiveAccount()
-        then(accountsRepositoryMock).shouldHaveNoMoreInteractions()
+        then(gnosisSafeRepositoryMock).should().createOwner()
+        then(gnosisSafeRepositoryMock).shouldHaveNoMoreInteractions()
         then(bip39Mock).shouldHaveZeroInteractions()
         then(relayServiceApiMock).shouldHaveZeroInteractions()
         then(tokenRepositoryMock).should().loadPaymentToken()

--- a/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/AdapterEntryHeaders.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/AdapterEntryHeaders.kt
@@ -1,4 +1,4 @@
-package pm.gnosis.heimdall.ui.safe.details.transactions.test
+package pm.gnosis.heimdall.ui.safe.details.transactions
 
 const val PENDING = "pending"
 const val SUBMITTED = "submitted"

--- a/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsAdapterHeaderViewHolderTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsAdapterHeaderViewHolderTest.kt
@@ -25,7 +25,6 @@ import pm.gnosis.heimdall.data.repositories.*
 import pm.gnosis.heimdall.data.repositories.models.ERC20Token
 import pm.gnosis.heimdall.data.repositories.models.SafeTransaction
 import pm.gnosis.heimdall.helpers.AddressHelper
-import pm.gnosis.heimdall.ui.safe.details.transactions.test.SUBMITTED
 import pm.gnosis.model.Solidity
 import pm.gnosis.models.AddressBookEntry
 import pm.gnosis.models.Transaction

--- a/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsAdapterTransactionViewHolderTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsAdapterTransactionViewHolderTest.kt
@@ -10,7 +10,6 @@ import org.mockito.BDDMockito.then
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import pm.gnosis.heimdall.R
-import pm.gnosis.heimdall.ui.safe.details.transactions.test.SUBMITTED
 import pm.gnosis.tests.utils.mockFindViewById
 
 @RunWith(MockitoJUnitRunner::class)

--- a/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsViewModelTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/safe/details/transactions/SafeTransactionsViewModelTest.kt
@@ -26,7 +26,6 @@ import pm.gnosis.heimdall.data.repositories.TransactionExecutionRepository.Publi
 import pm.gnosis.heimdall.data.repositories.models.ERC20Token
 import pm.gnosis.heimdall.data.repositories.models.TransactionStatus
 import pm.gnosis.heimdall.ui.base.Adapter
-import pm.gnosis.heimdall.ui.safe.details.transactions.test.*
 import pm.gnosis.heimdall.utils.DateTimeUtils
 import pm.gnosis.model.Solidity
 import pm.gnosis.svalinn.common.utils.DataResult

--- a/app/src/test/java/pm/gnosis/heimdall/ui/safe/helpers/DefaultRecoverSafeOwnersHelperTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/safe/helpers/DefaultRecoverSafeOwnersHelperTest.kt
@@ -1,7 +1,7 @@
 package pm.gnosis.heimdall.ui.safe.helpers
 
-import androidx.room.EmptyResultSetException
 import android.content.Context
+import androidx.room.EmptyResultSetException
 import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.observers.TestObserver
@@ -237,12 +237,12 @@ class DefaultRecoverSafeOwnersHelperTest {
 
     @Test
     fun processInvalidOwnerCountWithExtension() {
-        testProcessInvalidOwnerCount(TEST_EXTENSION, listOf(TEST_APP, TEST_RECOVER_1, TEST_RECOVER_2))
+        testProcessInvalidOwnerCount(TEST_EXTENSION, listOf(TEST_OWNER, TEST_RECOVER_1, TEST_RECOVER_2))
     }
 
     @Test
     fun processInvalidOwnerCountWithoutExtension() {
-        testProcessInvalidOwnerCount(null, listOf(TEST_APP, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2))
+        testProcessInvalidOwnerCount(null, listOf(TEST_OWNER, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2))
     }
 
     @Test
@@ -255,7 +255,7 @@ class DefaultRecoverSafeOwnersHelperTest {
         given(safeRepoMock.loadInfo(MockUtils.any()))
             .willReturn(
                 Observable.just(
-                    createSafeInfo(TEST_SAFE, Wei.ZERO, 2, listOf(TEST_APP, TEST_EXTENSION, TEST_SAFE, TEST_RECOVER_2), false, emptyList())
+                    createSafeInfo(TEST_SAFE, Wei.ZERO, 2, listOf(TEST_OWNER, TEST_EXTENSION, TEST_SAFE, TEST_RECOVER_2), false, emptyList())
                 )
             )
         given(bip39Mock.validateMnemonic(MockUtils.any())).willReturn("some new mnemonic!")
@@ -293,7 +293,7 @@ class DefaultRecoverSafeOwnersHelperTest {
         given(safeRepoMock.loadInfo(MockUtils.any()))
             .willReturn(
                 Observable.just(
-                    createSafeInfo(TEST_SAFE, Wei.ZERO, 2, listOf(TEST_APP, TEST_EXTENSION, TEST_SAFE, TEST_RECOVER_1), false, emptyList())
+                    createSafeInfo(TEST_SAFE, Wei.ZERO, 2, listOf(TEST_OWNER, TEST_EXTENSION, TEST_SAFE, TEST_RECOVER_1), false, emptyList())
                 )
             )
         given(bip39Mock.validateMnemonic(MockUtils.any())).willReturn("some new mnemonic!")
@@ -331,7 +331,7 @@ class DefaultRecoverSafeOwnersHelperTest {
         given(safeRepoMock.loadInfo(MockUtils.any()))
             .willReturn(
                 Observable.just(
-                    createSafeInfo(TEST_SAFE, Wei.ZERO, 2, listOf(TEST_APP, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2), false, emptyList())
+                    createSafeInfo(TEST_SAFE, Wei.ZERO, 2, listOf(TEST_OWNER, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2), false, emptyList())
                 )
             )
         given(bip39Mock.validateMnemonic(MockUtils.any())).willReturn("some new mnemonic!")
@@ -340,7 +340,7 @@ class DefaultRecoverSafeOwnersHelperTest {
             .willReturn(Single.just(TEST_RECOVER_1 to TEST_RECOVER_1_KEY))
         given(accountsRepoMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L)))
             .willReturn(Single.just(TEST_RECOVER_2 to TEST_RECOVER_2_KEY))
-        given(accountsRepoMock.loadActiveAccount()).willReturn(Single.error(EmptyResultSetException("")))
+        given(safeRepoMock.createOwner()).willReturn(Single.error(EmptyResultSetException("")))
 
         val observer = TestObserver<InputRecoveryPhraseContract.ViewUpdate>()
         helper.process(input, TEST_SAFE, TEST_EXTENSION).subscribe(observer)
@@ -353,7 +353,7 @@ class DefaultRecoverSafeOwnersHelperTest {
         then(bip39Mock).shouldHaveNoMoreInteractions()
         then(accountsRepoMock).should().accountFromMnemonicSeed(TEST_SEED, 0L)
         then(accountsRepoMock).should().accountFromMnemonicSeed(TEST_SEED, 1L)
-        then(accountsRepoMock).should().loadActiveAccount()
+        then(safeRepoMock).should().createOwner()
         then(accountsRepoMock).shouldHaveNoMoreInteractions()
         then(safeRepoMock).should().loadInfo(TEST_SAFE)
         then(safeRepoMock).shouldHaveNoMoreInteractions()
@@ -370,7 +370,7 @@ class DefaultRecoverSafeOwnersHelperTest {
         given(safeRepoMock.loadInfo(MockUtils.any()))
             .willReturn(
                 Observable.just(
-                    createSafeInfo(TEST_SAFE, Wei.ZERO, 2, listOfNotNull(TEST_APP, extension, TEST_RECOVER_1, TEST_RECOVER_2), false, emptyList())
+                    createSafeInfo(TEST_SAFE, Wei.ZERO, 2, listOfNotNull(TEST_OWNER, extension, TEST_RECOVER_1, TEST_RECOVER_2), false, emptyList())
                 )
             )
         given(bip39Mock.validateMnemonic(MockUtils.any())).willReturn("some new mnemonic!")
@@ -379,7 +379,7 @@ class DefaultRecoverSafeOwnersHelperTest {
             .willReturn(Single.just(TEST_RECOVER_1 to TEST_RECOVER_1_KEY))
         given(accountsRepoMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L)))
             .willReturn(Single.just(TEST_RECOVER_2 to TEST_RECOVER_2_KEY))
-        given(accountsRepoMock.loadActiveAccount()).willReturn(Single.just(Account(TEST_APP)))
+        given(safeRepoMock.createOwner()).willReturn(Single.just(TEST_OWNER to TEST_OWNER_KEY))
 
         val observer = TestObserver<InputRecoveryPhraseContract.ViewUpdate>()
         helper.process(input, TEST_SAFE, extension).subscribe(observer)
@@ -392,8 +392,8 @@ class DefaultRecoverSafeOwnersHelperTest {
         then(bip39Mock).shouldHaveNoMoreInteractions()
         then(accountsRepoMock).should().accountFromMnemonicSeed(TEST_SEED, 0L)
         then(accountsRepoMock).should().accountFromMnemonicSeed(TEST_SEED, 1L)
-        then(accountsRepoMock).should().loadActiveAccount()
         then(accountsRepoMock).shouldHaveNoMoreInteractions()
+        then(safeRepoMock).should().createOwner()
         then(safeRepoMock).should().loadInfo(TEST_SAFE)
         then(safeRepoMock).shouldHaveNoMoreInteractions()
         then(executionRepoMock).shouldHaveZeroInteractions()
@@ -411,9 +411,10 @@ class DefaultRecoverSafeOwnersHelperTest {
     }
 
     private fun testRecoverPayload(
-        app: Solidity.Address, extension: Solidity.Address?, recoverer: Solidity.Address,
+        ownerAddress: Solidity.Address, ownerKey: ByteArray,
+        extension: Solidity.Address?, recoverer: Solidity.Address,
         operation: TransactionExecutionRepository.Operation, data: String,
-        owners: List<Solidity.Address> = listOf(TEST_APP, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2)
+        owners: List<Solidity.Address> = listOf(TEST_OWNER, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2)
     ) {
         val phraseSubject = PublishSubject.create<CharSequence>()
         val retrySubject = PublishSubject.create<Unit>()
@@ -433,7 +434,7 @@ class DefaultRecoverSafeOwnersHelperTest {
             .willReturn(Single.just(TEST_RECOVER_1 to TEST_RECOVER_1_KEY))
         given(accountsRepoMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L)))
             .willReturn(Single.just(TEST_RECOVER_2 to TEST_RECOVER_2_KEY))
-        given(accountsRepoMock.loadActiveAccount()).willReturn(Single.just(Account(app)))
+        given(safeRepoMock.createOwner()).willReturn(Single.just(ownerAddress to ownerKey))
         given(executionRepoMock.loadExecuteInformation(MockUtils.any(), MockUtils.any(), MockUtils.any()))
             .willAnswer {
                 val tx = it.arguments[2] as SafeTransaction
@@ -474,8 +475,8 @@ class DefaultRecoverSafeOwnersHelperTest {
         then(bip39Mock).shouldHaveNoMoreInteractions()
         then(accountsRepoMock).should().accountFromMnemonicSeed(TEST_SEED, 0L)
         then(accountsRepoMock).should().accountFromMnemonicSeed(TEST_SEED, 1L)
-        then(accountsRepoMock).should().loadActiveAccount()
         then(accountsRepoMock).shouldHaveNoMoreInteractions()
+        then(safeRepoMock).should().createOwner()
         then(safeRepoMock).should().loadInfo(TEST_SAFE)
         then(safeRepoMock).shouldHaveNoMoreInteractions()
         then(executionRepoMock).should().loadExecuteInformation(MockUtils.any(), MockUtils.any(), MockUtils.any())
@@ -490,7 +491,8 @@ class DefaultRecoverSafeOwnersHelperTest {
     @Test
     fun processReplaceApp() {
         testRecoverPayload(
-            TEST_NEW_APP,
+            TEST_NEW_OWNER,
+            TEST_NEW_OWNER_KEY,
             TEST_EXTENSION,
             TEST_SAFE,
             TransactionExecutionRepository.Operation.CALL,
@@ -501,19 +503,21 @@ class DefaultRecoverSafeOwnersHelperTest {
     @Test
     fun processReplaceAppWithoutExtension() {
         testRecoverPayload(
-            TEST_NEW_APP,
+            TEST_NEW_OWNER,
+            TEST_NEW_OWNER_KEY,
             null,
             TEST_SAFE,
             TransactionExecutionRepository.Operation.CALL,
             "0xe318b52b000000000000000000000000000000000000000000000000000000000000000100000000000000000000000071de9579cd3857ce70058a1ce19e3d8894f65ab900000000000000000000000031b98d14007bdee637298086988a0bbd31184523",
-            listOf(TEST_APP, TEST_RECOVER_1, TEST_RECOVER_2)
+            listOf(TEST_OWNER, TEST_RECOVER_1, TEST_RECOVER_2)
         )
     }
 
     @Test
     fun processReplaceExtension() {
         testRecoverPayload(
-            TEST_APP,
+            TEST_OWNER,
+            TEST_OWNER_KEY,
             TEST_NEW_EXTENSION,
             TEST_SAFE,
             TransactionExecutionRepository.Operation.CALL,
@@ -524,7 +528,8 @@ class DefaultRecoverSafeOwnersHelperTest {
     @Test
     fun processReplaceAppAndExtension() {
         testRecoverPayload(
-            TEST_NEW_APP,
+            TEST_NEW_OWNER,
+            TEST_NEW_OWNER_KEY,
             TEST_NEW_EXTENSION,
             "0xe74d6af1670fb6560dd61ee29eb57c7bc027ce4e".asEthereumAddress()!!, // MultiSend address
             TransactionExecutionRepository.Operation.DELEGATE_CALL,
@@ -561,7 +566,7 @@ class DefaultRecoverSafeOwnersHelperTest {
         given(safeRepoMock.loadInfo(MockUtils.any()))
             .willReturn(
                 Observable.just(
-                    createSafeInfo(TEST_SAFE, Wei.ZERO, 2, listOf(TEST_APP, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2), false, emptyList())
+                    createSafeInfo(TEST_SAFE, Wei.ZERO, 2, listOf(TEST_OWNER, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2), false, emptyList())
                 )
             )
         given(bip39Mock.validateMnemonic(MockUtils.any())).willReturn("some new mnemonic!")
@@ -570,7 +575,7 @@ class DefaultRecoverSafeOwnersHelperTest {
             .willReturn(Single.just(TEST_RECOVER_1 to TEST_RECOVER_1_KEY))
         given(accountsRepoMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L)))
             .willReturn(Single.just(TEST_RECOVER_2 to TEST_RECOVER_2_KEY))
-        given(accountsRepoMock.loadActiveAccount()).willReturn(Single.just(Account(TEST_NEW_APP)))
+        given(safeRepoMock.createOwner()).willReturn(Single.just(TEST_NEW_OWNER to TEST_NEW_OWNER_KEY))
         val error = NotImplementedError()
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.error(error))
 
@@ -590,8 +595,8 @@ class DefaultRecoverSafeOwnersHelperTest {
         then(bip39Mock).shouldHaveNoMoreInteractions()
         then(accountsRepoMock).should().accountFromMnemonicSeed(TEST_SEED, 0L)
         then(accountsRepoMock).should().accountFromMnemonicSeed(TEST_SEED, 1L)
-        then(accountsRepoMock).should().loadActiveAccount()
         then(accountsRepoMock).shouldHaveNoMoreInteractions()
+        then(safeRepoMock).should().createOwner()
         then(safeRepoMock).should().loadInfo(TEST_SAFE)
         then(safeRepoMock).shouldHaveNoMoreInteractions()
         then(executionRepoMock).shouldHaveZeroInteractions()
@@ -610,7 +615,7 @@ class DefaultRecoverSafeOwnersHelperTest {
         given(safeRepoMock.loadInfo(MockUtils.any()))
             .willReturn(
                 Observable.just(
-                    createSafeInfo(TEST_SAFE, Wei.ZERO, 2, listOf(TEST_APP, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2), false, emptyList())
+                    createSafeInfo(TEST_SAFE, Wei.ZERO, 2, listOf(TEST_OWNER, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2), false, emptyList())
                 )
             )
         given(bip39Mock.validateMnemonic(MockUtils.any())).willReturn("some new mnemonic!")
@@ -619,7 +624,7 @@ class DefaultRecoverSafeOwnersHelperTest {
             .willReturn(Single.just(TEST_RECOVER_1 to TEST_RECOVER_1_KEY))
         given(accountsRepoMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L)))
             .willReturn(Single.just(TEST_RECOVER_2 to TEST_RECOVER_2_KEY))
-        given(accountsRepoMock.loadActiveAccount()).willReturn(Single.just(Account(TEST_NEW_APP)))
+        given(safeRepoMock.createOwner()).willReturn(Single.just(TEST_NEW_OWNER to TEST_NEW_OWNER_KEY))
         given(tokenRepositoryMock.loadPaymentToken()).willReturn(Single.just(ERC20Token.ETHER_TOKEN))
         given(executionRepoMock.loadExecuteInformation(MockUtils.any(), MockUtils.any(), MockUtils.any())).willReturn(
             Single.error(
@@ -643,8 +648,8 @@ class DefaultRecoverSafeOwnersHelperTest {
         then(bip39Mock).shouldHaveNoMoreInteractions()
         then(accountsRepoMock).should().accountFromMnemonicSeed(TEST_SEED, 0L)
         then(accountsRepoMock).should().accountFromMnemonicSeed(TEST_SEED, 1L)
-        then(accountsRepoMock).should().loadActiveAccount()
         then(accountsRepoMock).shouldHaveNoMoreInteractions()
+        then(safeRepoMock).should().createOwner()
         then(safeRepoMock).should().loadInfo(TEST_SAFE)
         then(safeRepoMock).shouldHaveNoMoreInteractions()
         then(executionRepoMock).should().loadExecuteInformation(MockUtils.any(), MockUtils.any(), MockUtils.any())
@@ -663,7 +668,7 @@ class DefaultRecoverSafeOwnersHelperTest {
         given(safeRepoMock.loadInfo(MockUtils.any()))
             .willReturn(
                 Observable.just(
-                    createSafeInfo(TEST_SAFE, Wei.ZERO, 2, listOf(TEST_APP, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2), false, emptyList())
+                    createSafeInfo(TEST_SAFE, Wei.ZERO, 2, listOf(TEST_OWNER, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2), false, emptyList())
                 )
             )
         given(bip39Mock.validateMnemonic(MockUtils.any())).willReturn("some new mnemonic!")
@@ -672,7 +677,7 @@ class DefaultRecoverSafeOwnersHelperTest {
             .willReturn(Single.just(TEST_RECOVER_1 to TEST_RECOVER_1_KEY))
         given(accountsRepoMock.accountFromMnemonicSeed(MockUtils.any(), eq(1L)))
             .willReturn(Single.just(TEST_RECOVER_2 to TEST_RECOVER_2_KEY))
-        given(accountsRepoMock.loadActiveAccount()).willReturn(Single.just(Account(TEST_NEW_APP)))
+        given(safeRepoMock.createOwner()).willReturn(Single.just(TEST_NEW_OWNER to TEST_NEW_OWNER_KEY))
         val execInfo = TransactionExecutionRepository.ExecuteInformation(
             TEST_HASH.toHex(),
             SafeTransaction(Transaction(TEST_SAFE), TransactionExecutionRepository.Operation.CALL),
@@ -707,8 +712,8 @@ class DefaultRecoverSafeOwnersHelperTest {
         then(bip39Mock).shouldHaveNoMoreInteractions()
         then(accountsRepoMock).should().accountFromMnemonicSeed(TEST_SEED, 0L)
         then(accountsRepoMock).should().accountFromMnemonicSeed(TEST_SEED, 1L)
-        then(accountsRepoMock).should().loadActiveAccount()
         then(accountsRepoMock).shouldHaveNoMoreInteractions()
+        then(safeRepoMock).should().createOwner()
         then(safeRepoMock).should().loadInfo(TEST_SAFE)
         then(safeRepoMock).shouldHaveNoMoreInteractions()
         then(executionRepoMock).should().loadExecuteInformation(MockUtils.any(), MockUtils.any(), MockUtils.any())
@@ -916,14 +921,19 @@ class DefaultRecoverSafeOwnersHelperTest {
         private val TEST_HASH = Sha3Utils.keccak(TEST_SEED)
         private val TEST_GAS_TOKEN = ERC20Token.ETHER_TOKEN.address
         private val TEST_SAFE = "0x1f81FFF89Bd57811983a35650296681f99C65C7E".asEthereumAddress()!!
-        private val TEST_APP = "0x71De9579cD3857ce70058a1ce19e3d8894f65Ab9".asEthereumAddress()!!
-        private val TEST_NEW_APP = "0x31B98D14007bDEe637298086988A0bBd31184523".asEthereumAddress()!!
+        private val TEST_OWNER = "0x71De9579cD3857ce70058a1ce19e3d8894f65Ab9".asEthereumAddress()!!
+        private val TEST_OWNER_KEY = byteArrayOf(0)
+        private val TEST_NEW_OWNER = "0x31B98D14007bDEe637298086988A0bBd31184523".asEthereumAddress()!!
+        private val TEST_NEW_OWNER_KEY = byteArrayOf(1)
+        //private val TEST_APP = "0x71De9579cD3857ce70058a1ce19e3d8894f65Ab9".asEthereumAddress()!!
+        //private val TEST_NEW_APP = "0x31B98D14007bDEe637298086988A0bBd31184523".asEthereumAddress()!!
         private val TEST_EXTENSION = "0xC2AC20b3Bb950C087f18a458DB68271325a48132".asEthereumAddress()!!
         private val TEST_NEW_EXTENSION = "0x1e6534e09b2B0Dc5EA965D0cE84AB07A4bd56B38".asEthereumAddress()!!
         private val TEST_RECOVER_1 = "0x979861dF79C7408553aAF20c01Cfb3f81CCf9341".asEthereumAddress()!!
         private val TEST_RECOVER_2 = "0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66".asEthereumAddress()!!
         private val TEST_RECOVER_1_KEY = Sha3Utils.keccak(TEST_RECOVER_1.value.toByteArray())
         private val TEST_RECOVER_2_KEY = Sha3Utils.keccak(TEST_RECOVER_2.value.toByteArray())
-        private val TEST_OWNERS = listOf(TEST_APP, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2)
+        //private val TEST_OWNERS = listOf(TEST_APP, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2)
+        private val TEST_OWNERS = listOf(TEST_OWNER, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2)
     }
 }

--- a/app/src/test/java/pm/gnosis/heimdall/ui/safe/helpers/DefaultRecoverSafeOwnersHelperTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/safe/helpers/DefaultRecoverSafeOwnersHelperTest.kt
@@ -34,7 +34,6 @@ import pm.gnosis.mnemonic.EmptyMnemonic
 import pm.gnosis.model.Solidity
 import pm.gnosis.models.Transaction
 import pm.gnosis.models.Wei
-import pm.gnosis.svalinn.accounts.base.models.Account
 import pm.gnosis.svalinn.accounts.base.repositories.AccountsRepository
 import pm.gnosis.tests.utils.Asserts
 import pm.gnosis.tests.utils.ImmediateSchedulersRule
@@ -925,15 +924,12 @@ class DefaultRecoverSafeOwnersHelperTest {
         private val TEST_OWNER_KEY = byteArrayOf(0)
         private val TEST_NEW_OWNER = "0x31B98D14007bDEe637298086988A0bBd31184523".asEthereumAddress()!!
         private val TEST_NEW_OWNER_KEY = byteArrayOf(1)
-        //private val TEST_APP = "0x71De9579cD3857ce70058a1ce19e3d8894f65Ab9".asEthereumAddress()!!
-        //private val TEST_NEW_APP = "0x31B98D14007bDEe637298086988A0bBd31184523".asEthereumAddress()!!
         private val TEST_EXTENSION = "0xC2AC20b3Bb950C087f18a458DB68271325a48132".asEthereumAddress()!!
         private val TEST_NEW_EXTENSION = "0x1e6534e09b2B0Dc5EA965D0cE84AB07A4bd56B38".asEthereumAddress()!!
         private val TEST_RECOVER_1 = "0x979861dF79C7408553aAF20c01Cfb3f81CCf9341".asEthereumAddress()!!
         private val TEST_RECOVER_2 = "0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66".asEthereumAddress()!!
         private val TEST_RECOVER_1_KEY = Sha3Utils.keccak(TEST_RECOVER_1.value.toByteArray())
         private val TEST_RECOVER_2_KEY = Sha3Utils.keccak(TEST_RECOVER_2.value.toByteArray())
-        //private val TEST_OWNERS = listOf(TEST_APP, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2)
         private val TEST_OWNERS = listOf(TEST_OWNER, TEST_EXTENSION, TEST_RECOVER_1, TEST_RECOVER_2)
     }
 }


### PR DESCRIPTION
Closes #369: Use separate owners for safes

Changes proposed in this pull request:
- Create separate owner for each safe instead of using device account
- Sign transaction using safes owner
- If no owner present (old safe) sign using device account

@gnosis/mobile-devs
