### PR TITLE
Show empty data error screen for safe settings

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsFragment.kt
@@ -56,8 +56,10 @@ class CoinsFragment : BaseViewBindingFragment<FragmentCoinsBinding>() {
                             }
                             is ShowError -> {
                                 hideLoading()
-                                binding.contentNoData.root.visible(true)
-                                when(action.error) {
+                                if (adapter.itemCount == 0) {
+                                    binding.contentNoData.root.visible(true)
+                                }
+                                when (action.error) {
                                     is Offline -> {
                                         snackbar(requireView(), R.string.error_no_internet)
                                     }

--- a/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsFragment.kt
@@ -52,16 +52,11 @@ class CoinsFragment : BaseViewBindingFragment<FragmentCoinsBinding>() {
                         when (action) {
                             is UpdateBalances -> {
                                 binding.contentNoData.root.visibility = View.GONE
-                                binding.refresh.visible(true)
-
                                 adapter.setItems(action.newBalances)
                             }
                             is ShowError -> {
                                 hideLoading()
-
                                 binding.contentNoData.root.visible(true)
-                                binding.refresh.visible(false)
-
                                 when(action.error) {
                                     is Offline -> {
                                         snackbar(requireView(), R.string.error_no_internet)

--- a/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsFragment.kt
@@ -14,6 +14,7 @@ import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.helpers.Offline
 import io.gnosis.safe.ui.base.BaseStateViewModel.ViewAction.ShowError
 import io.gnosis.safe.ui.base.fragment.BaseViewBindingFragment
+import io.gnosis.safe.utils.getErrorResForException
 import pm.gnosis.svalinn.common.utils.snackbar
 import pm.gnosis.svalinn.common.utils.visible
 import javax.inject.Inject
@@ -49,15 +50,24 @@ class CoinsFragment : BaseViewBindingFragment<FragmentCoinsBinding>() {
                     binding.refresh.isRefreshing = state.refreshing
                     state.viewAction?.let { action ->
                         when (action) {
-                            is UpdateBalances -> adapter.setItems(action.newBalances)
+                            is UpdateBalances -> {
+                                binding.contentNoData.root.visibility = View.GONE
+                                binding.refresh.visible(true)
+
+                                adapter.setItems(action.newBalances)
+                            }
                             is ShowError -> {
                                 hideLoading()
+
+                                binding.contentNoData.root.visible(true)
+                                binding.refresh.visible(false)
+
                                 when(action.error) {
                                     is Offline -> {
                                         snackbar(requireView(), R.string.error_no_internet)
                                     }
                                     else -> {
-                                        handleError(action.error)
+                                        snackbar(requireView(), action.error.getErrorResForException())
                                     }
                                 }
                             }
@@ -75,10 +85,6 @@ class CoinsFragment : BaseViewBindingFragment<FragmentCoinsBinding>() {
     private fun hideLoading() {
         binding.progress.visible(false)
         binding.refresh.isRefreshing = false
-    }
-
-    private fun handleError(throwable: Throwable) {
-        snackbar(requireView(), R.string.error_loading_balances)
     }
 
     companion object {

--- a/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsFragment.kt
@@ -12,7 +12,8 @@ import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentCoinsBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.helpers.Offline
-import io.gnosis.safe.ui.base.BaseStateViewModel.ViewAction.ShowError
+import io.gnosis.safe.ui.base.BaseStateViewModel
+import io.gnosis.safe.ui.base.BaseStateViewModel.ViewAction.*
 import io.gnosis.safe.ui.base.fragment.BaseViewBindingFragment
 import io.gnosis.safe.utils.getErrorResForException
 import pm.gnosis.svalinn.common.utils.snackbar
@@ -50,6 +51,9 @@ class CoinsFragment : BaseViewBindingFragment<FragmentCoinsBinding>() {
                     binding.refresh.isRefreshing = state.refreshing
                     state.viewAction?.let { action ->
                         when (action) {
+                            is UpdateActiveSafe -> {
+                                adapter.setItems(listOf())
+                            }
                             is UpdateBalances -> {
                                 binding.contentNoData.root.visibility = View.GONE
                                 adapter.setItems(action.newBalances)

--- a/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsViewModel.kt
@@ -27,7 +27,7 @@ class CoinsViewModel
         safeLaunch {
             val safe = safeRepository.getActiveSafe()
             if (safe != null) {
-                updateState { CoinsState(loading = !refreshing, refreshing = refreshing, viewAction = null) }
+                updateState { CoinsState(loading = !refreshing, refreshing = refreshing, viewAction = if(refreshing) null else ViewAction.UpdateActiveSafe(safe)) }
                 val balances = tokenRepository.loadBalanceOf(safe.address)
                 updateState { CoinsState(loading = false, refreshing = false, viewAction = UpdateBalances(balances)) }
             }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/safe/SafeSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/safe/SafeSettingsFragment.kt
@@ -62,16 +62,16 @@ class SafeSettingsFragment : BaseViewBindingFragment<FragmentSettingsSafeBinding
                     updateUi(viewAction.isLoading, it.safe, it.safeInfo, it.ensName)
                 }
                 is ShowError -> {
+                    if (!didLoadOnce) {
+                        showContentNoData()
+                    }
+                    hideLoading()
                     when (viewAction.error) {
                         is Offline -> {
-                            hideLoading()
                             snackbar(requireView(), R.string.error_no_internet)
-                            if (!didLoadOnce) {
-                                showContentNoData()
-                            }
                         }
                         else -> {
-                            showError(viewAction.error)
+                            snackbar(requireView(), viewAction.error.getErrorResForException())
                         }
                     }
                 }
@@ -126,14 +126,6 @@ class SafeSettingsFragment : BaseViewBindingFragment<FragmentSettingsSafeBinding
             refresh.isRefreshing = false
             progress.visible(false)
         }
-    }
-
-    private fun showError(throwable: Throwable) {
-        hideLoading()
-        if (!didLoadOnce) {
-            showContentNoData()
-        }
-        snackbar(requireView(), throwable.getErrorResForException())
     }
 
     private fun showRemoveDialog() {

--- a/app/src/main/java/io/gnosis/safe/ui/settings/safe/SafeSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/safe/SafeSettingsFragment.kt
@@ -21,6 +21,7 @@ import io.gnosis.safe.ui.base.fragment.BaseViewBindingFragment
 import io.gnosis.safe.ui.settings.SettingsFragmentDirections
 import io.gnosis.safe.ui.settings.view.AddressItem
 import io.gnosis.safe.utils.CustomAlertDialogBuilder
+import io.gnosis.safe.utils.getErrorResForException
 import pm.gnosis.model.Solidity
 import pm.gnosis.svalinn.common.utils.snackbar
 import pm.gnosis.svalinn.common.utils.visible
@@ -30,9 +31,10 @@ class SafeSettingsFragment : BaseViewBindingFragment<FragmentSettingsSafeBinding
 
     override fun screenId() = ScreenId.SETTINGS_SAFE
 
+    private var didLoadOnce = false
+
     @Inject
     lateinit var viewModel: SafeSettingsViewModel
-
 
     override fun inject(component: ViewComponent) {
         component.inject(this)
@@ -55,12 +57,18 @@ class SafeSettingsFragment : BaseViewBindingFragment<FragmentSettingsSafeBinding
         }
         viewModel.state.observe(viewLifecycleOwner, Observer {
             when (val viewAction = it.viewAction) {
-                is Loading -> updateUi(viewAction.isLoading, it.safe, it.safeInfo, it.ensName)
+                is Loading -> {
+                    didLoadOnce = if (didLoadOnce) didLoadOnce else !viewAction.isLoading
+                    updateUi(viewAction.isLoading, it.safe, it.safeInfo, it.ensName)
+                }
                 is ShowError -> {
-                    when(viewAction.error) {
+                    when (viewAction.error) {
                         is Offline -> {
                             hideLoading()
                             snackbar(requireView(), R.string.error_no_internet)
+                            if (!didLoadOnce) {
+                                showContentNoData()
+                            }
                         }
                         else -> {
                             showError(viewAction.error)
@@ -69,6 +77,11 @@ class SafeSettingsFragment : BaseViewBindingFragment<FragmentSettingsSafeBinding
                 }
             }
         })
+    }
+
+    private fun showContentNoData() {
+        binding.contentNoData.root.visible(true)
+        binding.mainContainer.visibility = View.GONE
     }
 
     private fun updateUi(isLoading: Boolean, safe: Safe?, safeInfo: SafeInfo?, ensNameValue: String?) {
@@ -117,8 +130,10 @@ class SafeSettingsFragment : BaseViewBindingFragment<FragmentSettingsSafeBinding
 
     private fun showError(throwable: Throwable) {
         hideLoading()
-        binding.mainContainer.visible(false)
-        snackbar(requireView(), throwable.message ?: getString(R.string.error_invalid_safe))
+        if (!didLoadOnce) {
+            showContentNoData()
+        }
+        snackbar(requireView(), throwable.getErrorResForException())
     }
 
     private fun showRemoveDialog() {

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
@@ -94,9 +94,9 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
                     is ShowError -> {
                         binding.progress.visible(false)
 
-                        if (adapter.itemCount == 0) {
+//                        if (!binding.transactions.isVisible) {
                             binding.contentNoData.root.visible(true)
-                        }
+//                        }
                         when (val errorException = viewAction.error) {
                             is Offline -> {
                                 snackbar(requireView(), R.string.error_no_internet)

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
@@ -23,6 +23,7 @@ import io.gnosis.safe.ui.base.SafeOverviewBaseFragment
 import io.gnosis.safe.ui.safe.empty.NoSafeFragment
 import io.gnosis.safe.ui.transactions.paging.TransactionLoadStateAdapter
 import io.gnosis.safe.ui.transactions.paging.TransactionViewListAdapter
+import io.gnosis.safe.utils.getErrorResForException
 import kotlinx.coroutines.launch
 import pm.gnosis.svalinn.common.utils.snackbar
 import pm.gnosis.svalinn.common.utils.visible
@@ -77,6 +78,8 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
 
         viewModel.state.observe(viewLifecycleOwner, Observer { state ->
             binding.progress.visible(state.isLoading)
+            binding.contentNoData.root.visible(false)
+
             state.viewAction.let { viewAction ->
                 when (viewAction) {
                     is LoadTransactions -> loadTransactions(viewAction.newTransactions)
@@ -90,12 +93,16 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
                     }
                     is ShowError -> {
                         binding.progress.visible(false)
-                        when(viewAction.error) {
+
+                        if (adapter.itemCount == 0) {
+                            binding.contentNoData.root.visible(true)
+                        }
+                        when (val errorException = viewAction.error) {
                             is Offline -> {
                                 snackbar(requireView(), R.string.error_no_internet)
                             }
                             else -> {
-                                //TODO: handle error
+                                snackbar(requireView(), errorException.getErrorResForException())
                             }
                         }
                     }

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
@@ -93,10 +93,8 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
                     }
                     is ShowError -> {
                         binding.progress.visible(false)
+                        binding.contentNoData.root.visible(true)
 
-//                        if (!binding.transactions.isVisible) {
-                            binding.contentNoData.root.visible(true)
-//                        }
                         when (val errorException = viewAction.error) {
                             is Offline -> {
                                 snackbar(requireView(), R.string.error_no_internet)

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsFragment.kt
@@ -89,6 +89,7 @@ class TransactionDetailsFragment : BaseViewBindingFragment<FragmentTransactionDe
                         else -> {
                             snackbar(requireView(), viewAction.error.getErrorResForException())
 
+                            // only show empty state if we don't have anything to show
                             if (binding.executed.value.isNullOrBlank() && binding.created.value.isNullOrBlank()) {
                                 binding.content.visibility = View.GONE
                                 binding.contentNoData.root.visible(true)

--- a/app/src/main/res/layout/fragment_coins.xml
+++ b/app/src/main/res/layout/fragment_coins.xml
@@ -18,6 +18,12 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 
+    <include layout="@layout/empty_error_state"
+        android:id="@+id/content_no_data"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"/>
+
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/refresh"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/fragment_settings_safe.xml
+++ b/app/src/main/res/layout/fragment_settings_safe.xml
@@ -17,6 +17,14 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 
+    <include layout="@layout/empty_error_state"
+        android:id="@+id/content_no_data"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        tools:visibility="gone"
+        />
+
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/refresh"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_transaction_details.xml
+++ b/app/src/main/res/layout/fragment_transaction_details.xml
@@ -47,7 +47,7 @@
         android:id="@+id/content_no_data"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:visibility="invisible"/>
+        android:visibility="gone"/>
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/refresh"

--- a/app/src/main/res/layout/fragment_transaction_details.xml
+++ b/app/src/main/res/layout/fragment_transaction_details.xml
@@ -47,7 +47,7 @@
         android:id="@+id/content_no_data"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:visibility="gone"/>
+        android:visibility="invisible"/>
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/refresh"

--- a/app/src/main/res/layout/fragment_transaction_list.xml
+++ b/app/src/main/res/layout/fragment_transaction_list.xml
@@ -15,6 +15,12 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <include layout="@layout/empty_error_state"
+        android:id="@+id/content_no_data"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"/>
+
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/refresh"
         android:layout_width="0dp"


### PR DESCRIPTION
Closes # .

Changes proposed in this pull request:
- Add empty error state to coins list, tx list and safe settings

@gnosis/mobile-devs
