### PR TITLE
Nonce missing in queued transfers

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
@@ -4,7 +4,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.res.ResourcesCompat
-import androidx.navigation.Navigation
 import androidx.viewbinding.ViewBinding
 import io.gnosis.safe.R
 import io.gnosis.safe.databinding.*
@@ -163,6 +162,8 @@ class SettingsChangeQueuedViewHolder(private val viewBinding: ItemTxQueuedSettin
             confirmations.setTextColor(ResourcesCompat.getColor(resources, viewTransfer.confirmationsTextColor, theme))
             confirmationsIcon.setImageDrawable(ResourcesCompat.getDrawable(resources, viewTransfer.confirmationsIcon, theme))
             confirmations.text = resources.getString(R.string.tx_list_confirmations, viewTransfer.confirmations, viewTransfer.threshold)
+
+            nonce.text = viewTransfer.nonce
         }
     }
 }
@@ -222,6 +223,8 @@ class ChangeMastercopyQueuedViewHolder(private val viewBinding: ItemTxQueuedChan
             version.visibility = viewTransfer.visibilityVersion
             ellipsizedAddress.visibility = viewTransfer.visibilityEllipsizedAddress
             moduleAddress.visibility = viewTransfer.visibilityModuleAddress
+
+            nonce.text = viewTransfer.nonce
         }
     }
 }
@@ -249,6 +252,8 @@ class CustomTransactionQueuedViewHolder(private val viewBinding: ItemTxQueuedTra
 
             blockies.setAddress(viewTransfer.address)
             ellipsizedAddress.text = viewTransfer.address.formatForTxList()
+
+            nonce.text = viewTransfer.nonce
         }
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
@@ -162,7 +162,6 @@ class SettingsChangeQueuedViewHolder(private val viewBinding: ItemTxQueuedSettin
             confirmations.setTextColor(ResourcesCompat.getColor(resources, viewTransfer.confirmationsTextColor, theme))
             confirmationsIcon.setImageDrawable(ResourcesCompat.getDrawable(resources, viewTransfer.confirmationsIcon, theme))
             confirmations.text = resources.getString(R.string.tx_list_confirmations, viewTransfer.confirmations, viewTransfer.threshold)
-
             nonce.text = viewTransfer.nonce
         }
     }
@@ -223,7 +222,6 @@ class ChangeMastercopyQueuedViewHolder(private val viewBinding: ItemTxQueuedChan
             version.visibility = viewTransfer.visibilityVersion
             ellipsizedAddress.visibility = viewTransfer.visibilityEllipsizedAddress
             moduleAddress.visibility = viewTransfer.visibilityModuleAddress
-
             nonce.text = viewTransfer.nonce
         }
     }
@@ -252,7 +250,6 @@ class CustomTransactionQueuedViewHolder(private val viewBinding: ItemTxQueuedTra
 
             blockies.setAddress(viewTransfer.address)
             ellipsizedAddress.text = viewTransfer.address.formatForTxList()
-
             nonce.text = viewTransfer.nonce
         }
     }


### PR DESCRIPTION
Regarding #714  .

Changes proposed in this pull request:
- Some bindings for queued txs were not setting the nonce

Before | After
------ | ------  
![Screenshot_20200729-123434](https://user-images.githubusercontent.com/246473/88790758-ed9dd700-d198-11ea-8d4f-884a88c3dbd6.png) | ![Screenshot_20200729-123314](https://user-images.githubusercontent.com/246473/88790703-d6f78000-d198-11ea-81d2-3775c8c14b3b.png)
 

@gnosis/mobile-devs
