### PR TITLE
Reset share dialog ui to prevent showing wrong safe's details

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/safe/share/ShareSafeDialog.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/share/ShareSafeDialog.kt
@@ -50,8 +50,13 @@ class ShareSafeDialog : BaseViewBindingDialogFragment<DialogShareSafeBinding>() 
                 is BaseStateViewModel.ViewAction.ShowError -> showError(viewAction.error)
             }
         })
-        viewModel.load()
         dismissBehaviour()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        resetUI()
+        viewModel.load()
     }
 
     private fun dismissBehaviour() {
@@ -102,5 +107,14 @@ class ShareSafeDialog : BaseViewBindingDialogFragment<DialogShareSafeBinding>() 
         }
         Timber.e(error)
         snackbar(requireView(), Snackbar.LENGTH_LONG, R.string.error_invalid_safe)
+    }
+
+    private fun resetUI() {
+        with(binding) {
+            blockies.setAddress(null)
+            safeLocalName.text = ""
+            progress.visible(true)
+            safeFields.visible(false)
+        }
     }
 }


### PR DESCRIPTION
Share dialog fragment is reused in navigation. When switching safes share dialog would have old safe details. Without resetting, those details will shortly appear before layout updates with active safe data.