### PR TITLE
Show nonces in historic transactions

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
@@ -94,6 +94,7 @@ class TransferViewHolder(private val viewBinding: ItemTxTransferBinding) :
             txTypeIcon.setImageResource(viewTransfer.txTypeIcon)
             blockies.setAddress(viewTransfer.address)
             ellipsizedAddress.text = viewTransfer.address.formatForTxList()
+            nonce.text = viewTransfer.nonce
 
             finalStatus.alpha = OPACITY_FULL
             amount.alpha = viewTransfer.alpha
@@ -106,8 +107,6 @@ class TransferViewHolder(private val viewBinding: ItemTxTransferBinding) :
                 //TODO: pass tx data to details page
                 //Navigation.findNavController(it).navigate(TransactionListFragmentDirections.actionTransactionListFragmentToTransactionDetailsFragment())
             }
-
-            nonce.text = viewTransfer.nonce
         }
     }
 }
@@ -148,12 +147,11 @@ class SettingsChangeViewHolder(private val viewBinding: ItemTxSettingsChangeBind
 
             dateTime.text = viewTransfer.dateTimeText
             settingName.text = viewTransfer.method
+            nonce.text = viewTransfer.nonce
 
             finalStatus.alpha = OPACITY_FULL
             dateTime.alpha = viewTransfer.alpha
             settingName.alpha = viewTransfer.alpha
-
-            nonce.text = viewTransfer.nonce
         }
     }
 }
@@ -230,12 +228,12 @@ class ChangeMastercopyQueuedViewHolder(private val viewBinding: ItemTxQueuedChan
             confirmations.setTextColor(ResourcesCompat.getColor(resources, viewTransfer.confirmationsTextColor, theme))
             confirmations.text = resources.getString(R.string.tx_list_confirmations, viewTransfer.confirmations, viewTransfer.threshold)
             confirmationsIcon.visibility = View.VISIBLE
+            nonce.text = viewTransfer.nonce
 
             moduleAddress.text = viewTransfer.address?.formatForTxList() ?: ""
             version.visibility = viewTransfer.visibilityVersion
             ellipsizedAddress.visibility = viewTransfer.visibilityEllipsizedAddress
             moduleAddress.visibility = viewTransfer.visibilityModuleAddress
-            nonce.text = viewTransfer.nonce
         }
     }
 }
@@ -289,6 +287,7 @@ class CustomTransactionViewHolder(private val viewBinding: ItemTxTransferBinding
             dataSize.text = viewTransfer.dataSizeText
             amount.text = viewTransfer.amountText
             amount.setTextColor(ResourcesCompat.getColor(resources, viewTransfer.amountColor, theme))
+            nonce.text = viewTransfer.nonce
 
             finalStatus.alpha = OPACITY_FULL
             txTypeIcon.alpha = viewTransfer.alpha
@@ -297,8 +296,6 @@ class CustomTransactionViewHolder(private val viewBinding: ItemTxTransferBinding
             ellipsizedAddress.alpha = viewTransfer.alpha
             dataSize.alpha = viewTransfer.alpha
             amount.alpha = viewTransfer.alpha
-
-            nonce.text = viewTransfer.nonce
 
         }
     }

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
@@ -106,6 +106,8 @@ class TransferViewHolder(private val viewBinding: ItemTxTransferBinding) :
                 //TODO: pass tx data to details page
                 //Navigation.findNavController(it).navigate(TransactionListFragmentDirections.actionTransactionListFragmentToTransactionDetailsFragment())
             }
+
+            nonce.text = viewTransfer.nonce
         }
     }
 }
@@ -150,6 +152,8 @@ class SettingsChangeViewHolder(private val viewBinding: ItemTxSettingsChangeBind
             finalStatus.alpha = OPACITY_FULL
             dateTime.alpha = viewTransfer.alpha
             settingName.alpha = viewTransfer.alpha
+
+            nonce.text = viewTransfer.nonce
         }
     }
 }
@@ -293,6 +297,8 @@ class CustomTransactionViewHolder(private val viewBinding: ItemTxTransferBinding
             ellipsizedAddress.alpha = viewTransfer.alpha
             dataSize.alpha = viewTransfer.alpha
             amount.alpha = viewTransfer.alpha
+
+            nonce.text = viewTransfer.nonce
 
         }
     }

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
@@ -224,11 +224,11 @@ class ChangeMastercopyQueuedViewHolder(private val viewBinding: ItemTxQueuedChan
             blockies.setAddress(viewTransfer.address)
             ellipsizedAddress.text = viewTransfer.address?.formatForTxList() ?: ""
             label.setText(viewTransfer.label)
+            nonce.text = viewTransfer.nonce
 
             confirmations.setTextColor(ResourcesCompat.getColor(resources, viewTransfer.confirmationsTextColor, theme))
             confirmations.text = resources.getString(R.string.tx_list_confirmations, viewTransfer.confirmations, viewTransfer.threshold)
             confirmationsIcon.visibility = View.VISIBLE
-            nonce.text = viewTransfer.nonce
 
             moduleAddress.text = viewTransfer.address?.formatForTxList() ?: ""
             version.visibility = viewTransfer.visibilityVersion

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
@@ -227,7 +227,8 @@ class TransactionListViewModel
             txTypeIcon = if (transfer.incoming) R.drawable.ic_arrow_green_16dp else R.drawable.ic_arrow_red_10dp,
             address = if (transfer.incoming) transfer.sender else transfer.recipient,
             amountColor = if (transfer.value > BigInteger.ZERO && transfer.incoming) R.color.safe_green else R.color.gnosis_dark_blue,
-            alpha = alpha(transfer)
+            alpha = alpha(transfer),
+            nonce = transfer.nonce?.toString() ?: ""
         )
     }
 
@@ -247,7 +248,7 @@ class TransactionListViewModel
             threshold = safeInfo.threshold,
             confirmationsTextColor = if (thresholdMet) R.color.safe_green else R.color.medium_grey,
             confirmationsIcon = if (thresholdMet) R.drawable.ic_confirmations_green_16dp else R.drawable.ic_confirmations_grey_16dp,
-            nonce = transfer.nonce.toString()
+            nonce = transfer.nonce?.toString() ?: ""
         )
     }
 
@@ -258,7 +259,8 @@ class TransactionListViewModel
             statusColorRes = statusTextColor(transaction.status),
             dateTimeText = transaction.date?.formatBackendDate() ?: "",
             method = transaction.dataDecoded.method,
-            alpha = alpha(transaction)
+            alpha = alpha(transaction),
+            nonce = transaction.nonce.toString()
         )
 
     private fun queuedSettingsChange(transaction: SettingsChange, threshold: Int): TransactionView.SettingsChangeQueued {
@@ -291,7 +293,8 @@ class TransactionListViewModel
             alpha = alpha(transaction),
             version = version,
             address = address,
-            label = R.string.tx_list_change_mastercopy
+            label = R.string.tx_list_change_mastercopy,
+            nonce = transaction.nonce.toString()
         )
     }
 
@@ -338,7 +341,8 @@ class TransactionListViewModel
             alpha = alpha(transaction),
             version = "DefaultFallbackHandler",
             address = address,
-            label = R.string.tx_list_set_fallback_handler
+            label = R.string.tx_list_set_fallback_handler,
+            nonce = transaction.nonce.toString()
         )
     }
 
@@ -382,7 +386,8 @@ class TransactionListViewModel
             version = "",
             visibilityVersion = View.INVISIBLE,
             visibilityEllipsizedAddress = View.INVISIBLE,
-            visibilityModuleAddress = View.VISIBLE
+            visibilityModuleAddress = View.VISIBLE,
+            nonce = transaction.nonce.toString()
         )
     }
 
@@ -430,7 +435,8 @@ class TransactionListViewModel
             dataSizeText = if (custom.dataSize > 0) "${custom.dataSize} bytes" else "",
             amountText = formatAmount(isIncoming, custom.value, ETH_SERVICE_TOKEN_INFO.decimals, ETH_SERVICE_TOKEN_INFO.symbol),
             amountColor = if (custom.value > BigInteger.ZERO && isIncoming) R.color.safe_green else R.color.gnosis_dark_blue,
-            alpha = alpha(custom)
+            alpha = alpha(custom),
+            nonce = custom.nonce.toString()
         )
     }
 

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionView.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionView.kt
@@ -17,7 +17,8 @@ sealed class TransactionView(open val status: TransactionStatus?) {
         @DrawableRes val txTypeIcon: Int,
         val address: Solidity.Address,
         @ColorRes val amountColor: Int,
-        val alpha: Float
+        val alpha: Float,
+        val nonce: String
     ) : TransactionView(status)
 
     data class TransferQueued(
@@ -42,7 +43,8 @@ sealed class TransactionView(open val status: TransactionStatus?) {
         @ColorRes val statusColorRes: Int,
         val dateTimeText: String,
         val method: String,
-        val alpha: Float
+        val alpha: Float,
+        val nonce: String
     ) : TransactionView(status)
 
     data class SettingsChangeQueued(
@@ -69,7 +71,8 @@ sealed class TransactionView(open val status: TransactionStatus?) {
         @StringRes val label: Int,
         val visibilityVersion: Int = View.VISIBLE,
         val visibilityEllipsizedAddress: Int = View.VISIBLE,
-        val visibilityModuleAddress: Int = View.GONE
+        val visibilityModuleAddress: Int = View.GONE,
+        val nonce: String
 
     ) : TransactionView(status)
 
@@ -100,7 +103,8 @@ sealed class TransactionView(open val status: TransactionStatus?) {
         val dataSizeText: String,
         val amountText: String,
         @ColorRes val amountColor: Int,
-        val alpha: Float
+        val alpha: Float,
+        val nonce: String
     ) : TransactionView(status)
 
     data class CustomTransactionQueued(

--- a/app/src/main/res/layout/item_tx_change_mastercopy.xml
+++ b/app/src/main/res/layout/item_tx_change_mastercopy.xml
@@ -29,6 +29,16 @@
         app:srcCompat="@drawable/ic_chevron_right" />
 
     <TextView
+        android:id="@+id/nonce"
+        style="@style/TextMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/chevron"
+        tools:text="10" />
+
+    <TextView
         android:id="@+id/ellipsized_address"
         style="@style/TextDark"
         android:layout_width="wrap_content"
@@ -62,10 +72,10 @@
         style="@style/TextMedium"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/default_margin"
-        android:layout_marginTop="3dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/ellipsized_address"
+        android:layout_marginStart="8dp"
+        app:layout_constraintBottom_toBottomOf="@+id/nonce"
+        app:layout_constraintStart_toEndOf="@+id/nonce"
+        app:layout_constraintTop_toTopOf="@+id/nonce"
         tools:text="Apr 27, 2020 — 1:01:42PM" />
 
     <TextView

--- a/app/src/main/res/layout/item_tx_settings_change.xml
+++ b/app/src/main/res/layout/item_tx_settings_change.xml
@@ -29,14 +29,24 @@
         app:srcCompat="@drawable/ic_chevron_right" />
 
     <TextView
-        android:id="@+id/date_time"
+        android:id="@+id/nonce"
         style="@style/TextMedium"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="3dp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/setting_name"
+        app:layout_constraintTop_toBottomOf="@+id/chevron"
+        tools:text="10" />
+
+    <TextView
+        android:id="@+id/date_time"
+        style="@style/TextMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        app:layout_constraintBottom_toBottomOf="@+id/nonce"
+        app:layout_constraintStart_toEndOf="@+id/nonce"
+        app:layout_constraintTop_toTopOf="@+id/nonce"
         tools:text="Apr 27, 2020 — 1:01:42PM" />
 
     <TextView

--- a/app/src/main/res/layout/item_tx_transfer.xml
+++ b/app/src/main/res/layout/item_tx_transfer.xml
@@ -27,7 +27,15 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_chevron_right" />
-
+    <TextView
+        android:id="@+id/nonce"
+        style="@style/TextMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/chevron"
+        tools:text="10" />
     <TextView
         android:id="@+id/amount"
         style="@style/TextDark"
@@ -48,10 +56,10 @@
         style="@style/TextMedium"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/default_margin"
-        android:layout_marginTop="@dimen/default_small_margin"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/blockies"
+        android:layout_marginStart="8dp"
+        app:layout_constraintBottom_toBottomOf="@+id/nonce"
+        app:layout_constraintStart_toEndOf="@+id/nonce"
+        app:layout_constraintTop_toTopOf="@+id/nonce"
         tools:text="Apr 27, 2020 — 1:01:42PM" />
 
 

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
@@ -340,7 +340,8 @@ class TransactionListViewModelTest {
                 dateTimeText = Date(0).formatBackendDate(),
                 txTypeIcon = R.drawable.ic_arrow_red_10dp,
                 address = defaultToAddress,
-                alpha = OPACITY_HALF
+                alpha = OPACITY_HALF,
+                nonce = "1"
             ),
             transactionViews[2]
         )
@@ -354,7 +355,8 @@ class TransactionListViewModelTest {
                 dateTimeText = Date(0).formatBackendDate(),
                 txTypeIcon = R.drawable.ic_arrow_red_10dp,
                 address = defaultToAddress,
-                alpha = OPACITY_FULL
+                alpha = OPACITY_FULL,
+                nonce = "1"
             ),
             transactionViews[3]
         )
@@ -368,7 +370,8 @@ class TransactionListViewModelTest {
                 dateTimeText = Date(0).formatBackendDate(),
                 txTypeIcon = R.drawable.ic_arrow_green_16dp,
                 address = defaultFromAddress,
-                alpha = OPACITY_FULL
+                alpha = OPACITY_FULL,
+                nonce = "1"
             ),
             transactionViews[4]
         )
@@ -382,7 +385,8 @@ class TransactionListViewModelTest {
                 dateTimeText = Date(0).formatBackendDate(),
                 txTypeIcon = R.drawable.ic_arrow_green_16dp,
                 address = defaultFromAddress,
-                alpha = OPACITY_FULL
+                alpha = OPACITY_FULL,
+                nonce = "1"
             ),
             transactionViews[5]
         )
@@ -425,7 +429,8 @@ class TransactionListViewModelTest {
                 dateTimeText = Date(0).formatBackendDate(),
                 txTypeIcon = R.drawable.ic_arrow_green_16dp,
                 address = defaultFromAddress,
-                alpha = OPACITY_FULL
+                alpha = OPACITY_FULL,
+                nonce = "1"
             ),
             transactionViews[0]
         )
@@ -439,7 +444,8 @@ class TransactionListViewModelTest {
                 dateTimeText = Date(0).formatBackendDate(),
                 txTypeIcon = R.drawable.ic_arrow_green_16dp,
                 address = defaultFromAddress,
-                alpha = OPACITY_FULL
+                alpha = OPACITY_FULL,
+                nonce = "1"
             ),
             transactionViews[1]
         )
@@ -453,7 +459,8 @@ class TransactionListViewModelTest {
                 dateTimeText = Date(0).formatBackendDate(),
                 txTypeIcon = R.drawable.ic_arrow_red_10dp,
                 address = defaultToAddress,
-                alpha = OPACITY_HALF
+                alpha = OPACITY_HALF,
+                nonce = "1"
             ),
             transactionViews[2]
         )
@@ -467,7 +474,8 @@ class TransactionListViewModelTest {
                 dateTimeText = Date(0).formatBackendDate(),
                 txTypeIcon = R.drawable.ic_arrow_red_10dp,
                 address = defaultToAddress,
-                alpha = OPACITY_HALF
+                alpha = OPACITY_HALF,
+                nonce = "1"
             ),
             transactionViews[3]
         )
@@ -547,7 +555,8 @@ class TransactionListViewModelTest {
                 dateTimeText = Date(0).formatBackendDate(),
                 address = defaultSafeAddress,
                 alpha = OPACITY_FULL,
-                dataSizeText = ""
+                dataSizeText = "",
+                nonce = "1"
             ),
             transactionViews[2]
         )
@@ -561,7 +570,8 @@ class TransactionListViewModelTest {
                 dateTimeText = Date(0).formatBackendDate(),
                 address = defaultToAddress,
                 alpha = OPACITY_HALF,
-                dataSizeText = ""
+                dataSizeText = "",
+                nonce = "1"
             ),
             transactionViews[3]
         )
@@ -575,7 +585,8 @@ class TransactionListViewModelTest {
                 dateTimeText = Date(0).formatBackendDate(),
                 address = defaultToAddress,
                 alpha = OPACITY_HALF,
-                dataSizeText = ""
+                dataSizeText = "",
+                nonce = "1"
             ),
             transactionViews[4]
         )
@@ -645,7 +656,8 @@ class TransactionListViewModelTest {
             buildSettingsChange(
                 status = SUCCESS,
                 confirmations = 2,
-                dataDecoded = buildDataDecodedDto(METHOD_REMOVE_OWNER, emptyList())
+                dataDecoded = buildDataDecodedDto(METHOD_REMOVE_OWNER, emptyList()),
+                nonce = 10.toBigInteger()
             )
         )
         val transactionViews =
@@ -771,7 +783,8 @@ class TransactionListViewModelTest {
                 visibilityModuleAddress = View.GONE,
                 visibilityVersion = View.VISIBLE,
                 address = defaultFallbackHandler,
-                version = "DefaultFallbackHandler"
+                version = "DefaultFallbackHandler",
+                nonce = "1"
             ),
             transactionViews[5]
         )
@@ -787,7 +800,8 @@ class TransactionListViewModelTest {
                 visibilityEllipsizedAddress = View.VISIBLE,
                 visibilityModuleAddress = View.GONE,
                 visibilityVersion = View.VISIBLE,
-                alpha = OPACITY_FULL
+                alpha = OPACITY_FULL,
+                nonce = "1"
             ),
             transactionViews[6]
         )
@@ -803,7 +817,8 @@ class TransactionListViewModelTest {
                 visibilityEllipsizedAddress = View.INVISIBLE,
                 visibilityModuleAddress = View.VISIBLE,
                 visibilityVersion = View.INVISIBLE,
-                address = defaultModuleAddress
+                address = defaultModuleAddress,
+                nonce = "1"
             ),
             transactionViews[7]
         )
@@ -814,7 +829,8 @@ class TransactionListViewModelTest {
                 statusColorRes = R.color.safe_green,
                 dateTimeText = Date(0).formatBackendDate(),
                 method = METHOD_REMOVE_OWNER,
-                alpha = OPACITY_FULL
+                alpha = OPACITY_FULL,
+                nonce = "10"
             ),
             transactionViews[8]
         )


### PR DESCRIPTION
Closes #763  .

This bug was not in the sprint. But for debugging the client gateway it would be really helpful to see nonces in historic transactions. 

Changes proposed in this pull request:
- Show nonces, where available or nothing where not. 

@gnosis/mobile-devs
