### PR TITLE
Track screen names

### DIFF
--- a/app/src/main/java/io/gnosis/safe/Tracker.kt
+++ b/app/src/main/java/io/gnosis/safe/Tracker.kt
@@ -1,5 +1,6 @@
 package io.gnosis.safe
 
+import android.app.Activity
 import android.content.Context
 import android.os.Bundle
 import com.google.firebase.analytics.FirebaseAnalytics
@@ -9,9 +10,13 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class Tracker @Inject constructor(@ApplicationContext context: Context) {
+class Tracker private constructor(context: Context) {
 
     private val firebaseAnalytics: FirebaseAnalytics = FirebaseAnalytics.getInstance(context)
+
+    fun setCurrentScreenId(activity: Activity, screenId: ScreenId) {
+        firebaseAnalytics.setCurrentScreen(activity, screenId.value, null)
+    }
 
     fun setNumSafes(numSafes: Int) {
         firebaseAnalytics.setUserProperty(Param.NUM_SAFES, numSafes.toString())
@@ -57,4 +62,51 @@ class Tracker @Inject constructor(@ApplicationContext context: Context) {
         val PUSH_ENABLED = "enabled"
         val PUSH_DISABLED = "disabled"
     }
+
+    companion object {
+
+        @Volatile
+        private var INSTANCE: Tracker? = null
+
+        @Inject
+        fun getInstance(@ApplicationContext context: Context): Tracker =
+            INSTANCE ?: synchronized(this) {
+                INSTANCE ?: Tracker(context).also { INSTANCE = it }
+            }
+    }
+}
+
+enum class ScreenId(val value: String) {
+
+    SPLASH("splash"),
+    LAUNCH("launch"),
+    LAUNCH_TERMS("launch_terms"),
+
+    BALANCES_NO_SAFE("assets_no_safe"),
+    BALANCES_COINS("assets_coins"),
+    BALANCES_COLLECTIBLES("assets_collectibles"),
+    BALANCES_COLLECTIBLES_DETAILS("assets_collectibles_details"),
+
+    SAFE_RECEIVE("safe_receive"),
+    SAFE_SELECT("safe_switch"),
+    SAFE_ADD_ADDRESS("safe_add_address"),
+    SAFE_ADD_NAME("safe_add_name"),
+    SAFE_ADD_ENS("safe_add_ens"),
+
+    TRANSACTIONS_NO_SAFE("transactions_no_safe"),
+    TRANSACTIONS("transactions"),
+    TRANSACTIONS_DETAILS("transactions_details"),
+    TRANSACTIONS_DETAILS_ADVANCED("transactions_details_advanced"),
+
+    SETTINGS_APP("settings_app"),
+    SETTINGS_APP_ADVANCED("settings_app_advanced"),
+    SETTINGS_APP_FIAT("settings_app_edit_fiat"),
+    SETTINGS_GET_IN_TOUCH("settings_app_support"),
+
+    SETTINGS_SAFE_NO_SAFE("settings_safe_no_safe"),
+    SETTINGS_SAFE("settings_safe"),
+    SETTINGS_SAFE_EDIT_NAME("settings_safe_edit_name"),
+    SETTINGS_SAFE_ADVANCED("settings_safe_advanced"),
+
+    SCANNER("camera"),
 }

--- a/app/src/main/java/io/gnosis/safe/Tracker.kt
+++ b/app/src/main/java/io/gnosis/safe/Tracker.kt
@@ -74,7 +74,6 @@ class Tracker private constructor(context: Context) {
 }
 
 enum class ScreenId(val value: String) {
-    SPLASH("splash"),
     LAUNCH("launch"),
     LAUNCH_TERMS("launch_terms"),
     BALANCES_NO_SAFE("assets_no_safe"),

--- a/app/src/main/java/io/gnosis/safe/Tracker.kt
+++ b/app/src/main/java/io/gnosis/safe/Tracker.kt
@@ -5,8 +5,6 @@ import android.content.Context
 import android.os.Bundle
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
-import io.gnosis.safe.di.ApplicationContext
-import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
@@ -68,8 +66,7 @@ class Tracker private constructor(context: Context) {
         @Volatile
         private var INSTANCE: Tracker? = null
 
-        @Inject
-        fun getInstance(@ApplicationContext context: Context): Tracker =
+        fun getInstance(context: Context): Tracker =
             INSTANCE ?: synchronized(this) {
                 INSTANCE ?: Tracker(context).also { INSTANCE = it }
             }
@@ -77,36 +74,29 @@ class Tracker private constructor(context: Context) {
 }
 
 enum class ScreenId(val value: String) {
-
     SPLASH("splash"),
     LAUNCH("launch"),
     LAUNCH_TERMS("launch_terms"),
-
     BALANCES_NO_SAFE("assets_no_safe"),
     BALANCES_COINS("assets_coins"),
     BALANCES_COLLECTIBLES("assets_collectibles"),
     BALANCES_COLLECTIBLES_DETAILS("assets_collectibles_details"),
-
     SAFE_RECEIVE("safe_receive"),
     SAFE_SELECT("safe_switch"),
     SAFE_ADD_ADDRESS("safe_add_address"),
     SAFE_ADD_NAME("safe_add_name"),
     SAFE_ADD_ENS("safe_add_ens"),
-
     TRANSACTIONS_NO_SAFE("transactions_no_safe"),
     TRANSACTIONS("transactions"),
     TRANSACTIONS_DETAILS("transactions_details"),
     TRANSACTIONS_DETAILS_ADVANCED("transactions_details_advanced"),
-
     SETTINGS_APP("settings_app"),
     SETTINGS_APP_ADVANCED("settings_app_advanced"),
     SETTINGS_APP_FIAT("settings_app_edit_fiat"),
     SETTINGS_GET_IN_TOUCH("settings_app_support"),
-
     SETTINGS_SAFE_NO_SAFE("settings_safe_no_safe"),
     SETTINGS_SAFE("settings_safe"),
     SETTINGS_SAFE_EDIT_NAME("settings_safe_edit_name"),
     SETTINGS_SAFE_ADVANCED("settings_safe_advanced"),
-
     SCANNER("camera"),
 }

--- a/app/src/main/java/io/gnosis/safe/di/components/ApplicationComponent.kt
+++ b/app/src/main/java/io/gnosis/safe/di/components/ApplicationComponent.kt
@@ -10,6 +10,7 @@ import io.gnosis.safe.di.modules.*
 import io.gnosis.safe.helpers.AppInitManager
 import io.gnosis.safe.ui.base.AppDispatchers
 import io.gnosis.safe.ui.base.BaseActivity
+import io.gnosis.safe.ui.base.BaseFragment
 import io.gnosis.safe.ui.safe.terms.TermsChecker
 import javax.inject.Singleton
 
@@ -41,7 +42,9 @@ interface ApplicationComponent {
 
     // Base injects
     fun inject(activity: BaseActivity)
-//
+
+    fun inject(fragment: BaseFragment)
+
 //    fun inject(service: BridgeService)
 //    fun inject(service: HeimdallFirebaseService)
 }

--- a/app/src/main/java/io/gnosis/safe/di/modules/ApplicationModule.kt
+++ b/app/src/main/java/io/gnosis/safe/di/modules/ApplicationModule.kt
@@ -55,7 +55,7 @@ class ApplicationModule(private val application: Application) {
 
     @Provides
     @Singleton
-    fun providesTracker(@ApplicationContext context: Context): Tracker = Tracker(context)
+    fun providesTracker(@ApplicationContext context: Context): Tracker = Tracker.getInstance(context)
 
     @Provides
     @Singleton

--- a/app/src/main/java/io/gnosis/safe/helpers/AddressInputHelper.kt
+++ b/app/src/main/java/io/gnosis/safe/helpers/AddressInputHelper.kt
@@ -6,6 +6,8 @@ import android.content.Intent
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import io.gnosis.safe.qrscanner.QRCodeScanActivity
 import io.gnosis.safe.R
+import io.gnosis.safe.ScreenId
+import io.gnosis.safe.Tracker
 import io.gnosis.safe.ui.base.BaseFragment
 import io.gnosis.safe.ui.dialogs.EnsInputDialog
 import io.gnosis.safe.utils.handleAddressBookResult
@@ -19,6 +21,7 @@ import pm.gnosis.utils.exceptions.InvalidAddressException
 
 class AddressInputHelper(
     fragment: BaseFragment,
+    tracker: Tracker,
     private val addressCallback: (Solidity.Address) -> Unit,
     private val errorCallback: ((Throwable) -> Unit)? = null,
     allowAddressBook: Boolean = false
@@ -48,6 +51,7 @@ class AddressInputHelper(
             }
             bottom_sheet_address_input_qr_touch.setOnClickListener {
                 QRCodeScanActivity.startForResult(fragment)
+                tracker.setCurrentScreenId(fragment.requireActivity(), ScreenId.SCANNER)
                 hide()
             }
             bottom_sheet_address_input_paste_touch.setOnClickListener {

--- a/app/src/main/java/io/gnosis/safe/helpers/AddressInputHelper.kt
+++ b/app/src/main/java/io/gnosis/safe/helpers/AddressInputHelper.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import io.gnosis.safe.qrscanner.QRCodeScanActivity
 import io.gnosis.safe.R
-import io.gnosis.safe.ui.base.BaseActivity
 import io.gnosis.safe.ui.base.BaseFragment
 import io.gnosis.safe.ui.dialogs.EnsInputDialog
 import io.gnosis.safe.utils.handleAddressBookResult
@@ -19,14 +18,14 @@ import pm.gnosis.svalinn.common.utils.visible
 import pm.gnosis.utils.exceptions.InvalidAddressException
 
 class AddressInputHelper(
-    fragment: BaseFragment<*>,
+    fragment: BaseFragment,
     private val addressCallback: (Solidity.Address) -> Unit,
     private val errorCallback: ((Throwable) -> Unit)? = null,
     allowAddressBook: Boolean = false
 ) {
 
     private val dialog =
-        BottomSheetDialog(fragment.context!!).apply {
+        BottomSheetDialog(fragment.requireContext()).apply {
             val clipboard = fragment.activity?.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
 
             setContentView(layoutInflater.inflate(R.layout.bottom_sheet_address_input, null))

--- a/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
@@ -75,5 +75,7 @@ class StartActivity : BaseActivity(), SafeOverviewNavigationHandler {
             safeAddress.text = safe.address.asEthereumAddressString().asMiddleEllipsized(4)
         }
     }
+
+    override fun screenId() = null
 }
 

--- a/app/src/main/java/io/gnosis/safe/ui/base/BaseActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/base/BaseActivity.kt
@@ -5,17 +5,28 @@ import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import io.gnosis.safe.BuildConfig
 import io.gnosis.safe.HeimdallApplication
+import io.gnosis.safe.ScreenId
+import io.gnosis.safe.Tracker
 import io.gnosis.safe.di.components.DaggerViewComponent
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.di.modules.ViewModule
+import javax.inject.Inject
 
 abstract class BaseActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var tracker: Tracker
+
+    abstract fun screenId(): ScreenId?
 
     override fun onCreate(savedInstanceState: Bundle?) {
         HeimdallApplication[this].inject(this)
         super.onCreate(savedInstanceState)
         if (!BuildConfig.DEBUG) {
             window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
+        }
+        screenId()?.let {
+            tracker.setCurrentScreenId(this, it)
         }
     }
 

--- a/app/src/main/java/io/gnosis/safe/ui/base/BaseBottomSheetDialogFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/base/BaseBottomSheetDialogFragment.kt
@@ -11,11 +11,17 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import io.gnosis.safe.HeimdallApplication
 import io.gnosis.safe.R
+import io.gnosis.safe.ScreenId
+import io.gnosis.safe.Tracker
 import io.gnosis.safe.di.components.DaggerViewComponent
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.di.modules.ViewModule
+import javax.inject.Inject
 
 abstract class BaseBottomSheetDialogFragment<T : ViewBinding> : BottomSheetDialogFragment() {
+
+    @Inject
+    lateinit var tracker: Tracker
 
     private var _binding: T? = null
     protected val binding get() = _binding!!
@@ -39,8 +45,11 @@ abstract class BaseBottomSheetDialogFragment<T : ViewBinding> : BottomSheetDialo
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
         BottomSheetDialog(requireContext(), theme)
 
-    override fun getTheme(): Int {
-        return R.style.BottomSheetDialogTheme
+    override fun onStart() {
+        super.onStart()
+        screenId()?.let {
+            tracker.setCurrentScreenId(requireActivity(), it)
+        }
     }
 
     override fun onDestroyView() {
@@ -48,11 +57,17 @@ abstract class BaseBottomSheetDialogFragment<T : ViewBinding> : BottomSheetDialo
         _binding = null
     }
 
+    override fun getTheme(): Int {
+        return R.style.BottomSheetDialogTheme
+    }
+
     private fun buildViewComponent(context: Context) =
         DaggerViewComponent.builder()
             .applicationComponent(HeimdallApplication[context])
             .viewModule(ViewModule(context, viewModelProvider()))
             .build()
+
+    abstract fun screenId(): ScreenId?
 
     abstract fun inject(viewComponent: ViewComponent)
 

--- a/app/src/main/java/io/gnosis/safe/ui/base/BaseFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/base/BaseFragment.kt
@@ -8,12 +8,18 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.viewbinding.ViewBinding
 import io.gnosis.safe.HeimdallApplication
+import io.gnosis.safe.ScreenId
+import io.gnosis.safe.Tracker
 import io.gnosis.safe.di.components.DaggerViewComponent
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.di.modules.ViewModule
+import javax.inject.Inject
 
 abstract class BaseFragment<T> : Fragment()
         where T : ViewBinding {
+
+    @Inject
+    lateinit var tracker: Tracker
 
     private var _binding: T? = null
     protected val binding get() = _binding!!
@@ -32,6 +38,13 @@ abstract class BaseFragment<T> : Fragment()
         return binding.root
     }
 
+    override fun onStart() {
+        super.onStart()
+        screenId()?.let {
+            tracker.setCurrentScreenId(requireActivity(), it)
+        }
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
@@ -42,6 +55,8 @@ abstract class BaseFragment<T> : Fragment()
             .applicationComponent(HeimdallApplication[context])
             .viewModule(ViewModule(context, viewModelProvider()))
             .build()
+
+    abstract fun screenId(): ScreenId?
 
     abstract fun inject(component: ViewComponent)
 

--- a/app/src/main/java/io/gnosis/safe/ui/base/BaseFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/base/BaseFragment.kt
@@ -1,12 +1,7 @@
 package io.gnosis.safe.ui.base
 
 import android.content.Context
-import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.viewbinding.ViewBinding
 import io.gnosis.safe.HeimdallApplication
 import io.gnosis.safe.ScreenId
 import io.gnosis.safe.Tracker
@@ -15,27 +10,14 @@ import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.di.modules.ViewModule
 import javax.inject.Inject
 
-abstract class BaseFragment<T> : Fragment()
-        where T : ViewBinding {
+abstract class BaseFragment : Fragment() {
 
     @Inject
     lateinit var tracker: Tracker
 
-    private var _binding: T? = null
-    protected val binding get() = _binding!!
-
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        inject(buildViewComponent(context))
-    }
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        _binding = inflateBinding(inflater, container)
-        return binding.root
+        HeimdallApplication[requireContext()].inject(this)
     }
 
     override fun onStart() {
@@ -45,12 +27,7 @@ abstract class BaseFragment<T> : Fragment()
         }
     }
 
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
-    }
-
-    private fun buildViewComponent(context: Context): ViewComponent =
+    protected fun buildViewComponent(context: Context): ViewComponent =
         DaggerViewComponent.builder()
             .applicationComponent(HeimdallApplication[context])
             .viewModule(ViewModule(context, viewModelProvider()))
@@ -61,6 +38,4 @@ abstract class BaseFragment<T> : Fragment()
     abstract fun inject(component: ViewComponent)
 
     open protected fun viewModelProvider(): Any? = parentFragment
-
-    abstract fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?): T
 }

--- a/app/src/main/java/io/gnosis/safe/ui/base/BaseViewBindingFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/base/BaseViewBindingFragment.kt
@@ -1,0 +1,37 @@
+package io.gnosis.safe.ui.base
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.viewbinding.ViewBinding
+
+abstract class BaseViewBindingFragment<T> : BaseFragment()
+        where T : ViewBinding {
+
+    private var _binding: T? = null
+
+    protected val binding get() = _binding!!
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        inject(buildViewComponent(context))
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = inflateBinding(inflater, container)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    abstract fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?): T
+}

--- a/app/src/main/java/io/gnosis/safe/ui/safe/SafeOverviewBase.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/SafeOverviewBase.kt
@@ -3,9 +3,9 @@ package io.gnosis.safe.ui.safe
 import android.content.Context
 import androidx.viewbinding.ViewBinding
 import io.gnosis.data.models.Safe
-import io.gnosis.safe.ui.base.BaseFragment
+import io.gnosis.safe.ui.base.BaseViewBindingFragment
 
-abstract class SafeOverviewBaseFragment<T> : BaseFragment<T>() where T : ViewBinding {
+abstract class SafeOverviewBaseFragment<T> : BaseViewBindingFragment<T>() where T : ViewBinding {
 
     protected var navHandler: SafeOverviewNavigationHandler? = null
 

--- a/app/src/main/java/io/gnosis/safe/ui/safe/SafeOverviewBase.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/SafeOverviewBase.kt
@@ -20,6 +20,8 @@ abstract class SafeOverviewBaseFragment<T> : BaseFragment<T>() where T : ViewBin
     }
 
     abstract fun handleActiveSafe(safe: Safe?)
+
+    override fun screenId() = null
 }
 
 interface SafeOverviewNavigationHandler {

--- a/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import io.gnosis.safe.R
+import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentAddSafeBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.helpers.AddressInputHelper
@@ -28,6 +29,8 @@ class AddSafeFragment : BaseFragment<FragmentAddSafeBinding>() {
     private val addressInputHelper by lazy {
         AddressInputHelper(this, ::updateAddress, allowAddressBook = false)
     }
+
+    override fun screenId() = ScreenId.SAFE_ADD_ADDRESS
 
     override fun inject(component: ViewComponent) {
         component.inject(this)

--- a/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeFragment.kt
@@ -12,7 +12,7 @@ import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentAddSafeBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.helpers.AddressInputHelper
-import io.gnosis.safe.ui.base.BaseFragment
+import io.gnosis.safe.ui.base.BaseViewBindingFragment
 import io.gnosis.safe.ui.base.BaseStateViewModel
 import kotlinx.android.synthetic.main.fragment_add_safe.*
 import pm.gnosis.model.Solidity
@@ -21,7 +21,7 @@ import pm.gnosis.utils.asEthereumAddressString
 import timber.log.Timber
 import javax.inject.Inject
 
-class AddSafeFragment : BaseFragment<FragmentAddSafeBinding>() {
+class AddSafeFragment : BaseViewBindingFragment<FragmentAddSafeBinding>() {
 
     @Inject
     lateinit var viewModel: AddSafeViewModel

--- a/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeFragment.kt
@@ -12,8 +12,8 @@ import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentAddSafeBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.helpers.AddressInputHelper
-import io.gnosis.safe.ui.base.BaseViewBindingFragment
 import io.gnosis.safe.ui.base.BaseStateViewModel
+import io.gnosis.safe.ui.base.BaseViewBindingFragment
 import kotlinx.android.synthetic.main.fragment_add_safe.*
 import pm.gnosis.model.Solidity
 import pm.gnosis.svalinn.common.utils.visible
@@ -27,7 +27,7 @@ class AddSafeFragment : BaseViewBindingFragment<FragmentAddSafeBinding>() {
     lateinit var viewModel: AddSafeViewModel
 
     private val addressInputHelper by lazy {
-        AddressInputHelper(this, ::updateAddress, allowAddressBook = false)
+        AddressInputHelper(this, tracker, ::updateAddress, allowAddressBook = false)
     }
 
     override fun screenId() = ScreenId.SAFE_ADD_ADDRESS

--- a/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeNameFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeNameFragment.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import io.gnosis.safe.R
+import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentAddSafeNameBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.ui.base.BaseFragment
@@ -27,6 +28,8 @@ class AddSafeNameFragment : BaseFragment<FragmentAddSafeNameBinding>() {
 
     private val navArgs by navArgs<AddSafeNameFragmentArgs>()
     private val newAddress by lazy { navArgs.newAddress.asEthereumAddress()!! }
+
+    override fun screenId() = ScreenId.SAFE_ADD_NAME
 
     override fun inject(component: ViewComponent) {
         component.inject(this)

--- a/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeNameFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeNameFragment.kt
@@ -11,7 +11,7 @@ import io.gnosis.safe.R
 import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentAddSafeNameBinding
 import io.gnosis.safe.di.components.ViewComponent
-import io.gnosis.safe.ui.base.BaseFragment
+import io.gnosis.safe.ui.base.BaseViewBindingFragment
 import io.gnosis.safe.ui.base.BaseStateViewModel
 import io.gnosis.safe.utils.formatEthAddress
 import kotlinx.android.synthetic.main.fragment_add_safe.*
@@ -21,7 +21,7 @@ import pm.gnosis.utils.asEthereumAddress
 import timber.log.Timber
 import javax.inject.Inject
 
-class AddSafeNameFragment : BaseFragment<FragmentAddSafeNameBinding>() {
+class AddSafeNameFragment : BaseViewBindingFragment<FragmentAddSafeNameBinding>() {
 
     @Inject
     lateinit var viewModel: AddSafeNameViewModel

--- a/app/src/main/java/io/gnosis/safe/ui/safe/balances/SafeBalancesFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/balances/SafeBalancesFragment.kt
@@ -90,7 +90,7 @@ class BalancesPagerAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) 
 
     override fun createFragment(position: Int): Fragment =
         when (Tabs.values()[position]) {
-            Tabs.COINS -> if (noActiveSafe) NoSafeFragment.newInstance() else CoinsFragment.newInstance()
+            Tabs.COINS -> if (noActiveSafe) NoSafeFragment.newInstance(NoSafeFragment.Position.BALANCES) else CoinsFragment.newInstance()
             Tabs.COLLECTIBLES -> CollectiblesFragment.newInstance()
         }
 

--- a/app/src/main/java/io/gnosis/safe/ui/safe/balances/coins/CoinsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/balances/coins/CoinsFragment.kt
@@ -11,14 +11,14 @@ import io.gnosis.safe.R
 import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentCoinsBinding
 import io.gnosis.safe.di.components.ViewComponent
-import io.gnosis.safe.ui.base.BaseFragment
+import io.gnosis.safe.ui.base.BaseViewBindingFragment
 import io.gnosis.safe.ui.base.BaseStateViewModel
 import pm.gnosis.svalinn.common.utils.snackbar
 import pm.gnosis.svalinn.common.utils.visible
 import timber.log.Timber
 import javax.inject.Inject
 
-class CoinsFragment : BaseFragment<FragmentCoinsBinding>() {
+class CoinsFragment : BaseViewBindingFragment<FragmentCoinsBinding>() {
 
     @Inject
     lateinit var viewModel: CoinsViewModel

--- a/app/src/main/java/io/gnosis/safe/ui/safe/balances/coins/CoinsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/balances/coins/CoinsFragment.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import io.gnosis.safe.R
+import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentCoinsBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.ui.base.BaseFragment
@@ -23,6 +24,8 @@ class CoinsFragment : BaseFragment<FragmentCoinsBinding>() {
     lateinit var viewModel: CoinsViewModel
 
     private val adapter = CoinBalanceAdapter()
+
+    override fun screenId() = ScreenId.BALANCES_COINS
 
     override fun inject(component: ViewComponent) {
         component.inject(this)

--- a/app/src/main/java/io/gnosis/safe/ui/safe/balances/coins/CoinsViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/balances/coins/CoinsViewModel.kt
@@ -26,8 +26,12 @@ class CoinsViewModel
     fun load(refreshing: Boolean = false) {
         safeLaunch {
             updateState { CoinsState(loading = !refreshing, refreshing = refreshing, viewAction = null) }
-            val balances = tokenRepository.loadBalanceOf(safeRepository.getActiveSafe()!!.address)
-            updateState { CoinsState(loading = false, refreshing = false, viewAction = UpdateBalances(balances)) }
+            val activeSafe = safeRepository.getActiveSafe()
+            activeSafe?.let {
+                val balances = tokenRepository.loadBalanceOf(safeRepository.getActiveSafe()!!.address)
+                updateState { CoinsState(loading = false, refreshing = false, viewAction = UpdateBalances(balances)) }
+            }
+
         }
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/safe/balances/coins/CoinsViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/balances/coins/CoinsViewModel.kt
@@ -26,12 +26,8 @@ class CoinsViewModel
     fun load(refreshing: Boolean = false) {
         safeLaunch {
             updateState { CoinsState(loading = !refreshing, refreshing = refreshing, viewAction = null) }
-            val activeSafe = safeRepository.getActiveSafe()
-            activeSafe?.let {
-                val balances = tokenRepository.loadBalanceOf(safeRepository.getActiveSafe()!!.address)
-                updateState { CoinsState(loading = false, refreshing = false, viewAction = UpdateBalances(balances)) }
-            }
-
+            val balances = tokenRepository.loadBalanceOf(safeRepository.getActiveSafe()!!.address)
+            updateState { CoinsState(loading = false, refreshing = false, viewAction = UpdateBalances(balances)) }
         }
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/safe/balances/collectibles/CollectiblesFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/balances/collectibles/CollectiblesFragment.kt
@@ -5,9 +5,9 @@ import android.view.ViewGroup
 import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentCollectiblesBinding
 import io.gnosis.safe.di.components.ViewComponent
-import io.gnosis.safe.ui.base.BaseFragment
+import io.gnosis.safe.ui.base.BaseViewBindingFragment
 
-class CollectiblesFragment : BaseFragment<FragmentCollectiblesBinding>() {
+class CollectiblesFragment : BaseViewBindingFragment<FragmentCollectiblesBinding>() {
 
     override fun screenId() = ScreenId.BALANCES_COLLECTIBLES
 

--- a/app/src/main/java/io/gnosis/safe/ui/safe/balances/collectibles/CollectiblesFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/balances/collectibles/CollectiblesFragment.kt
@@ -2,11 +2,14 @@ package io.gnosis.safe.ui.safe.balances.collectibles
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentCollectiblesBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.ui.base.BaseFragment
 
 class CollectiblesFragment : BaseFragment<FragmentCollectiblesBinding>() {
+
+    override fun screenId() = ScreenId.BALANCES_COLLECTIBLES
 
     override fun inject(component: ViewComponent) {
         component.inject(this)

--- a/app/src/main/java/io/gnosis/safe/ui/safe/empty/NoSafeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/empty/NoSafeFragment.kt
@@ -9,10 +9,10 @@ import io.gnosis.safe.R
 import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentNoSafesBinding
 import io.gnosis.safe.di.components.ViewComponent
-import io.gnosis.safe.ui.base.BaseFragment
+import io.gnosis.safe.ui.base.BaseViewBindingFragment
 import pm.gnosis.svalinn.common.utils.withArgs
 
-class NoSafeFragment : BaseFragment<FragmentNoSafesBinding>() {
+class NoSafeFragment : BaseViewBindingFragment<FragmentNoSafesBinding>() {
 
     override fun screenId() = when(requireArguments()[ARGS_POSITION] as Position) {
         Position.BALANCES -> ScreenId.BALANCES_NO_SAFE

--- a/app/src/main/java/io/gnosis/safe/ui/safe/empty/NoSafeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/empty/NoSafeFragment.kt
@@ -6,11 +6,19 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.navigation.fragment.findNavController
 import io.gnosis.safe.R
+import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentNoSafesBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.ui.base.BaseFragment
+import pm.gnosis.svalinn.common.utils.withArgs
 
 class NoSafeFragment : BaseFragment<FragmentNoSafesBinding>() {
+
+    override fun screenId() = when(requireArguments()[ARGS_POSITION] as Position) {
+        Position.BALANCES -> ScreenId.BALANCES_NO_SAFE
+        Position.TRANSACTIONS -> ScreenId.TRANSACTIONS_NO_SAFE
+        Position.SETTINGS -> ScreenId.SETTINGS_SAFE_NO_SAFE
+    }
 
     override fun inject(component: ViewComponent) {}
 
@@ -25,10 +33,20 @@ class NoSafeFragment : BaseFragment<FragmentNoSafesBinding>() {
         }
     }
 
+    enum class Position {
+        BALANCES,
+        TRANSACTIONS,
+        SETTINGS
+    }
+
     companion object {
 
-        fun newInstance(): NoSafeFragment {
-           return NoSafeFragment()
+        private const val ARGS_POSITION = "args.serializable.position"
+
+        fun newInstance(position: Position): NoSafeFragment {
+           return NoSafeFragment().withArgs(Bundle().apply {
+               putSerializable(ARGS_POSITION, position)
+           }) as NoSafeFragment
         }
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/safe/selection/SafeSelectionDialog.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/selection/SafeSelectionDialog.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
+import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.DialogSafeSelectionBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.ui.base.BaseBottomSheetDialogFragment
@@ -35,6 +36,8 @@ class SafeSelectionDialog : BaseBottomSheetDialogFragment<DialogSafeSelectionBin
         super.onDetach()
         navHandler = null
     }
+
+    override fun screenId() = ScreenId.SAFE_SELECT
 
     override fun inject(component: ViewComponent) {
         component.inject(this)

--- a/app/src/main/java/io/gnosis/safe/ui/safe/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/settings/SettingsFragment.kt
@@ -93,7 +93,7 @@ class SettingsPagerAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) 
 
     override fun createFragment(position: Int): Fragment =
         when (Tabs.values()[position]) {
-            Tabs.SAFE -> if (noActiveSafe) NoSafeFragment.newInstance() else SafeSettingsFragment.newInstance()
+            Tabs.SAFE -> if (noActiveSafe) NoSafeFragment.newInstance(NoSafeFragment.Position.SETTINGS) else SafeSettingsFragment.newInstance()
             Tabs.APP -> AppSettingsFragment.newInstance()
         }
 
@@ -103,7 +103,6 @@ class SettingsPagerAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) 
             Tabs.APP -> Items.APP.value
         }
     }
-
 
     override fun containsItem(itemId: Long): Boolean {
         return when (itemId) {

--- a/app/src/main/java/io/gnosis/safe/ui/safe/settings/app/AdvancedAppSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/settings/app/AdvancedAppSettingsFragment.kt
@@ -10,6 +10,7 @@ import androidx.navigation.fragment.findNavController
 import io.gnosis.data.repositories.EnsRepository
 import io.gnosis.safe.BuildConfig
 import io.gnosis.safe.R
+import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentSettingsAppAdvancedBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.ui.base.BaseFragment
@@ -18,6 +19,8 @@ import pm.gnosis.svalinn.common.utils.openUrl
 import pm.gnosis.utils.asEthereumAddressString
 
 class AdvancedAppSettingsFragment : BaseFragment<FragmentSettingsAppAdvancedBinding>() {
+
+    override fun screenId() = ScreenId.SETTINGS_APP_ADVANCED
 
     override fun inject(component: ViewComponent) {
         component.inject(this)

--- a/app/src/main/java/io/gnosis/safe/ui/safe/settings/app/AdvancedAppSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/settings/app/AdvancedAppSettingsFragment.kt
@@ -13,12 +13,12 @@ import io.gnosis.safe.R
 import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentSettingsAppAdvancedBinding
 import io.gnosis.safe.di.components.ViewComponent
-import io.gnosis.safe.ui.base.BaseFragment
+import io.gnosis.safe.ui.base.BaseViewBindingFragment
 import io.gnosis.safe.utils.formatEthAddress
 import pm.gnosis.svalinn.common.utils.openUrl
 import pm.gnosis.utils.asEthereumAddressString
 
-class AdvancedAppSettingsFragment : BaseFragment<FragmentSettingsAppAdvancedBinding>() {
+class AdvancedAppSettingsFragment : BaseViewBindingFragment<FragmentSettingsAppAdvancedBinding>() {
 
     override fun screenId() = ScreenId.SETTINGS_APP_ADVANCED
 

--- a/app/src/main/java/io/gnosis/safe/ui/safe/settings/app/AppSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/settings/app/AppSettingsFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.navigation.fragment.findNavController
 import io.gnosis.safe.BuildConfig
 import io.gnosis.safe.R
+import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentSettingsAppBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.ui.base.BaseFragment
@@ -14,6 +15,8 @@ import io.gnosis.safe.ui.safe.settings.SettingsFragmentDirections
 import pm.gnosis.svalinn.common.utils.openUrl
 
 class AppSettingsFragment: BaseFragment<FragmentSettingsAppBinding>() {
+
+    override fun screenId() = ScreenId.SETTINGS_APP
 
     override fun inject(component: ViewComponent) {}
 

--- a/app/src/main/java/io/gnosis/safe/ui/safe/settings/app/AppSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/settings/app/AppSettingsFragment.kt
@@ -10,11 +10,11 @@ import io.gnosis.safe.R
 import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentSettingsAppBinding
 import io.gnosis.safe.di.components.ViewComponent
-import io.gnosis.safe.ui.base.BaseFragment
+import io.gnosis.safe.ui.base.BaseViewBindingFragment
 import io.gnosis.safe.ui.safe.settings.SettingsFragmentDirections
 import pm.gnosis.svalinn.common.utils.openUrl
 
-class AppSettingsFragment: BaseFragment<FragmentSettingsAppBinding>() {
+class AppSettingsFragment: BaseViewBindingFragment<FragmentSettingsAppBinding>() {
 
     override fun screenId() = ScreenId.SETTINGS_APP
 

--- a/app/src/main/java/io/gnosis/safe/ui/safe/settings/app/GetInTouchFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/settings/app/GetInTouchFragment.kt
@@ -11,6 +11,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
 import io.gnosis.safe.R
+import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentGetInTouchBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.ui.base.BaseFragment
@@ -19,6 +20,8 @@ import pm.gnosis.svalinn.common.utils.snackbar
 import timber.log.Timber
 
 class GetInTouchFragment : BaseFragment<FragmentGetInTouchBinding>() {
+
+    override fun screenId() = ScreenId.SETTINGS_GET_IN_TOUCH
 
     override fun inject(component: ViewComponent) {
         component.inject(this)

--- a/app/src/main/java/io/gnosis/safe/ui/safe/settings/app/GetInTouchFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/settings/app/GetInTouchFragment.kt
@@ -14,12 +14,12 @@ import io.gnosis.safe.R
 import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentGetInTouchBinding
 import io.gnosis.safe.di.components.ViewComponent
-import io.gnosis.safe.ui.base.BaseFragment
+import io.gnosis.safe.ui.base.BaseViewBindingFragment
 import pm.gnosis.svalinn.common.utils.openUrl
 import pm.gnosis.svalinn.common.utils.snackbar
 import timber.log.Timber
 
-class GetInTouchFragment : BaseFragment<FragmentGetInTouchBinding>() {
+class GetInTouchFragment : BaseViewBindingFragment<FragmentGetInTouchBinding>() {
 
     override fun screenId() = ScreenId.SETTINGS_GET_IN_TOUCH
 

--- a/app/src/main/java/io/gnosis/safe/ui/safe/settings/safe/SafeSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/settings/safe/SafeSettingsFragment.kt
@@ -7,10 +7,10 @@ import android.view.ViewGroup
 import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentSettingsSafeBinding
 import io.gnosis.safe.di.components.ViewComponent
-import io.gnosis.safe.ui.base.BaseFragment
+import io.gnosis.safe.ui.base.BaseViewBindingFragment
 import javax.inject.Inject
 
-class SafeSettingsFragment : BaseFragment<FragmentSettingsSafeBinding>() {
+class SafeSettingsFragment : BaseViewBindingFragment<FragmentSettingsSafeBinding>() {
 
     override fun screenId() = ScreenId.SETTINGS_SAFE
 

--- a/app/src/main/java/io/gnosis/safe/ui/safe/settings/safe/SafeSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/settings/safe/SafeSettingsFragment.kt
@@ -4,12 +4,15 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentSettingsSafeBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.ui.base.BaseFragment
 import javax.inject.Inject
 
 class SafeSettingsFragment : BaseFragment<FragmentSettingsSafeBinding>() {
+
+    override fun screenId() = ScreenId.SETTINGS_SAFE
 
     @Inject
     lateinit var viewModel: SafeSettingsViewModel

--- a/app/src/main/java/io/gnosis/safe/ui/safe/terms/TermsBottomSheetDialog.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/terms/TermsBottomSheetDialog.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import io.gnosis.safe.R
+import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.BottomSheetTermsAndConditionsBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.ui.base.BaseBottomSheetDialogFragment
@@ -15,6 +16,7 @@ import pm.gnosis.svalinn.common.utils.appendText
 import pm.gnosis.svalinn.common.utils.openUrl
 
 class TermsBottomSheetDialog : BaseBottomSheetDialogFragment<BottomSheetTermsAndConditionsBinding>() {
+
     lateinit var onAgreeClickListener: () -> Unit
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -41,6 +43,8 @@ class TermsBottomSheetDialog : BaseBottomSheetDialogFragment<BottomSheetTermsAnd
     }
 
     override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) = BottomSheetTermsAndConditionsBinding.inflate(layoutInflater)
+
+    override fun screenId() = ScreenId.LAUNCH_TERMS
 
     override fun inject(viewComponent: ViewComponent) {
         viewComponent.inject(this)

--- a/app/src/main/java/io/gnosis/safe/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/splash/SplashActivity.kt
@@ -2,6 +2,7 @@ package io.gnosis.safe.ui.splash
 
 import android.os.Bundle
 import androidx.lifecycle.Observer
+import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.ActivitySplashBinding
 import io.gnosis.safe.ui.base.BaseActivity
 import io.gnosis.safe.ui.base.BaseStateViewModel.ViewAction
@@ -15,6 +16,9 @@ class SplashActivity : BaseActivity() {
 
     private val binding by lazy { ActivitySplashBinding.inflate(layoutInflater) }
     private val termsBottomSheetDialog = TermsBottomSheetDialog()
+
+    //TODO: split splash and get started screen
+    override fun screenId() = ScreenId.LAUNCH
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/io/gnosis/safe/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/splash/SplashActivity.kt
@@ -17,7 +17,6 @@ class SplashActivity : BaseActivity() {
     private val binding by lazy { ActivitySplashBinding.inflate(layoutInflater) }
     private val termsBottomSheetDialog = TermsBottomSheetDialog()
 
-    //TODO: split splash and get started screen
     override fun screenId() = ScreenId.LAUNCH
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsFragment.kt
@@ -5,10 +5,10 @@ import android.view.ViewGroup
 import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentTransactionsBinding
 import io.gnosis.safe.di.components.ViewComponent
-import io.gnosis.safe.ui.base.BaseFragment
+import io.gnosis.safe.ui.base.BaseViewBindingFragment
 import javax.inject.Inject
 
-class TransactionsFragment : BaseFragment<FragmentTransactionsBinding>() {
+class TransactionsFragment : BaseViewBindingFragment<FragmentTransactionsBinding>() {
 
     override fun screenId() = ScreenId.TRANSACTIONS
 

--- a/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsFragment.kt
@@ -2,12 +2,15 @@ package io.gnosis.safe.ui.transaction
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentTransactionsBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.ui.base.BaseFragment
 import javax.inject.Inject
 
 class TransactionsFragment : BaseFragment<FragmentTransactionsBinding>() {
+
+    override fun screenId() = ScreenId.TRANSACTIONS
 
     @Inject
     lateinit var viewModel: TransactionsViewModel


### PR DESCRIPTION
Closes #599 

Changes proposed in this pull request:
- Manually track screens with firebase analytics
- Split BaseFragment into BaseFragment and BaseViewBindingFragment
- Use BaseFragment to track screen id for screen fragments
- Use BaseBottomSheetDialogFragment to track screen id of bottom sheet dialogs
- Use BaseActivity to track screen id for screens represented by activities outside of the main nav graph


@gnosis/mobile-devs
