### PR TITLE
Enter safe screen design compliant

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeFragment.kt
@@ -86,6 +86,7 @@ class AddSafeFragment : BaseViewBindingFragment<FragmentAddSafeBinding>() {
 
     private fun updateAddress(address: Solidity.Address) {
         with(binding) {
+            nextButton.isEnabled = true
             addSafeAddressInputLayout.isErrorEnabled = false
             addSafeAddressInputEntry.setText(address.asEthereumAddressString())
         }

--- a/app/src/main/res/color/text_button_color.xml
+++ b/app/src/main/res/color/text_button_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/primary" android:state_enabled="true" />
+    <item android:color="@color/light_grey" android:state_enabled="false" />
+</selector>

--- a/app/src/main/res/drawable/ic_baseline_arrow_back_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_arrow_back_24.xml
@@ -1,0 +1,10 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_link_green_24dp.xml
+++ b/app/src/main/res/drawable/ic_link_green_24dp.xml
@@ -1,14 +1,15 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
-  <path
-      android:pathData="M20,20v-8c0,-0.552 0.448,-1 1,-1s1,0.448 1,1v8c0,1.105 -0.895,2 -2,2H4c-1.105,0 -2,-0.895 -2,-2V4c0,-1.105 0.895,-2 2,-2h8c0.552,0 1,0.448 1,1s-0.448,1 -1,1H4v16h16z"
-      android:fillColor="#008C73"
-      android:fillType="nonZero"/>
-  <path
-      android:pathData="M18.536,4H15.95c-0.553,0 -1,-0.448 -1,-1s0.447,-1 1,-1h5c0.276,0 0.526,0.112 0.707,0.293 0.18,0.18 0.293,0.43 0.293,0.707v5c0,0.552 -0.448,1 -1,1 -0.553,0 -1,-0.448 -1,-1V5.414l-9.243,9.243c-0.39,0.39 -1.024,0.39 -1.414,0 -0.39,-0.39 -0.39,-1.024 0,-1.414L18.536,4z"
-      android:fillColor="#008C73"
-      android:fillType="evenOdd"/>
+    <path
+        android:fillColor="#008C73"
+        android:fillType="nonZero"
+        android:pathData="M20,20v-8c0,-0.552 0.448,-1 1,-1s1,0.448 1,1v8c0,1.105 -0.895,2 -2,2H4c-1.105,0 -2,-0.895 -2,-2V4c0,-1.105 0.895,-2 2,-2h8c0.552,0 1,0.448 1,1s-0.448,1 -1,1H4v16h16z" />
+    <path
+        android:fillColor="#008C73"
+        android:fillType="evenOdd"
+        android:pathData="M18.536,4H15.95c-0.553,0 -1,-0.448 -1,-1s0.447,-1 1,-1h5c0.276,0 0.526,0.112 0.707,0.293 0.18,0.18 0.293,0.43 0.293,0.707v5c0,0.552 -0.448,1 -1,1 -0.553,0 -1,-0.448 -1,-1V5.414l-9.243,9.243c-0.39,0.39 -1.024,0.39 -1.414,0 -0.39,-0.39 -0.39,-1.024 0,-1.414L18.536,4z" />
 </vector>

--- a/app/src/main/res/layout/fragment_add_safe.xml
+++ b/app/src/main/res/layout/fragment_add_safe.xml
@@ -9,33 +9,33 @@
 
     <LinearLayout
         android:id="@+id/toolbar_layout"
-        android:layout_width="0dp"
-        android:layout_height="?android:actionBarSize"
+        style="@style/Toolbar"
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:padding="16dp"
-        app:elevation="4dp"
         app:layout_constraintBottom_toTopOf="@id/add_safe_label_top"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
+        <ImageButton
             android:id="@+id/back_button"
-            style="@style/TextButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
             android:layout_weight="0"
-            android:drawableStart="@drawable/ic_keyboard_arrow_left_black_24dp"
+            android:background="@android:color/transparent"
             android:gravity="center_vertical"
-            android:text="@string/back" />
+            android:src="@drawable/ic_baseline_arrow_back_24" />
 
         <TextView
             android:id="@+id/title"
+            style="@style/ToolbarTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
             android:layout_weight="1"
-            android:gravity="center_horizontal"
+            android:gravity="start"
             android:text="@string/load_safe_multisig" />
 
         <TextView
@@ -56,6 +56,7 @@
 
     <TextView
         android:id="@+id/add_safe_label_top"
+        style="@style/TextDark.Bold"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="center"

--- a/app/src/main/res/layout/fragment_add_safe.xml
+++ b/app/src/main/res/layout/fragment_add_safe.xml
@@ -44,6 +44,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="0"
+            android:enabled="false"
             android:text="@string/next" />
     </LinearLayout>
 
@@ -60,7 +61,9 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="center"
-        android:padding="16dp"
+        android:paddingHorizontal="16dp"
+        android:paddingTop="28dp"
+        android:paddingBottom="22dp"
         android:text="@string/add_safe_label_top"
         app:layout_constraintBottom_toTopOf="@id/add_safe_address_input_layout"
         app:layout_constraintEnd_toEndOf="parent"
@@ -73,7 +76,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_margin="16dp"
-        android:hint="@string/address"
+        android:hint="@string/enter_safe_address"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/add_safe_label_top">
@@ -99,17 +102,29 @@
     </com.google.android.material.textfield.TextInputLayout>
 
     <TextView
-        android:id="@+id/add_safe_label_bottom"
+        android:id="@+id/add_safe_label_bottom_line1"
+        style="@style/TextDark.Bold"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:autoLink="web"
-        android:breakStrategy="simple"
         android:gravity="center"
-        android:padding="16dp"
+        android:paddingTop="16dp"
         android:text="@string/add_safe_label_bottom"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/add_safe_address_input_layout" />
+
+    <TextView
+        android:id="@+id/add_safe_label_bottom_line2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:autoLink="web"
+        android:drawableEnd="@drawable/ic_link_green_24dp"
+        android:drawablePadding="4dp"
+        android:gravity="center"
+        android:text="@string/add_safe_label_link"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/add_safe_label_bottom_line1" />
 
     <ProgressBar
         android:id="@+id/progress"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,12 +5,13 @@
     <string name="load_safe_multisig">Load Safe Multisig</string>
     <string name="tab_title_coins">COINS</string>
     <string name="tab_title_collectibles">COLLECTIBLES</string>
-    <string name="address">Address</string>
+    <string name="enter_safe_address">Enter Safe Address</string>
     <string name="enter_name">Enter name</string>
     <string name="enter_safe_name_description">Choose a name for the Safe. The name is only stored locally and will not be shared with Gnosis or any third parties.</string>
     <string name="next">Next</string>
     <string name="add_safe_label_top">Enter your Safe Multisig address.</string>
-    <string name="add_safe_label_bottom">Don\'t have a Safe? Create one first at https://gnosis-safe.io</string>
+    <string name="add_safe_label_bottom">Don\'t have a Safe? Create one first at</string>
+    <string name="add_safe_label_link">https://gnosis-safe.io</string>
     <string name="back">Back</string>
     <string name="choose_input_method">Choose input method</string>
     <string name="address_input_ens">ENS name</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -29,7 +29,7 @@
     </style>
 
     <style name="TextButton">
-        <item name="android:textColor">@color/primary</item>
+        <item name="android:textColor">@color/text_button_color</item>
         <item name="android:drawableTint">@color/primary</item>
         <item name="android:foreground">@drawable/background_selectable</item>
         <item name="android:textAllCaps">true</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -32,6 +32,7 @@
         <item name="android:textColor">@color/primary</item>
         <item name="android:drawableTint">@color/primary</item>
         <item name="android:foreground">@drawable/background_selectable</item>
+        <item name="android:textAllCaps">true</item>
         <item name="android:fontFamily">sans-serif</item>
         <item name="android:textSize">16sp</item>
         <item name="android:textStyle">bold</item>


### PR DESCRIPTION
Changes proposed in this pull request:
- "NEXT" button is disabled upon entering the screen
- Added color state list for text buttons and made them all caps
- Adjusted font styles and margins to match that of the designs

| Before | After |
|-------|-------|
|![image](https://user-images.githubusercontent.com/246473/84641801-e037d080-aefb-11ea-86a4-fedb6c16c285.png)|![image](https://user-images.githubusercontent.com/246473/84641789-dada8600-aefb-11ea-9eb3-5bc57b878c91.png)|

@gnosis/mobile-devs
