### PR TITLE
Closes #583 internal build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Replace `<YOUR_PROJECT_ID>` with the `project id` that you get from Infura. You 
 ### Firebase
 The Gnosis Safe Android App uses Firebase and your build will fail if you don't have the `google-services.json` file.
 To get this file, you need to create a Firebase project at <https://console.firebase.google.com/> and add at least one Android application.
-If you didn't change the applicationId in `app/build.gradle` you need to create an app with the Package name `io.gnosis.safe.debug` to be able  
-to build a debug app. You can find the latest `google-services.json` file in the `Project Settings` -> `General`
+If you didn't change the applicationId in `app/build.gradle` you need to create an app with the Package name `io.gnosis.safe.debug` to be able to build a debug app. You can find the latest `google-services.json` file in the `Project Settings` -> `General`
 
 After downloading the file, copy it to the `app` module folder.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Replace `<YOUR_PROJECT_ID>` with the `project id` that you get from Infura. You 
 The Gnosis Safe Android App uses Firebase and your build will fail if you don't have the `google-services.json` file.
 To get this file, you need to create a Firebase project at <https://console.firebase.google.com/> and add at least one Android application.
 If you didn't change the applicationId in `app/build.gradle` you need to create an app with the Package name `io.gnosis.safe.debug` to be able  
-to build a debug app. You can find the latest config file `google-services.json` in the `Project Settings` -> `General`
+to build a debug app. You can find the latest `google-services.json` file in the `Project Settings` -> `General`
 
 After downloading the file, copy it to the `app` module folder.
 

--- a/README.md
+++ b/README.md
@@ -10,17 +10,18 @@ Transactions are secured by on-chain multi-factor-authentication. This is achiev
 ### Infura
 The Json RPC depends on [Infura](https://infura.io/). You need to get an API key and create a file named `project_keys` with the following contents:
 ```
-INFURA_API_KEY=<YOUR_API_KEY>
+INFURA_API_KEY=<YOUR_PROJECT_ID>
 ```
 
-Replace `<YOUR_API_KEY>` with the key that you get from Infura.
+Replace `<YOUR_PROJECT_ID>` with the `project id` that you get from Infura. You can find this `project id` at `Projects -> Settings -> Keys -> PROJECT ID` on the Infura Website.
 
 ### Firebase
 The Gnosis Safe Android App uses Firebase and your build will fail if you don't have the `google-services.json` file.
+To get this file, you need to create a Firebase project at <https://console.firebase.google.com/> and add at least one Android application.
+If you didn't change the applicationId in `app/build.gradle` you need to create an app with the Package name `io.gnosis.safe.debug` to be able  
+to build a debug app. You can find the latest config file `google-services.json` in the `Project Settings` -> `General`
 
-This file can be found in the Settings page of the Firebase project.
-
-After getting access to the file, move it to the `app` module.
+After downloading the file, copy it to the `app` module folder.
 
 ### Contribute
 You can contribute to this repo by creating a Pull Request or an issue. Please follow the default template set for the Pull Requests.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Replace `<YOUR_PROJECT_ID>` with the `project id` that you get from Infura. You 
 ### Firebase
 The Gnosis Safe Android App uses Firebase and your build will fail if you don't have the `google-services.json` file.
 To get this file, you need to create a Firebase project at <https://console.firebase.google.com/> and add at least one Android application.
-If you didn't change the applicationId in `app/build.gradle` you need to create an app with the Package name `io.gnosis.safe.debug` to be able to build a debug app. You can find the latest `google-services.json` file in the `Project Settings` -> `General`
+If you didn't change the applicationId in `app/build.gradle` you need to create an app with the package name `io.gnosis.safe.debug` to be able to build a debug app. You can find the latest `google-services.json` file in the `Project Settings` -> `General`
 
 After downloading the file, copy it to the `app` module folder.
 

--- a/docs/INTERNAL_BUILD.md
+++ b/docs/INTERNAL_BUILD.md
@@ -12,7 +12,7 @@ For a custom build, please have a look at the [README.md#Firebase](../README.md#
 ### Infura API Key
 
 We need an Infura API key for the JSON RPC calls. Please create a free (of charge) account with Infura at: <https://infura.io/>. Then create a project. Find the `project id` in the Project settings -> Keys.
-You need to get an API key and create a file named `project_keys` in the project folder with the following content:
+You need to get an API key and create a file named `project_keys` in the project root folder with the following content:
 
 ```
 INFURA_API_KEY=<YOUR_PROJECT_ID>
@@ -25,7 +25,7 @@ Replace `<YOUR_PROJECT_ID>` with the `project id` that you got from Infura.
 
 ## Buildkite (Continuous Integration) Setup
 
-We use a self hosted Buildkite agent. Given you have the appropriate credentials you can see its Android projects here: https://buildkite.com/gnosis
+We use a self hosted Buildkite agent. Given that you have the appropriate credentials you can see the Android projects here: https://buildkite.com/gnosis
 The Buildkite instance is also responsible for app signing and distribution. The `internal` app is distributed to Firebase.
 
 ## buildkite configuration within the project
@@ -34,9 +34,9 @@ The directory `.buildkite` contains two yml files recognized by the ci server:
 - `deployment.yml`
   - Contains a label to upload to Firebase App distribution via `ci/upload_app_distribution.sh` on merges to master
 - `pipeline.yml`
-  - Contains a label to run certain scripts in the `ci` folder for unit and ui tests
+  - Contains a label to run certain scripts in the `ci` folder for unit and UI tests
 
-The directory `ci` contains scripts run on the ci server during a build
+The directory `ci` contains scripts run on the CI server during a build
 
 - `prepare_env_buildkite.sh`
   - sets versionCode and versionName
@@ -52,13 +52,13 @@ We use the following hook scripts (located in `/etc/buildkite-agent/hooks` on th
 - `environment`
   - Setup environment variables regarding the Android SDK and the CODECOV_TOKEN
 - `pre-command`
-  - Copy google-services.json to respective build type folders (prod version for `rinkeby` and `release` build type and staging version for `internal` builds)
-  - Copy gnosis-upload.jks keystore used for release and rinkeby version (NOT `internal`)
+  - Copy `google-services.json` to the respective build type folders (prod version for `rinkeby` and `release` build type and staging version for `internal` builds)
+  - Copy `gnosis-upload.jks` keystore used for release and rinkeby version (NOT `internal`)
   - Prepare environment with different secrets for the legacy (v1) app and the current (v2) app build
 
 ## Secrets injected on the ci server
 
-The `internal` build uses the debug.keystore that has been committed to the git repository. The CI server adds the following secrets to the build process.
+The `internal` build uses the `debug.keystore` that has been committed to the git repository. The CI server adds the following secrets to the build process.
 
 - FIREBASE_TOKEN
   - For pushing updates to Firebase App Distribution

--- a/docs/INTERNAL_BUILD.md
+++ b/docs/INTERNAL_BUILD.md
@@ -5,10 +5,9 @@ The `internal` app uses the Rinkeby test network. It uses the staging environmen
 ## Local Build Setup Requirements
 ### Firebase / Google Services Plugin
 
-To build the `internal` buildType you need to have a properly configured `google-services.json` file. We need it for App distribution via Firebase and Crash reporting.
-Whe don't want to have this file in the git repository because it contains an api_key which might cause builds by external developers to report accidentally to our Crashlytics database
-As an Gnosis developer you can get the latest version here: <https://console.firebase.google.com/u/0/project/safe-firebase-staging/settings/general/android:io.gnosis.safe.internal>
-As an external developer please have a look at [README](../README.md#Firebase) on instructions how to get it.
+To build the `internal` buildType you need to have a properly configured `google-services.json` file. We need it for App distribution via Firebase and Crash reporting. Whe don't want to have this file in the git repository because it contains an api_key which might cause custom builds to report accidentally to our Crashlytics database. For a Gnosis build you can get the latest version here: <https://console.firebase.google.com/u/0/project/safe-firebase-staging/settings/general/android:io.gnosis.safe.internal>.
+
+For a custom build, please have a look at the [README.md#Firebase](../README.md#Firebase) for instructions on how to get it.
 
 ### INFURA API Key
 

--- a/docs/INTERNAL_BUILD.md
+++ b/docs/INTERNAL_BUILD.md
@@ -65,11 +65,11 @@ The `internal` build uses the debug.keystore that has been committed to the git 
 - INFURA_API_KEY
   - Used for Infura API calls
 - GITHUB_API_KEY
-  - Deploy to github in (`ci/upload_to_github.sh`)
+  - Deploy to github (used in `ci/upload_to_github.sh`)
 - SLACK_WEBHOOK
   - Used to notify certain slack channels
 - CODECOV_TOKEN
-  - To provide code coverage
+  - To provide test coverage analysis
 
 ##  Access to the `internal` app
 

--- a/docs/INTERNAL_BUILD.md
+++ b/docs/INTERNAL_BUILD.md
@@ -54,7 +54,7 @@ We use the following hook scripts (located in `/etc/buildkite-agent/hooks` on th
 - `pre-command`
   - Copy `google-services.json` to the respective build type folders (prod version for `rinkeby` and `release` build type and staging version for `internal` builds)
   - Copy `gnosis-upload.jks` keystore used for release and rinkeby version (NOT `internal`)
-  - Prepare environment with different secrets for the legacy (v1) app and the current (v2) app build
+  - Prepare build environment with secrets (see below)
 
 ## Secrets injected on the ci server
 

--- a/docs/INTERNAL_BUILD.md
+++ b/docs/INTERNAL_BUILD.md
@@ -1,11 +1,11 @@
 # Build `internal` app
 
-The `internal` app is meant to test new features as soon as they are merged to master. It uses the Rinkeby test network and the staging environment for relay and notification services.
+The `internal` build type is meant to test new features as soon as they are merged to master. It uses the Rinkeby test network and the staging environment for relay and notification services.
 
 ## Local Build Setup Requirements
 ### Firebase / Google Services Plugin
 
-To build the `internal` buildType you need to have a properly configured `google-services.json` file. We need it for App distribution via Firebase and Crash reporting. Whe don't want to have this file in the git repository because it contains an api_key which might cause custom builds to report accidentally to our Crashlytics database. For a Gnosis build you can get the latest version here: <https://console.firebase.google.com/u/0/project/safe-firebase-staging/settings/general/android:io.gnosis.safe.internal>.
+To build the `internal` build type you need to have a properly configured `google-services.json` file. We need it for app distribution and crash reporting via Firebase. We don't want to have this file in the git repository because it contains an api_key which might cause custom builds to report accidentally to our Crashlytics database. For a Gnosis build you can get the latest version here: <https://console.firebase.google.com/u/0/project/safe-firebase-staging/settings/general/android:io.gnosis.safe.internal>.
 
 For a custom build, please have a look at the [README.md#Firebase](../README.md#Firebase) for instructions on how to get it.
 

--- a/docs/INTERNAL_BUILD.md
+++ b/docs/INTERNAL_BUILD.md
@@ -1,22 +1,14 @@
-# Build internal/debug app
+# Build `internal` app
 
-## Requirements
+The `internal` app uses the Rinkeby test network. It uses the staging environment for relay and notification services. It is meant to test new features as soon as they are merged to master.
+
+## Local Build Setup Requirements
 ### Firebase / Goggle Services Plugin
-- google-services.json
-  - Why do we need it?
-    - Google Services Plugin depends on it for:
-      - App distribution
-      - Crash reporting
-  - Why don't we provide one
-    -  It contains an api_key which might cause builds by external developers to report accidentally to our Crashlytics database
-  - How where to get it
-    - As an Gnosis developer you can get it here: <https://console.firebase.google.com/u/0/project/safe-firebase-staging/settings/general/android:io.gnosis.safe.internal>
-    - As an external developer you need to do the following
-      - Create a project here: <https://console.firebase.google.com/>
-      - In that project create at least one app with the applicationId `io.gnosis.safe.debug`
-      - Download the file google-services.json and place it inside the projects app folder
-      - If you use a different applicationId then adjust the applicationId in: `app/build.gradle`
-  - Gnosis employees / Outside contributors
+
+To build the `internal` buildType you need to have a properly configured `google-services.json` file. We need it for App distribution via Firebase and Crash reporting.
+Whe don't want to have this file in the git repository because it contains an api_key which might cause builds by external developers to report accidentally to our Crashlytics database
+As an Gnosis developer you can get the latest version here: <https://console.firebase.google.com/u/0/project/safe-firebase-staging/settings/general/android:io.gnosis.safe.internal>
+As an external developer please have a look at [README](../README.md#Firebase) on instructions how to get it.
 
 ### INFURA API Key
   - Why do we need it?
@@ -31,6 +23,29 @@ INFURA_API_KEY=<YOUR_PROJECT_ID>
 Replace <YOUR_PROJECT_ID> with the project id that you get from Infura.
 
 
-## Gradle tasks
-- ./gradlew assembleDebug
-- 
+## Gradle tasks for local builds
+
+`./gradlew assembleInternal`
+
+## Buildkite (Continuous Integration) Setup
+
+We use a self hosted Buildkite agent. Given you have the appropriate credentials you can see its Android projects here: https://buildkite.com/gnosis
+The Buildkite instance is also responsible for app signing and distribution. The `internal` app is distributed to Firebase.
+
+## Secrets injected on the ci server
+
+- SIGNING_STORE_PASSWORD
+- SIGNING_KEY_PASSWORD
+- FIREBASE_TOKEN -> Necessary to push updates to Firebase App Distribution
+- INFURA_API_KEY -> See above
+- GITHUB_API_KEY ->
+- SLACK_WEBHOOK -> Used to notify certain slack channels
+- CODECOV
+
+##  Access to the `internal` app
+
+Access to `internal` builds is defined in the `internal` app in the `safe-firebase-staging` project on Firebase. See `Users and permissions` tab in `Settings`
+
+## Build trigger
+
+Whenever a PR is merged to master and `internal` build is triggered.

--- a/docs/INTERNAL_BUILD.md
+++ b/docs/INTERNAL_BUILD.md
@@ -3,7 +3,7 @@
 The `internal` app uses the Rinkeby test network. It uses the staging environment for relay and notification services. It is meant to test new features as soon as they are merged to master.
 
 ## Local Build Setup Requirements
-### Firebase / Goggle Services Plugin
+### Firebase / Google Services Plugin
 
 To build the `internal` buildType you need to have a properly configured `google-services.json` file. We need it for App distribution via Firebase and Crash reporting.
 Whe don't want to have this file in the git repository because it contains an api_key which might cause builds by external developers to report accidentally to our Crashlytics database
@@ -11,19 +11,16 @@ As an Gnosis developer you can get the latest version here: <https://console.fir
 As an external developer please have a look at [README](../README.md#Firebase) on instructions how to get it.
 
 ### INFURA API Key
-  - Why do we need it?
-    - The Json RPC depends on [Infura](https://infura.io/).
-  - How/where to get it
-    - Create a free (of charge) account at <https://infura.io/>
-    - Create a project
-    - Find project id in the project settings -> Keys
 
+We need an Infura API key for the JSON RPC calls. Please create a free (of charge) account with Infura at: <https://infura.io/>. Then create a project. Find the `project id` in the Project settings -> Keys.
 You need to get an API key and create a file named ``project_keys` in the project folder with the following contents:
+
+```
 INFURA_API_KEY=<YOUR_PROJECT_ID>
-Replace <YOUR_PROJECT_ID> with the project id that you get from Infura.
+```
+Replace <YOUR_PROJECT_ID> with the project id that you got from Infura.
 
-
-## Gradle tasks for local builds
+### Gradle task for local builds
 
 `./gradlew assembleInternal`
 
@@ -48,4 +45,4 @@ Access to `internal` builds is defined in the `internal` app in the `safe-fireba
 
 ## Build trigger
 
-Whenever a PR is merged to master and `internal` build is triggered.
+Whenever a PR is merged to master an `internal` build is triggered.

--- a/docs/INTERNAL_BUILD.md
+++ b/docs/INTERNAL_BUILD.md
@@ -9,7 +9,7 @@ To build the `internal` build type you need to have a properly configured `googl
 
 For a custom build, please have a look at the [README.md#Firebase](../README.md#Firebase) for instructions on how to get it.
 
-### INFURA API Key
+### Infura API Key
 
 We need an Infura API key for the JSON RPC calls. Please create a free (of charge) account with Infura at: <https://infura.io/>. Then create a project. Find the `project id` in the Project settings -> Keys.
 You need to get an API key and create a file named `project_keys` in the project folder with the following content:
@@ -30,13 +30,18 @@ The Buildkite instance is also responsible for app signing and distribution. The
 
 ## Secrets injected on the ci server
 
-- SIGNING_STORE_PASSWORD
-- SIGNING_KEY_PASSWORD
-- FIREBASE_TOKEN -> Necessary to push updates to Firebase App Distribution
-- INFURA_API_KEY -> See above
-- GITHUB_API_KEY ->
-- SLACK_WEBHOOK -> Used to notify certain slack channels
+The `internal` build uses the debug.keystore that has been committed to the git repository. The CI server adds the following secrets to the build process.
+
+- FIREBASE_TOKEN
+  - For pushing updates to Firebase App Distribution
+- INFURA_API_KEY
+  - Used for Infura API calls
+- GITHUB_API_KEY
+  - ????
+- SLACK_WEBHOOK
+  - Used to notify certain slack channels
 - CODECOV
+  - To provide code coverage
 
 ##  Access to the `internal` app
 
@@ -44,4 +49,5 @@ Access to `internal` builds is defined in the `internal` app in the `safe-fireba
 
 ## Build trigger
 
-Whenever a PR is merged to master an `internal` build is triggered.
+Whenever a PR is merged to master an `internal` build and its distribution to Firebase is triggered automatically. Firebase sends an email to all registered email addresses to notify them, that there is a new version.
+ 

--- a/docs/INTERNAL_BUILD.md
+++ b/docs/INTERNAL_BUILD.md
@@ -1,0 +1,36 @@
+# Build internal/debug app
+
+## Requirements
+### Firebase / Goggle Services Plugin
+- google-services.json
+  - Why do we need it?
+    - Google Services Plugin depends on it for:
+      - App distribution
+      - Crash reporting
+  - Why don't we provide one
+    -  It contains an api_key which might cause builds by external developers to report accidentally to our Crashlytics database
+  - How where to get it
+    - As an Gnosis developer you can get it here: <https://console.firebase.google.com/u/0/project/safe-firebase-staging/settings/general/android:io.gnosis.safe.internal>
+    - As an external developer you need to do the following
+      - Create a project here: <https://console.firebase.google.com/>
+      - In that project create at least one app with the applicationId `io.gnosis.safe.debug`
+      - Download the file google-services.json and place it inside the projects app folder
+      - If you use a different applicationId then adjust the applicationId in: `app/build.gradle`
+  - Gnosis employees / Outside contributors
+
+### INFURA API Key
+  - Why do we need it?
+    - The Json RPC depends on [Infura](https://infura.io/).
+  - How/where to get it
+    - Create a free (of charge) account at <https://infura.io/>
+    - Create a project
+    - Find project id in the project settings -> Keys
+
+You need to get an API key and create a file named ``project_keys` in the project folder with the following contents:
+INFURA_API_KEY=<YOUR_PROJECT_ID>
+Replace <YOUR_PROJECT_ID> with the project id that you get from Infura.
+
+
+## Gradle tasks
+- ./gradlew assembleDebug
+- 

--- a/docs/INTERNAL_BUILD.md
+++ b/docs/INTERNAL_BUILD.md
@@ -1,6 +1,6 @@
 # Build `internal` app
 
-The `internal` app uses the Rinkeby test network. It uses the staging environment for relay and notification services. It is meant to test new features as soon as they are merged to master.
+The `internal` app is meant to test new features as soon as they are merged to master. It uses the Rinkeby test network and the staging environment for relay and notification services.
 
 ## Local Build Setup Requirements
 ### Firebase / Google Services Plugin
@@ -12,12 +12,12 @@ For a custom build, please have a look at the [README.md#Firebase](../README.md#
 ### INFURA API Key
 
 We need an Infura API key for the JSON RPC calls. Please create a free (of charge) account with Infura at: <https://infura.io/>. Then create a project. Find the `project id` in the Project settings -> Keys.
-You need to get an API key and create a file named ``project_keys` in the project folder with the following contents:
+You need to get an API key and create a file named `project_keys` in the project folder with the following content:
 
 ```
 INFURA_API_KEY=<YOUR_PROJECT_ID>
 ```
-Replace <YOUR_PROJECT_ID> with the project id that you got from Infura.
+Replace `<YOUR_PROJECT_ID>` with the `project id` that you got from Infura.
 
 ### Gradle task for local builds
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,26 +2,26 @@
 
 ## QA
 1. Decide what commit should be used for the release and create a draft release
-  - This commit is normally a `master` branch commit, but there are exceptions (e.g. hotfixes)
-  - The release description MUST contain a list of new features
+   - This commit is normally a `master` branch commit, but there are exceptions (e.g. hotfixes)
+   - The release description MUST contain a list of new features
 2. Share release and a Crashlytics Beta link to that commit with the QA team
-  - New features and core features (create Safe, send transactions, restore Safe) MUST be tested with the Mainnet version
-  - Other features SHOULD be tested with the Rinkeby version
+   - New features and core features (create Safe, send transactions, restore Safe) MUST be tested with the Mainnet version
+   - Other features SHOULD be tested with the Rinkeby version
 3. If required fix bugs and repeat process
 
 ## Build release version
 1. Finalize the draft created in [QA step](#qa)
-  - CI will automatically build a Mainnet and Rinkeby versions, which will be attached to the release
+   - CI will automatically build a Mainnet and Rinkeby versions, which will be attached to the release
 2. Download Mainnet apk file (prefixed with `-release`)
 3. Create new version in PlayStore with downloaded Mainnet apk file
-  - Check if version should be published as Alpha/Beta to signed up users first
-  - Check with communications and product team for PlayStore assets
-    - Version release notes
-    - Updates to screenshots or store description
-  - Check if there should be an announcement for the new release
+   - Check if version should be published as Alpha/Beta to signed up users first
+   - Check with communications and product team for PlayStore assets
+     - Version release notes
+     - Updates to screenshots or store description
+   - Check if there should be an announcement for the new release
 4. Release new version on PlayStore
-  - If enough users are using the app it is recommended to use a staged rollout over the duration of a couple days
-  - If app was published as Alpha/Beta, a date MUST be set when the app should be propagated to the Release channel
+   - If enough users are using the app it is recommended to use a staged rollout over the duration of a couple days
+   - If app was published as Alpha/Beta, a date MUST be set when the app should be propagated to the Release channel
   
 ## Monitor release
 - Check Crashlytics for crashes


### PR DESCRIPTION
Closes #583 .

Changes proposed in this pull request:
- Update README.md instructions on Infura API-Key now called project id
- Add instruction on `internal` builds


@gnosis/mobile-devs
