### PR TITLE
Closes #500: Release 1.9.0 issues

### DIFF
--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/main/SafeMainActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/main/SafeMainActivity.kt
@@ -383,7 +383,7 @@ class SafeMainActivity : ViewModelActivity<SafeMainContract>() {
                             SetupNewRecoveryPhraseIntroActivity.createIntent(this, safeAddress = safe.address())
                         )
                     }
-                    R.id.safe_details_menu_replace_browser_extension -> selectedSafe?.let { safe ->
+                    R.id.safe_details_menu_replace_2fa -> selectedSafe?.let { safe ->
                         startActivity(Replace2FaStartActivity.createIntent(this, safe.address()))
                     }
                     R.id.safe_details_menu_show_on_etherscan -> selectedSafe?.let { safe ->
@@ -407,7 +407,7 @@ class SafeMainActivity : ViewModelActivity<SafeMainContract>() {
 
     private fun hideMenuOptions() {
         popupMenu.menu.findItem(R.id.safe_details_menu_sync).isVisible = false
-        popupMenu.menu.findItem(R.id.safe_details_menu_replace_browser_extension).isVisible = false
+        popupMenu.menu.findItem(R.id.safe_details_menu_replace_2fa).isVisible = false
         popupMenu.menu.findItem(R.id.safe_details_menu_connect).isVisible = false
         popupMenu.menu.findItem(R.id.safe_details_menu_remove_2fa).isVisible = false
     }
@@ -428,7 +428,7 @@ class SafeMainActivity : ViewModelActivity<SafeMainContract>() {
             }
         }
         popupMenu.menu.findItem(R.id.safe_details_menu_sync).isVisible = isConnected && selectedSafe is Safe
-        popupMenu.menu.findItem(R.id.safe_details_menu_replace_browser_extension).isVisible = isConnected && selectedSafe is Safe
+        popupMenu.menu.findItem(R.id.safe_details_menu_replace_2fa).isVisible = isConnected && selectedSafe is Safe
         popupMenu.menu.findItem(R.id.safe_details_menu_connect).isVisible = !isConnected && selectedSafe is Safe
         popupMenu.menu.findItem(R.id.safe_details_menu_remove_2fa).isVisible = isConnected && selectedSafe is Safe
     }

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/pairing/PairingStartActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/pairing/PairingStartActivity.kt
@@ -131,8 +131,8 @@ abstract class PairingStartActivity : ViewModelActivity<PairingStartContract>() 
     }
 
     private fun startEstimation() {
-        viewModel.estimate()
         onLoading(true)
+        viewModel.estimate()
     }
 
     private fun onLoading(isLoading: Boolean) {
@@ -140,6 +140,7 @@ abstract class PairingStartActivity : ViewModelActivity<PairingStartContract>() 
         progressBar.visible(isLoading)
         swipeToRefresh.isRefreshing = false
         swipeToRefresh.isActivated = !isLoading
+        swipeToRefresh.isEnabled = !isLoading
     }
 
     companion object {

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/recover/recoveryphrase/SetupNewRecoveryPhraseIntroActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/recover/recoveryphrase/SetupNewRecoveryPhraseIntroActivity.kt
@@ -21,6 +21,7 @@ import pm.gnosis.heimdall.ui.base.handleViewAction
 import pm.gnosis.heimdall.ui.recoveryphrase.RecoveryPhraseIntroActivity
 import pm.gnosis.heimdall.utils.AuthenticatorInfo
 import pm.gnosis.model.Solidity
+import pm.gnosis.svalinn.common.utils.visible
 import pm.gnosis.utils.asEthereumAddress
 import pm.gnosis.utils.asEthereumAddressString
 import pm.gnosis.utils.nullOnThrow
@@ -109,6 +110,7 @@ class SetupNewRecoveryPhraseIntroActivity : RecoveryPhraseIntroActivity() {
         val safe = nullOnThrow { intent.getStringExtra(EXTRA_SAFE_ADDRESS)?.let { it.asEthereumAddress()!! } }
             ?: run { finish(); return }
         viewModel.setup(safe)
+        layout_recovery_phrase_intro_step_indicator.visible(false)
         layout_recovery_phrase_intro_next.isEnabled = false
         viewModel.state.observe(this, Observer {
             layout_recovery_phrase_intro_next.isEnabled = !it.loading

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/recover/safe/RecoverSafe2FAActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/recover/safe/RecoverSafe2FAActivity.kt
@@ -13,18 +13,18 @@ import pm.gnosis.utils.asEthereumAddressString
 class RecoverSafe2FAActivity : Select2FaActivity() {
 
     override fun onAuthenticatorSetupInfo(info: AuthenticatorSetupInfo) {
-        val safeAddress = intent.getStringExtra(EXTRA_SAFE)!!.asEthereumAddress()!!
+        val safeAddress = intent.getStringExtra(EXTRA_RECOVERING_SAFE)!!.asEthereumAddress()!!
         startActivity(RecoverSafeRecoveryPhraseActivity.createIntent(this, safeAddress, info))
     }
 
     companion object {
-        private const val EXTRA_SAFE = "extra.string.safe"
+        private const val EXTRA_RECOVERING_SAFE = "extra.string.recovering_safe"
 
         fun createIntent(context: Context, recoveringSafe: Solidity.Address) =
             Intent(context, RecoverSafe2FAActivity::class.java)
                 .addSelectAuthenticatorExtras(null)
                 .apply {
-                    putExtra(EXTRA_SAFE, recoveringSafe.asEthereumAddressString())
+                    putExtra(EXTRA_RECOVERING_SAFE, recoveringSafe.asEthereumAddressString())
                 }
     }
 }

--- a/app/src/main/java/pm/gnosis/heimdall/ui/two_factor/authenticator/PairingAuthenticatorActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/two_factor/authenticator/PairingAuthenticatorActivity.kt
@@ -195,6 +195,7 @@ class PairingAuthenticatorViewModel @Inject constructor(
                         PairingResult.PairingError(e)
                     )
                 )
+                Timber.e(e)
             }
         }
     }

--- a/app/src/main/res/layout/layout_recovery_phrase_intro.xml
+++ b/app/src/main/res/layout/layout_recovery_phrase_intro.xml
@@ -23,6 +23,7 @@
             android:orientation="vertical">
 
             <pm.gnosis.heimdall.views.StepIndicator
+                android:id="@+id/layout_recovery_phrase_intro_step_indicator"
                 android:layout_marginTop="16dp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">

--- a/app/src/main/res/layout/screen_pairing_review.xml
+++ b/app/src/main/res/layout/screen_pairing_review.xml
@@ -125,7 +125,7 @@
                         tools:text="0x9bebe3b9e7a461e35775ec935336891edf856da2" />
 
                     <androidx.constraintlayout.widget.Barrier
-                        android:id="@+id/layout_replace_recovery_phrase_transaction_top_barrier"
+                        android:id="@+id/review_transaction_top_barrier"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         app:barrierDirection="top"
@@ -167,7 +167,7 @@
                         android:textSize="13sp"
                         app:layout_constraintBottom_toBottomOf="@+id/review_transaction_divider"
                         app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toEndOf="@+id/layout_replace_recovery_phrase_transaction_divider"
+                        app:layout_constraintStart_toEndOf="@+id/review_transaction_divider"
                         app:layout_constraintTop_toTopOf="@+id/review_transaction_divider" />
 
                     <androidx.constraintlayout.widget.Barrier

--- a/app/src/main/res/menu/safe_details_menu.xml
+++ b/app/src/main/res/menu/safe_details_menu.xml
@@ -26,8 +26,8 @@
         android:visible="false"
         app:showAsAction="never" />
     <item
-        android:id="@+id/safe_details_menu_replace_browser_extension"
-        android:title="@string/replace_browser_extension"
+        android:id="@+id/safe_details_menu_replace_2fa"
+        android:title="@string/replace_2fa"
         android:visible="false"
         app:showAsAction="never" />
     <item


### PR DESCRIPTION
Closes #500.

Changes proposed in this pull request:
### Required fixes
- [x] https://github.com/gnosis/safe-android/pull/441/files#diff-d06cf5891222f9839c83764fa08e202aL21 (related to QA bug)
- [x] stepper shown when setting new recovery phrase
- [x] wording: Replace Authenticator vs Disable 2FA
- [x] Errors are not logged with timber
### Nice to have fixes
- [x] view ids in screen_pairing_review inconsistent
- [x] pull to refresh not immediately disabled on refresh

@gnosis/mobile-devs
