### PR TITLE
Use tag for app version name only for tagged builds when uploading to…

### DIFF
--- a/ci/upload_crashlytics_versions.sh
+++ b/ci/upload_crashlytics_versions.sh
@@ -6,7 +6,10 @@ set -e
 ./ci/prepare_env_buildkite.sh
 
 # Buildkite branch equals to tag name if build was triggered by tag
-export APP_VERSION_NAME=${BUILDKITE_BRANCH:1}
+if [[ $BUILKITE_BRANCH != 'master' ]]
+then
+    export APP_VERSION_NAME=${BUILDKITE_BRANCH:1}
+fi
 
 echo "apiSecret=$FABRIC_API_SECRET" > app/fabric.properties
 echo "apiKey=$FABRIC_API_KEY" >> app/fabric.properties


### PR DESCRIPTION

Changes proposed in this pull request:
- Adjust app version name for crashlytics uploads

@gnosis/mobile-devs
