### PR TITLE
Transaction status

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsViewModel.kt
@@ -19,7 +19,7 @@ class TransactionsViewModel
     fun load() {
         safeLaunch {
             val safeAddress = safeRepository.getActiveSafe()!!.address
-            val safeInfo = safeRepository.getSafeInfo(safeAddress)!!
+            val safeInfo = safeRepository.getSafeInfo(safeAddress)
             val transactions = transactionRepository.getTransactions(safeAddress, safeInfo)
             updateState {
                 TransactionsViewState(

--- a/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsViewModel.kt
@@ -19,7 +19,8 @@ class TransactionsViewModel
     fun load() {
         safeLaunch {
             val safeAddress = safeRepository.getActiveSafe()!!.address
-            val transactions = transactionRepository.getTransactions(safeAddress)
+            val safeInfo = safeRepository.getSafeInfo(safeAddress)!!
+            val transactions = transactionRepository.getTransactions(safeAddress, safeInfo)
             updateState {
                 TransactionsViewState(
                     isLoading = false,

--- a/app/src/test/java/io/gnosis/safe/ui/safe/settings/SafeSettingsViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/safe/settings/SafeSettingsViewModelTest.kt
@@ -1,6 +1,7 @@
 package io.gnosis.safe.ui.safe.settings
 
 import io.gnosis.data.models.Safe
+import io.gnosis.data.models.SafeInfo
 import io.gnosis.data.repositories.SafeRepository
 import io.gnosis.safe.*
 import io.gnosis.safe.ui.base.BaseStateViewModel
@@ -72,7 +73,7 @@ class SafeSettingsViewModelTest {
 
     @Test
     fun `removeSafe (two or more safes) - should remove safe and select next safe`() = runBlockingTest {
-        coEvery { safeRepository.getSafeInfo(any()) } returns null
+        coEvery { safeRepository.getSafeInfo(any()) } returns SafeInfo(SAFE_1.address, BigInteger.ONE, 2)
         coEvery { safeRepository.getActiveSafe() } returnsMany listOf(SAFE_1, SAFE_2)
         coEvery { safeRepository.activeSafeFlow() } returns flow {
             emit(SAFE_1)

--- a/data/src/main/java/io/gnosis/data/backend/dto/SafeInfoDto.kt
+++ b/data/src/main/java/io/gnosis/data/backend/dto/SafeInfoDto.kt
@@ -9,7 +9,7 @@ import java.math.BigInteger
 data class SafeInfoDto(
     @Json(name = "address") val address: Solidity.Address,
     @Json(name = "nonce") val nonce: BigInteger,
-    @Json(name = "threshold") val threshold: BigInteger,
+    @Json(name = "threshold") val threshold: Int,
     @Json(name = "owners") val owners: List<Solidity.Address>,
     @Json(name = "masterCopy") val masterCopy: Solidity.Address,
     @Json(name = "modules") val modules: List<Solidity.Address>,

--- a/data/src/main/java/io/gnosis/data/backend/dto/TransactionDto.kt
+++ b/data/src/main/java/io/gnosis/data/backend/dto/TransactionDto.kt
@@ -24,6 +24,8 @@ data class MultisigTransactionDto(
     val gasPrice: BigInteger,
     val refundReceiver: Solidity.Address? = null,
     val nonce: BigInteger,
+    val isExecuted: Boolean,
+    val isSuccessful: Boolean? = null,
     val executionDate: String? = null,
     val submissionDate: String? = null,
     val creationDate: String? = null,

--- a/data/src/main/java/io/gnosis/data/models/SafeInfo.kt
+++ b/data/src/main/java/io/gnosis/data/models/SafeInfo.kt
@@ -6,5 +6,5 @@ import java.math.BigInteger
 data class SafeInfo(
     val address: Solidity.Address,
     val nonce: BigInteger,
-    val threshold: BigInteger
+    val threshold: Int
 )

--- a/data/src/main/java/io/gnosis/data/models/Transaction.kt
+++ b/data/src/main/java/io/gnosis/data/models/Transaction.kt
@@ -6,7 +6,10 @@ import pm.gnosis.model.Solidity
 import java.math.BigInteger
 
 sealed class Transaction {
+    abstract val status: TransactionStatus
+
     data class Custom(
+        override val status: TransactionStatus,
         val nonce: BigInteger?,
         val address: Solidity.Address,
         val dataSize: Long,
@@ -15,12 +18,14 @@ sealed class Transaction {
     ) : Transaction()
 
     data class SettingsChange(
+        override val status: TransactionStatus,
         val dataDecoded: DataDecodedDto,
         val date: String?,
         val nonce: BigInteger
     ) : Transaction()
 
     data class Transfer(
+        override val status: TransactionStatus,
         val recipient: Solidity.Address,
         val sender: Solidity.Address,
         val value: BigInteger,
@@ -29,3 +34,11 @@ sealed class Transaction {
     ) : Transaction()
 }
 
+enum class TransactionStatus {
+    AwaitingConfirmation,
+    AwaitingExecution,
+    Cancelled,
+    Failed,
+    Success,
+    Pending // Not supported yet as these correspond to the ones issued from the device
+}

--- a/data/src/main/java/io/gnosis/data/repositories/SafeRepository.kt
+++ b/data/src/main/java/io/gnosis/data/repositories/SafeRepository.kt
@@ -71,7 +71,7 @@ class SafeRepository(
                 getSafeBy(address)
             }
 
-    suspend fun getSafeInfo(safeAddress: Solidity.Address): SafeInfo? =
+    suspend fun getSafeInfo(safeAddress: Solidity.Address): SafeInfo =
         transactionServiceApi.getSafeInfo(safeAddress.asEthereumAddressChecksumString()).let {
             SafeInfo(it.address, it.nonce, it.threshold)
         }

--- a/data/src/main/java/io/gnosis/data/repositories/TransactionRepository.kt
+++ b/data/src/main/java/io/gnosis/data/repositories/TransactionRepository.kt
@@ -191,6 +191,7 @@ class TransactionRepository(
         )
     }
 
+    // Pending not reachable yet
     private fun MultisigTransactionDto.status(safeInfo: SafeInfo): TransactionStatus =
         when {
             isExecuted && isSuccessful == true -> TransactionStatus.Success

--- a/data/src/main/java/io/gnosis/data/repositories/TransactionRepository.kt
+++ b/data/src/main/java/io/gnosis/data/repositories/TransactionRepository.kt
@@ -191,7 +191,7 @@ class TransactionRepository(
         )
     }
 
-    // Pending not reachable yet
+    // TODO Pending not reachable yet
     private fun MultisigTransactionDto.status(safeInfo: SafeInfo): TransactionStatus =
         when {
             isExecuted && isSuccessful == true -> TransactionStatus.Success

--- a/data/src/test/java/io/gnosis/data/repositories/SafeRepositoryTest.kt
+++ b/data/src/test/java/io/gnosis/data/repositories/SafeRepositoryTest.kt
@@ -267,7 +267,7 @@ class SafeRepositoryTest {
         val safeInfoDto = SafeInfoDto(
             Solidity.Address(BigInteger.ONE),
             BigInteger.TEN,
-            BigInteger.ONE,
+            1,
             listOf(Solidity.Address(BigInteger.ONE)),
             Solidity.Address(BigInteger.ONE),
             listOf(Solidity.Address(BigInteger.ONE)),

--- a/data/src/test/java/io/gnosis/data/repositories/TransactionRepositoryTest.kt
+++ b/data/src/test/java/io/gnosis/data/repositories/TransactionRepositoryTest.kt
@@ -25,13 +25,14 @@ class TransactionRepositoryTest {
     private val defaultFromAddress = "0x7cd310A8AeBf268bF78ea16C601F201ca81e84Cc".asEthereumAddress()!!
     private val defaultToAddress = "0x2134Bb3DE97813678daC21575E7A77a95079FC51".asEthereumAddress()!!
     private val defaultValue = BigInteger("230000000000000000")
+    private val defaultSafeInfo = SafeInfo(defaultSafeAddress, BigInteger.TEN, 10)
 
     @Test
     fun `getTransactions (api failure) should throw`() = runBlockingTest {
         val throwable = Throwable()
         coEvery { transactionServiceApi.loadTransactions(any()) } throws throwable
 
-        val actual = runCatching { transactionRepository.getTransactions(defaultSafeAddress) }
+        val actual = runCatching { transactionRepository.getTransactions(defaultSafeAddress, defaultSafeInfo) }
 
         with(actual) {
             assert(isFailure)
@@ -46,7 +47,7 @@ class TransactionRepositoryTest {
         val pagedResult = listOf(transactionDto)
         coEvery { transactionServiceApi.loadTransactions(any()) } returns Page(1, null, null, pagedResult)
 
-        val actual = transactionRepository.getTransactions(defaultSafeAddress)
+        val actual = transactionRepository.getTransactions(defaultSafeAddress, defaultSafeInfo)
 
         with(actual.results[0] as Transaction.Custom) {
             assertEquals(transactionDto.module, address)
@@ -62,7 +63,7 @@ class TransactionRepositoryTest {
         val pagedResult = listOf(transactionDto)
         coEvery { transactionServiceApi.loadTransactions(any()) } returns Page(1, null, null, pagedResult)
 
-        val actual = transactionRepository.getTransactions(defaultSafeAddress)
+        val actual = transactionRepository.getTransactions(defaultSafeAddress, defaultSafeInfo)
 
         coVerify { transactionServiceApi.loadTransactions(defaultSafeAddress.asEthereumAddressChecksumString()) }
         assertEquals(1, actual.results.size)
@@ -81,7 +82,7 @@ class TransactionRepositoryTest {
         val pagedResult = listOf(transactionDto)
         coEvery { transactionServiceApi.loadTransactions(any()) } returns Page(1, null, null, pagedResult)
 
-        val actual = transactionRepository.getTransactions(defaultSafeAddress)
+        val actual = transactionRepository.getTransactions(defaultSafeAddress, defaultSafeInfo)
 
         coVerify { transactionServiceApi.loadTransactions(defaultSafeAddress.asEthereumAddressChecksumString()) }
         assertEquals(1, actual.results.size)
@@ -107,7 +108,7 @@ class TransactionRepositoryTest {
         val pagedResult = listOf(transactionDto)
         coEvery { transactionServiceApi.loadTransactions(any()) } returns Page(1, null, null, pagedResult)
 
-        val actual = transactionRepository.getTransactions(defaultSafeAddress)
+        val actual = transactionRepository.getTransactions(defaultSafeAddress, defaultSafeInfo)
 
         coVerify { transactionServiceApi.loadTransactions(defaultSafeAddress.asEthereumAddressChecksumString()) }
         assertEquals("Expect one Transfer result", 1, actual.results.size)
@@ -137,7 +138,7 @@ class TransactionRepositoryTest {
         val pagedResult = listOf(transactionDto)
         coEvery { transactionServiceApi.loadTransactions(any()) } returns Page(1, null, null, pagedResult)
 
-        val actual = transactionRepository.getTransactions(defaultSafeAddress)
+        val actual = transactionRepository.getTransactions(defaultSafeAddress, defaultSafeInfo)
 
         coVerify { transactionServiceApi.loadTransactions(defaultSafeAddress.asEthereumAddressChecksumString()) }
         assertEquals("Expect one Transfer result", 1, actual.results.size)
@@ -160,7 +161,7 @@ class TransactionRepositoryTest {
         val pagedResult = listOf(transactionDto)
         coEvery { transactionServiceApi.loadTransactions(any()) } returns Page(1, null, null, pagedResult)
 
-        val actual = transactionRepository.getTransactions(defaultSafeAddress)
+        val actual = transactionRepository.getTransactions(defaultSafeAddress, defaultSafeInfo)
 
         coVerify { transactionServiceApi.loadTransactions(defaultSafeAddress.asEthereumAddressChecksumString()) }
         assertEquals(1, actual.results.size)
@@ -180,7 +181,7 @@ class TransactionRepositoryTest {
         val pagedResult = listOf(transactionDto)
         coEvery { transactionServiceApi.loadTransactions(any()) } returns Page(1, null, null, pagedResult)
 
-        val actual = transactionRepository.getTransactions(defaultSafeAddress)
+        val actual = transactionRepository.getTransactions(defaultSafeAddress, defaultSafeInfo)
 
         coVerify { transactionServiceApi.loadTransactions(defaultSafeAddress.asEthereumAddressChecksumString()) }
         assertEquals(1, actual.results.size)
@@ -200,7 +201,7 @@ class TransactionRepositoryTest {
         val pagedResult = listOf(transactionDto)
         coEvery { transactionServiceApi.loadTransactions(any()) } returns Page(1, null, null, pagedResult)
 
-        val actual = transactionRepository.getTransactions(defaultSafeAddress)
+        val actual = transactionRepository.getTransactions(defaultSafeAddress, defaultSafeInfo)
 
         coVerify { transactionServiceApi.loadTransactions(defaultSafeAddress.asEthereumAddressChecksumString()) }
         assertEquals(1, actual.results.size)
@@ -222,7 +223,7 @@ class TransactionRepositoryTest {
         val pagedResult = listOf(transactionDto)
         coEvery { transactionServiceApi.loadTransactions(any()) } returns Page(1, null, null, pagedResult)
 
-        val actual = transactionRepository.getTransactions(defaultSafeAddress)
+        val actual = transactionRepository.getTransactions(defaultSafeAddress, defaultSafeInfo)
 
         coVerify { transactionServiceApi.loadTransactions(defaultSafeAddress.asEthereumAddressChecksumString()) }
         assertEquals(3, actual.results.size)
@@ -256,7 +257,7 @@ class TransactionRepositoryTest {
         val pagedResult = listOf(transactionDto)
         coEvery { transactionServiceApi.loadTransactions(any()) } returns Page(1, null, null, pagedResult)
 
-        val actual = transactionRepository.getTransactions(defaultSafeAddress)
+        val actual = transactionRepository.getTransactions(defaultSafeAddress, defaultSafeInfo)
 
         coVerify { transactionServiceApi.loadTransactions(defaultSafeAddress.asEthereumAddressChecksumString()) }
         assertEquals(1, actual.results.size)
@@ -274,7 +275,7 @@ class TransactionRepositoryTest {
         val pagedResult = listOf(transactionDto)
         coEvery { transactionServiceApi.loadTransactions(any()) } returns Page(1, null, null, pagedResult)
 
-        val actual = transactionRepository.getTransactions(defaultSafeAddress)
+        val actual = transactionRepository.getTransactions(defaultSafeAddress, defaultSafeInfo)
 
         coVerify { transactionServiceApi.loadTransactions(defaultSafeAddress.asEthereumAddressChecksumString()) }
         assertEquals(1, actual.results.size)
@@ -293,7 +294,7 @@ class TransactionRepositoryTest {
             val pagedResult = listOf(transactionDto)
             coEvery { transactionServiceApi.loadTransactions(any()) } returns Page(1, null, null, pagedResult)
 
-            val actual = transactionRepository.getTransactions(defaultSafeAddress)
+            val actual = transactionRepository.getTransactions(defaultSafeAddress, defaultSafeInfo)
 
             coVerify { transactionServiceApi.loadTransactions(defaultSafeAddress.asEthereumAddressChecksumString()) }
             assertEquals(1, actual.results.size)
@@ -366,7 +367,8 @@ class TransactionRepositoryTest {
             gasPrice = BigInteger.ONE,
             transfers = transfers,
             contractInfo = contractInfoType?.let { ContractInfoDto(it) },
-            dataDecoded = dataDecodedDto
+            dataDecoded = dataDecodedDto,
+            isExecuted = true
         )
     }
 


### PR DESCRIPTION
Reference #665 .

Changes proposed in this pull request:
- Passing `SafeInfo` to `getTransaction` method
- Calculation of status for each transaction, module and ethereum transactions are always assumed as `Success`
- Unit tests 

@gnosis/mobile-devs
