### PR TITLE
Enable RxAndroid's new async api (#225)

### DIFF
--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -36,7 +36,7 @@ ext {
             picasso                   : '2.71828',
             play_services_auth        : '16.0.1',
             retrofit                  : '2.4.0',
-            rxandroid                 : '2.1.0',
+            rxandroid                 : '2.1.1',
             rxbinding                 : '2.1.1',
             rxjava                    : '2.2.1',
             rxkotlin                  : '2.3.0',


### PR DESCRIPTION
Closes #225: Enable RxAndroid's new async api

Changes proposed in this pull request:
- enable async api
- see https://app.zenhub.com/workspaces/gnosis-safe-5c1b98250e13551e8aae81eb/issues/gnosis/safe-android/225 for profiling info

@gnosis/mobile-devs
