### PR TITLE
Send only x.y.z versions to notification service

### DIFF
--- a/app/src/main/java/io/gnosis/safe/notifications/NotificationRepository.kt
+++ b/app/src/main/java/io/gnosis/safe/notifications/NotificationRepository.kt
@@ -24,6 +24,12 @@ class NotificationRepository(
     private val notificationManager: NotificationManager
 ) {
 
+    //FIXME: workaround for versioning validation on notification service
+    private val appVersion: String = BuildConfig.VERSION_NAME
+        .replace("(\\d*)\\.(\\d*)\\.(\\d*)(.*)".toRegex()) {
+            "${it.groupValues[1]}.${it.groupValues[2]}.${it.groupValues[3]}"
+        }
+
     private var deviceUuid: String?
         get() = preferencesManager.prefs.getString(DEVICE_UUID, null)
         set(value) {
@@ -69,12 +75,11 @@ class NotificationRepository(
                         token,
                         BuildConfig.VERSION_CODE,
                         BuildConfig.APPLICATION_ID,
-                        BuildConfig.VERSION_NAME,
+                        appVersion,
                         "ANDROID",
                         deviceUuid
                     )
                 )
-
             }
                 .onSuccess {
                     Timber.d("notification service registration success")
@@ -101,7 +106,7 @@ class NotificationRepository(
                             token,
                             BuildConfig.VERSION_CODE,
                             BuildConfig.APPLICATION_ID,
-                            BuildConfig.VERSION_NAME,
+                            appVersion,
                             "ANDROID",
                             deviceUuid
                         )


### PR DESCRIPTION
semantic versioning validation for registering push notification devices on the transaction service was added => the versions android is sending have to be adjusted. iOS is sending x.y.z, so we will do the same.

Changes proposed in this pull request:
- Adjust version sent to notification service when registering device

@gnosis/mobile-devs
