### PR TITLE
Closes #479: Correct typo

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,7 +78,7 @@
     <string name="next">Next</string>
     <string name="confirm_password">Confirm Password</string>
     <string name="confirm_password_hint">Confirm password</string>
-    <string name="choose_password_hint">Choose passwrod</string>
+    <string name="choose_password_hint">Choose password</string>
     <string name="confirm_password_info">Please enter your password again to confirm.</string>
     <string name="onboarding_intro_info">The most secure way to manage your crypto funds</string>
     <string name="create_password">Create Password</string>


### PR DESCRIPTION
Closes #479.

Changes proposed in this pull request:
- Fix misspelled "create password" hint 

@gnosis/mobile-devs
