### PR TITLE
Incoming amounts should be green.

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/view/AmountView.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/view/AmountView.kt
@@ -3,7 +3,9 @@ package io.gnosis.safe.ui.transactions.details.view
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import androidx.annotation.ColorRes
 import androidx.constraintlayout.widget.ConstraintLayout
+import io.gnosis.safe.R
 import io.gnosis.safe.databinding.ViewTxAmountBinding
 import io.gnosis.safe.utils.loadTokenLogo
 
@@ -15,8 +17,9 @@ class AmountView @JvmOverloads constructor(
 
     private val binding by lazy { ViewTxAmountBinding.inflate(LayoutInflater.from(context), this) }
 
-    fun setAmount(formattedAmount: String, logoUri: String = "local::ethereum") {
+    fun setAmount(formattedAmount: String, logoUri: String = "local::ethereum", @ColorRes color: Int = R.color.gnosis_dark_blue) {
         binding.amountTitle.text = formattedAmount
         binding.logo.loadTokenLogo(logoUri)
+        binding.amountTitle.setTextColor(context.resources.getColor(color))
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/view/AmountView.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/view/AmountView.kt
@@ -8,6 +8,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import io.gnosis.safe.R
 import io.gnosis.safe.databinding.ViewTxAmountBinding
 import io.gnosis.safe.utils.loadTokenLogo
+import pm.gnosis.svalinn.common.utils.getColorCompat
 
 class AmountView @JvmOverloads constructor(
     context: Context,
@@ -20,6 +21,6 @@ class AmountView @JvmOverloads constructor(
     fun setAmount(formattedAmount: String, logoUri: String = "local::ethereum", @ColorRes color: Int = R.color.gnosis_dark_blue) {
         binding.amountTitle.text = formattedAmount
         binding.logo.loadTokenLogo(logoUri)
-        binding.amountTitle.setTextColor(context.resources.getColor(color))
+        binding.amountTitle.setTextColor(context.getColorCompat(color))
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/view/TxTransferActionView.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/view/TxTransferActionView.kt
@@ -31,7 +31,7 @@ class TxTransferActionView @JvmOverloads constructor(
         clear()
 
         if (outgoing) {
-            addAmountItem(amount, logoUri)
+            addAmountItem(amount, logoUri, outgoing)
         } else {
             addAddressItem(address)
         }
@@ -41,16 +41,17 @@ class TxTransferActionView @JvmOverloads constructor(
         if (outgoing) {
             addAddressItem(address)
         } else {
-            addAmountItem(amount, logoUri)
+            addAmountItem(amount, logoUri, outgoing)
         }
     }
 
-    private fun addAmountItem(amount: String, logoUri: String) {
+    private fun addAmountItem(amount: String, logoUri: String, outgoing: Boolean) {
         val amountView = AmountView(context)
+        val color = if(outgoing) R.color.gnosis_dark_blue else R.color.safe_green
         val layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
         layoutParams.setMargins(dpToPx(DEFAULT_MARGIN), 0, 0, 0)
         amountView.layoutParams = layoutParams
-        amountView.setAmount(amount, logoUri)
+        amountView.setAmount(amount, logoUri, color)
         addView(amountView)
     }
 


### PR DESCRIPTION
Closes # .

Changes proposed in this pull request:
- When an amount is incoming it is rendered in green in the details view
- 
- 

@gnosis/mobile-devs
