### PR TITLE
Update compileSdk & targetSdk versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ before_install:
   - mkdir "$ANDROID_HOME/licenses" || true
   - echo "8933bad161af4178b1185d1a37fbf41ea5269c55" >> "$ANDROID_HOME/licenses/android-sdk-license"
   - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" >> "$ANDROID_HOME/licenses/android-sdk-license"
+  - echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" >> "$ANDROID_HOME/licenses/android-sdk-license"
 
 script:
   - . ./ci/prepare_env_travis.sh

--- a/build.gradle
+++ b/build.gradle
@@ -32,12 +32,11 @@ subprojects {
     afterEvaluate { project ->
         if (project.hasProperty("android")) {
             android {
-                compileSdkVersion 28
-                buildToolsVersion "28.0.3"
+                compileSdkVersion 29
 
                 defaultConfig {
                     minSdkVersion 19
-                    targetSdkVersion 28
+                    targetSdkVersion 29
                 }
                 lintOptions {
                     abortOnError false


### PR DESCRIPTION
Closes #475: Cannot create safe with keycard on MotoG.

Changes proposed in this pull request:
- Update compileSdk & targetSdk versions

@gnosis/mobile-devs
