### PR TITLE
Empty state to be shown only when a safe has no transactions

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/safe/SafeOverviewBase.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/SafeOverviewBase.kt
@@ -20,8 +20,6 @@ abstract class SafeOverviewBaseFragment<T> : BaseViewBindingFragment<T>() where 
     }
 
     abstract fun handleActiveSafe(safe: Safe?)
-
-    override fun screenId() = null
 }
 
 interface SafeOverviewNavigationHandler {

--- a/app/src/main/java/io/gnosis/safe/ui/safe/assets/AssetsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/assets/AssetsFragment.kt
@@ -69,6 +69,9 @@ class AssetsFragment : SafeOverviewBaseFragment<FragmentSafeBalancesBinding>() {
     override fun handleActiveSafe(safe: Safe?) {
         navHandler?.setSafeData(safe)
     }
+
+    override fun screenId() = null
+
 }
 
 class BalancesPagerAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) {

--- a/app/src/main/java/io/gnosis/safe/ui/safe/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/settings/SettingsFragment.kt
@@ -71,6 +71,8 @@ class SettingsFragment : SafeOverviewBaseFragment<FragmentSettingsBinding>() {
     override fun handleActiveSafe(safe: Safe?) {
         navHandler?.setSafeData(safe)
     }
+
+    override fun screenId() = null
 }
 
 class SettingsPagerAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) {

--- a/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsFragment.kt
@@ -28,6 +28,7 @@ class TransactionsFragment : SafeOverviewBaseFragment<FragmentTransactionsBindin
     lateinit var viewModel: TransactionsViewModel
 
     private val adapter by lazy { MultiViewHolderAdapter(TransactionViewHolderFactory()) }
+    private val noSafeFragment by lazy { NoSafeFragment.newInstance(NoSafeFragment.Position.TRANSACTIONS) }
 
     override fun inject(component: ViewComponent) {
         component.inject(this)
@@ -66,9 +67,8 @@ class TransactionsFragment : SafeOverviewBaseFragment<FragmentTransactionsBindin
             labelEmpty.visible(false)
             noSafe.apply {
                 childFragmentManager.beginTransaction()
-                    .add(noSafe.id, NoSafeFragment.newInstance(NoSafeFragment.Position.TRANSACTIONS))
-                    .commit()
-                visible(true)
+                    .replace(noSafe.id, noSafeFragment)
+                    .commitNow()
             }
         }
     }
@@ -79,7 +79,6 @@ class TransactionsFragment : SafeOverviewBaseFragment<FragmentTransactionsBindin
             transactions.visible(true)
             imageEmpty.visible(false)
             labelEmpty.visible(false)
-            noSafe.visible(false)
         }
         adapter.updateData(Adapter.Data(entries = newTransactions))
     }
@@ -90,11 +89,13 @@ class TransactionsFragment : SafeOverviewBaseFragment<FragmentTransactionsBindin
             progress.visible(false)
             imageEmpty.visible(true)
             labelEmpty.visible(true)
-            noSafe.visible(false)
         }
     }
 
     override fun handleActiveSafe(safe: Safe?) {
         navHandler?.setSafeData(safe)
+        if (safe != null) {
+            childFragmentManager.beginTransaction().remove(noSafeFragment).commitNow()
+        }
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
+import io.gnosis.data.models.Safe
 import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentTransactionsBinding
 import io.gnosis.safe.di.components.ViewComponent
@@ -14,11 +15,12 @@ import io.gnosis.safe.ui.base.Adapter
 import io.gnosis.safe.ui.base.BaseStateViewModel
 import io.gnosis.safe.ui.base.BaseViewBindingFragment
 import io.gnosis.safe.ui.base.MultiViewHolderAdapter
+import io.gnosis.safe.ui.safe.SafeOverviewBaseFragment
 import io.gnosis.safe.ui.safe.empty.NoSafeFragment
 import pm.gnosis.svalinn.common.utils.visible
 import javax.inject.Inject
 
-class TransactionsFragment : BaseViewBindingFragment<FragmentTransactionsBinding>() {
+class TransactionsFragment : SafeOverviewBaseFragment<FragmentTransactionsBinding>() {
 
     override fun screenId() = ScreenId.TRANSACTIONS
 
@@ -48,6 +50,7 @@ class TransactionsFragment : BaseViewBindingFragment<FragmentTransactionsBinding
                     is LoadTransactions -> loadTransactions(viewAction.newTransactions)
                     is NoSafeSelected -> loadNoSafeFragment()
                     is BaseStateViewModel.ViewAction.ShowEmptyState -> showEmptyState()
+                    is ActiveSafeChanged -> handleActiveSafe(viewAction.activeSafe)
                     else -> binding.progress.visible(state.isLoading)
                 }
             }
@@ -89,5 +92,9 @@ class TransactionsFragment : BaseViewBindingFragment<FragmentTransactionsBinding
             labelEmpty.visible(true)
             noSafe.visible(false)
         }
+    }
+
+    override fun handleActiveSafe(safe: Safe?) {
+        navHandler?.setSafeData(safe)
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsFragment.kt
@@ -14,7 +14,7 @@ import io.gnosis.safe.ui.base.Adapter
 import io.gnosis.safe.ui.base.BaseStateViewModel
 import io.gnosis.safe.ui.base.BaseViewBindingFragment
 import io.gnosis.safe.ui.base.MultiViewHolderAdapter
-import kotlinx.android.synthetic.main.fragment_transactions.*
+import io.gnosis.safe.ui.safe.empty.NoSafeFragment
 import pm.gnosis.svalinn.common.utils.visible
 import javax.inject.Inject
 
@@ -46,6 +46,7 @@ class TransactionsFragment : BaseViewBindingFragment<FragmentTransactionsBinding
             state.viewAction.let { viewAction ->
                 when (viewAction) {
                     is LoadTransactions -> loadTransactions(viewAction.newTransactions)
+                    is NoSafeSelected -> loadNoSafeFragment()
                     is BaseStateViewModel.ViewAction.ShowEmptyState -> showEmptyState()
                     else -> binding.progress.visible(state.isLoading)
                 }
@@ -54,12 +55,28 @@ class TransactionsFragment : BaseViewBindingFragment<FragmentTransactionsBinding
         viewModel.load()
     }
 
+    private fun loadNoSafeFragment() {
+        with(binding) {
+            transactions.visible(false)
+            progress.visible(false)
+            imageEmpty.visible(false)
+            labelEmpty.visible(false)
+            noSafe.apply {
+                childFragmentManager.beginTransaction()
+                    .add(noSafe.id, NoSafeFragment.newInstance(NoSafeFragment.Position.TRANSACTIONS))
+                    .commit()
+                visible(true)
+            }
+        }
+    }
+
     private fun loadTransactions(newTransactions: List<TransactionView>) {
         with(binding) {
             progress.visible(false)
             transactions.visible(true)
             imageEmpty.visible(false)
             labelEmpty.visible(false)
+            noSafe.visible(false)
         }
         adapter.updateData(Adapter.Data(entries = newTransactions))
     }
@@ -70,6 +87,7 @@ class TransactionsFragment : BaseViewBindingFragment<FragmentTransactionsBinding
             progress.visible(false)
             imageEmpty.visible(true)
             labelEmpty.visible(true)
+            noSafe.visible(false)
         }
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsViewModel.kt
@@ -2,6 +2,7 @@ package io.gnosis.safe.ui.transaction
 
 import androidx.annotation.StringRes
 import io.gnosis.data.models.Page
+import io.gnosis.data.models.Safe
 import io.gnosis.data.models.Transaction
 import io.gnosis.data.models.TransactionStatus
 import io.gnosis.data.repositories.SafeRepository
@@ -30,10 +31,10 @@ class TransactionsViewModel
 
     fun load() {
         safeLaunch {
-            val safeAddress = safeRepository.getActiveSafe()?.address
+            val safeAddress = safeRepository.getActiveSafe()
+            updateState { TransactionsViewState(isLoading = true, viewAction = ActiveSafeChanged(safeAddress)) }
             if (safeAddress != null) {
-                updateState { TransactionsViewState(null, isLoading = true) }
-                loadTransactions(safeAddress)
+                loadTransactions(safeAddress.address)
             } else {
                 updateState(forceViewAction = true) { TransactionsViewState(isLoading = false, viewAction = NoSafeSelected) }
             }
@@ -117,6 +118,10 @@ data class TransactionsViewState(
 
 data class LoadTransactions(
     val newTransactions: List<TransactionView>
+) : BaseStateViewModel.ViewAction
+
+data class ActiveSafeChanged(
+    val activeSafe: Safe?
 ) : BaseStateViewModel.ViewAction
 
 object NoSafeSelected : BaseStateViewModel.ViewAction

--- a/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transaction/TransactionsViewModel.kt
@@ -32,9 +32,10 @@ class TransactionsViewModel
         safeLaunch {
             val safeAddress = safeRepository.getActiveSafe()?.address
             if (safeAddress != null) {
+                updateState { TransactionsViewState(null, isLoading = true) }
                 loadTransactions(safeAddress)
             } else {
-                updateState(forceViewAction = true) { TransactionsViewState(isLoading = false, viewAction = ViewAction.ShowEmptyState) }
+                updateState(forceViewAction = true) { TransactionsViewState(isLoading = false, viewAction = NoSafeSelected) }
             }
         }
     }
@@ -117,3 +118,5 @@ data class TransactionsViewState(
 data class LoadTransactions(
     val newTransactions: List<TransactionView>
 ) : BaseStateViewModel.ViewAction
+
+object NoSafeSelected : BaseStateViewModel.ViewAction

--- a/app/src/main/res/layout/fragment_transactions.xml
+++ b/app/src/main/res/layout/fragment_transactions.xml
@@ -55,7 +55,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="56dp"
-        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_transactions.xml
+++ b/app/src/main/res/layout/fragment_transactions.xml
@@ -49,4 +49,15 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/image_empty" />
+
+    <FrameLayout
+        android:id="@+id/no_safe"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="56dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/io/gnosis/safe/ui/transaction/TransactionsViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transaction/TransactionsViewModelTest.kt
@@ -124,7 +124,7 @@ class TransactionsViewModelTest {
         }
         with(testObserver.values()[1]) {
             assertEquals(true, isLoading)
-            assertEquals(null, viewAction)
+            assertEquals(ActiveSafeChanged(safe), viewAction)
         }
         with(testObserver.values()[2]) {
             assertEquals(false, isLoading)
@@ -160,7 +160,7 @@ class TransactionsViewModelTest {
         }
         with(testObserver.values()[1]) {
             assertEquals(true, isLoading)
-            assertEquals(null, viewAction)
+            assertEquals(ActiveSafeChanged(safe), viewAction)
         }
         with(testObserver.values()[2]) {
             assertEquals(false, isLoading)

--- a/app/src/test/java/io/gnosis/safe/ui/transaction/TransactionsViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transaction/TransactionsViewModelTest.kt
@@ -117,12 +117,16 @@ class TransactionsViewModelTest {
         transactionsViewModel.state.observeForever(testObserver)
         transactionsViewModel.load()
 
-        testObserver.assertValueCount(2)
+        testObserver.assertValueCount(3)
         with(testObserver.values()[0]) {
             assertEquals(true, isLoading)
             assertEquals(null, viewAction)
         }
         with(testObserver.values()[1]) {
+            assertEquals(true, isLoading)
+            assertEquals(null, viewAction)
+        }
+        with(testObserver.values()[2]) {
             assertEquals(false, isLoading)
             assertEquals(BaseStateViewModel.ViewAction.ShowEmptyState, viewAction)
         }
@@ -149,12 +153,16 @@ class TransactionsViewModelTest {
         transactionsViewModel.state.observeForever(testObserver)
         transactionsViewModel.load()
 
-        testObserver.assertValueCount(2)
+        testObserver.assertValueCount(3)
         with(testObserver.values()[0]) {
             assertEquals(true, isLoading)
             assertEquals(null, viewAction)
         }
         with(testObserver.values()[1]) {
+            assertEquals(true, isLoading)
+            assertEquals(null, viewAction)
+        }
+        with(testObserver.values()[2]) {
             assertEquals(false, isLoading)
             assertEquals(true, viewAction is LoadTransactions)
         }


### PR DESCRIPTION
Reference #684 and #687 .

Changes proposed in this pull request:
- Empty state is only shown if the loaded safe has no transactions

Remaining issues: the tool bar is not updated on safe change because it is not possible to inherit from `SafeOverviewBaseFragment` without losing tracking information. Not sure what to do about that.

@gnosis/mobile-devs
