### PR TITLE
Change the release group on firebase.

### DIFF
--- a/.buildkite/deployment.yml
+++ b/.buildkite/deployment.yml
@@ -7,12 +7,12 @@ steps:
   - label: 'Upload App Distribution Rinkeby'
     if: build.branch == "master" || build.branch =~ /^v[0-9]+.*/
     key: 'upload-firebase-rinkeby'
-    command: 'ci/upload_app_distribution.sh rinkeby-release rinkeby'
+    command: 'ci/upload_app_distribution.sh rinkeby-release-internal rinkeby'
 
   - label: 'Upload App Distribution Mainnet'
     if: build.branch == "master" || build.branch =~ /^v[0-9]+.*/
     key: 'upload-firebase-mainnet'
-    command: 'ci/upload_app_distribution.sh mainnet-release release'
+    command: 'ci/upload_app_distribution.sh mainnet-release-internal release'
 
   - label: 'Upload Github Release'
     if: build.branch =~ /^v[0-9]+.*/


### PR DESCRIPTION
This way any merge to master releases to `mainnet-release-internal` and `rinkeby-release-internal`. When we want to update external users we promote a build in https://console.firebase.google.com/project/safe-firebase-rinkeby/appdistribution/app/android:io.gnosis.safe.rinkeby/releases and https://console.firebase.google.com/project/safe-firebase-mainnet/appdistribution/app/android:io.gnosis.safe/releases respectively to the groups `mainnet-release` and `rinkeby-release`


@gnosis/mobile-devs
