### PR TITLE
Use tag name from buildkite env variable for app version name

### DIFF
--- a/ci/upload_crashlytics_versions.sh
+++ b/ci/upload_crashlytics_versions.sh
@@ -5,6 +5,8 @@ set -e
 # Buildkite uses a clean state for each step (for concurrency)
 ./ci/prepare_env_buildkite.sh
 
+# Buildkite branch equals to tag name if build was triggered by tag
+export APP_VERSION_NAME=$BUILDKITE_BRANCH
 
 echo "apiSecret=$FABRIC_API_SECRET" > app/fabric.properties
 echo "apiKey=$FABRIC_API_KEY" >> app/fabric.properties

--- a/ci/upload_crashlytics_versions.sh
+++ b/ci/upload_crashlytics_versions.sh
@@ -6,7 +6,7 @@ set -e
 ./ci/prepare_env_buildkite.sh
 
 # Buildkite branch equals to tag name if build was triggered by tag
-export APP_VERSION_NAME=$BUILDKITE_BRANCH
+export APP_VERSION_NAME=${BUILDKITE_BRANCH:1}
 
 echo "apiSecret=$FABRIC_API_SECRET" > app/fabric.properties
 echo "apiKey=$FABRIC_API_KEY" >> app/fabric.properties

--- a/ci/upload_to_github.sh
+++ b/ci/upload_to_github.sh
@@ -7,7 +7,7 @@ set -e
 source ./ci/prepare_env_buildkite.sh
 
 # Buildkite branch equals to tag name if build was triggered by tag
-export APP_VERSION_NAME=$BUILDKITE_BRANCH
+export APP_VERSION_NAME=${BUILDKITE_BRANCH:1}
 
 echo "apiSecret=$FABRIC_API_SECRET" > app/fabric.properties
 echo "apiKey=$FABRIC_API_KEY" >> app/fabric.properties

--- a/ci/upload_to_github.sh
+++ b/ci/upload_to_github.sh
@@ -6,6 +6,9 @@ set -e
 # Buildkite uses a clean state for each step (for concurrency)
 source ./ci/prepare_env_buildkite.sh
 
+# Buildkite branch equals to tag name if build was triggered by tag
+export APP_VERSION_NAME=$BUILDKITE_BRANCH
+
 echo "apiSecret=$FABRIC_API_SECRET" > app/fabric.properties
 echo "apiKey=$FABRIC_API_KEY" >> app/fabric.properties
 


### PR DESCRIPTION

Changes proposed in this pull request:
- workaround for setting APP_VERSION when build triggered from tag
- git describe --tags --always not seeing the recent tag

@gnosis/mobile-devs
