### PR TITLE
Fix incoming status on confirmations/rejections

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
@@ -159,6 +159,8 @@ class SettingsChangeQueuedViewHolder(private val viewBinding: ItemTxQueuedSettin
             status.setTextColor(ResourcesCompat.getColor(resources, viewTransfer.statusColorRes, theme))
 
             dateTime.text = viewTransfer.dateTimeText
+            settingName.text = viewTransfer.settingNameText
+
             confirmations.setTextColor(ResourcesCompat.getColor(resources, viewTransfer.confirmationsTextColor, theme))
             confirmationsIcon.setImageDrawable(ResourcesCompat.getDrawable(resources, viewTransfer.confirmationsIcon, theme))
             confirmations.text = resources.getString(R.string.tx_list_confirmations, viewTransfer.confirmations, viewTransfer.threshold)

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
@@ -217,6 +217,7 @@ class ChangeMastercopyQueuedViewHolder(private val viewBinding: ItemTxQueuedChan
             ellipsizedAddress.text = viewTransfer.address?.formatForTxList() ?: ""
             label.setText(viewTransfer.label)
 
+            confirmations.setTextColor(ResourcesCompat.getColor(resources, viewTransfer.confirmationsTextColor, theme))
             confirmations.text = resources.getString(R.string.tx_list_confirmations, viewTransfer.confirmations, viewTransfer.threshold)
             confirmationsIcon.visibility = View.VISIBLE
 
@@ -243,6 +244,7 @@ class CustomTransactionQueuedViewHolder(private val viewBinding: ItemTxQueuedTra
 
             dateTime.text = viewTransfer.dateTimeText
 
+            confirmations.setTextColor(ResourcesCompat.getColor(resources, viewTransfer.confirmationsTextColor, theme))
             confirmations.text = resources.getString(R.string.tx_list_confirmations, viewTransfer.confirmations, viewTransfer.threshold)
             confirmationsIcon.visibility = View.VISIBLE
 

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
@@ -101,7 +101,7 @@ class TransactionListViewModel
                     if (before == null) {
                         // we're at the beginning of the list
 
-                       return@insertSeparators if (after.isQueued()) {
+                        return@insertSeparators if (after.isQueued()) {
                             TransactionView.SectionHeader(title = R.string.tx_list_queue)
                         } else if (after.isHistory()) {
                             TransactionView.SectionHeader(title = R.string.tx_list_history)
@@ -215,34 +215,32 @@ class TransactionListViewModel
         transfer: Transfer,
         safeInfo: SafeInfo
     ): TransactionView.Transfer {
-        val isIncoming: Boolean = transfer.recipient == safeInfo.address
 
         return TransactionView.Transfer(
             status = transfer.status,
             statusText = displayString(transfer.status),
             statusColorRes = statusTextColor(transfer.status),
-            amountText = formatTransferAmount(transfer, isIncoming),
+            amountText = formatTransferAmount(transfer, transfer.incoming),
             dateTimeText = transfer.date ?: "",
-            txTypeIcon = if (isIncoming) R.drawable.ic_arrow_green_16dp else R.drawable.ic_arrow_red_10dp,
-            address = if (isIncoming) transfer.sender else transfer.recipient,
-            amountColor = if (transfer.value > BigInteger.ZERO && isIncoming) R.color.safe_green else R.color.gnosis_dark_blue,
+            txTypeIcon = if (transfer.incoming) R.drawable.ic_arrow_green_16dp else R.drawable.ic_arrow_red_10dp,
+            address = if (transfer.incoming) transfer.sender else transfer.recipient,
+            amountColor = if (transfer.value > BigInteger.ZERO && transfer.incoming) R.color.safe_green else R.color.gnosis_dark_blue,
             alpha = alpha(transfer)
         )
     }
 
     private fun queuedTransfer(transfer: Transfer, safeInfo: SafeInfo): TransactionView? {
         val thresholdMet = checkThreshold(safeInfo.threshold, transfer.confirmations)
-        val isIncoming: Boolean = transfer.recipient == safeInfo.address
 
         return TransactionView.TransferQueued(
             status = transfer.status,
             statusText = displayString(transfer.status),
             statusColorRes = statusTextColor(transfer.status),
-            amountText = formatTransferAmount(transfer, isIncoming),
+            amountText = formatTransferAmount(transfer, transfer.incoming),
             dateTimeText = transfer.date ?: "",
-            txTypeIcon = if (isIncoming) R.drawable.ic_arrow_green_16dp else R.drawable.ic_arrow_red_10dp,
-            address = if (isIncoming) transfer.sender else transfer.recipient,
-            amountColor = if (transfer.value > BigInteger.ZERO && isIncoming) R.color.safe_green else R.color.gnosis_dark_blue,
+            txTypeIcon = if (transfer.incoming) R.drawable.ic_arrow_green_16dp else R.drawable.ic_arrow_red_10dp,
+            address = if (transfer.incoming) transfer.sender else transfer.recipient,
+            amountColor = if (transfer.value > BigInteger.ZERO && transfer.incoming) R.color.safe_green else R.color.gnosis_dark_blue,
             confirmations = transfer.confirmations ?: 0,
             threshold = safeInfo.threshold,
             confirmationsTextColor = if (thresholdMet) R.color.safe_green else R.color.medium_grey,

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
@@ -829,7 +829,7 @@ class TransactionListViewModelTest {
 
     private fun createTransactionListWithStatus(vararg transactionStatus: TransactionStatus): Page<Transaction> {
         val transfers = transactionStatus.map { status ->
-            Transaction.Transfer(status, 2, defaultToAddress, defaultFromAddress, BigInteger.ONE, "", ETH_SERVICE_TOKEN_INFO, defaultNonce)
+            Transaction.Transfer(status, 2, defaultToAddress, defaultFromAddress, BigInteger.ONE, "", ETH_SERVICE_TOKEN_INFO, defaultNonce, false)
         }
         return Page(1, "", "", transfers)
     }
@@ -852,7 +852,8 @@ class TransactionListViewModelTest {
             value = value,
             date = date,
             tokenInfo = serviceTokenInfo,
-            nonce = nonce
+            nonce = nonce,
+            incoming = defaultSafeAddress == recipient
         )
 
     private fun buildCustom(

--- a/data/src/main/java/io/gnosis/data/models/Transaction.kt
+++ b/data/src/main/java/io/gnosis/data/models/Transaction.kt
@@ -37,7 +37,8 @@ sealed class Transaction {
         val value: BigInteger,
         val date: String?,
         val tokenInfo: ServiceTokenInfo?,
-        val nonce: BigInteger?
+        val nonce: BigInteger?,
+        val incoming: Boolean
     ) : Transaction()
 }
 


### PR DESCRIPTION
Ticket #714 .

Changes proposed in this pull request:
- Move calculation of incoming status to repository because we need access to data decoded to calculate it.
- Follow the rules laid out here: https://docs.google.com/document/d/1vhTu5NbB-6m8nE3cqTS3bRONigPO3NA5YkJqNTA6AOk/edit?skip_itp2_check=true **Except** the rules for custom tx because they are in a different issue/ticket and maybe obsoleted by the client service
- Tests added for new `incoming` calculation
- I sneaked in two fixes for missing confirmations text color and settings name (queued txs) 
- Also solves: https://github.com/gnosis/safe-android/issues/706 and  #712 

Before | After
------- | -----
![Screenshot_20200729-185226](https://user-images.githubusercontent.com/246473/88829506-f9a38c00-d1cc-11ea-9d8a-5a9c8a1097cd.png)  | ![Screenshot_20200729-185129](https://user-images.githubusercontent.com/246473/88829568-0f18b600-d1cd-11ea-9c7b-05555e66d93c.png)



@gnosis/mobile-devs
