### PR TITLE
Fix crashlytics upload script

### DIFF
--- a/ci/upload_crashlytic_versions.sh
+++ b/ci/upload_crashlytic_versions.sh
@@ -5,5 +5,5 @@ set -e
 if [[ $TRAVIS_BRANCH == 'master' ]]
 then
     ./gradlew assembleInternal assembleRinkeby assembleRelease
-    ./gradlew crashlyticsUploadDistributionInternal crashlyticsUploadDistributionRinkeby crashlyticsUploadDistributionInternal
+    ./gradlew crashlyticsUploadDistributionInternal crashlyticsUploadDistributionRinkeby crashlyticsUploadDistributionRelease
 fi


### PR DESCRIPTION
In some refactoring a copy paste error happened and the release version is not uploaded to crashlytics anymore. This PR fixes that