### PR TITLE
Closes #332: Add specific exception in case of transaction failure during recovery

### DIFF
--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/recover/safe/submit/RecoveringSafeContract.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/recover/safe/submit/RecoveringSafeContract.kt
@@ -34,4 +34,6 @@ abstract class RecoveringSafeContract : ViewModel() {
     data class RecoveryInfo(val safeAddress: String, val paymentToken: ERC20TokenWithBalance?, val paymentAmount: BigInteger, val qrCode: Bitmap?)
     data class RecoveryExecuteInfo(val balance: BigInteger, val paymentAmount: BigInteger, val paymentToken: ERC20Token, val canSubmit: Boolean)
 
+    class TransactionExecutionException(message: String? = null) : IllegalStateException(message)
+
 }

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/recover/safe/submit/RecoveringSafeViewModel.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/recover/safe/submit/RecoveringSafeViewModel.kt
@@ -69,7 +69,7 @@ class RecoveringSafeViewModel @Inject constructor(
                         .flatMap { (success) ->
                             if (success)
                                 safeRepository.recoveringSafeToDeployedSafe(safe).andThen(Single.just(safe.address))
-                            else throw IllegalStateException() // TODO: proper error here
+                            else throw TransactionExecutionException("transaction execution failed")
                         }
                 } ?: throw IllegalStateException()
             }


### PR DESCRIPTION
Closes #332 .

Currently we react and display following errors during mnemonic input
- SafeInfoError
- InvalidMnemonic => invalid recovery phrase
- WrongMnemonic => wrong recovery phrase for safe
- RecoverDataError
- NoRecoveryNecessary

Safe address is being checked on the address input screen which comes at the begining of the flow. Thus errors like wrong safe address or address that cannot be found on network will be filtered during this step.

Hence user should be properly informed about most of the errors.

Changes proposed in this pull request:
- Add specific exception in case transaction fails during recovery


@gnosis/mobile-devs
