### PR TITLE
Prevent access to null binding after view is destroyed

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
@@ -58,15 +58,18 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
             }
         }
         adapter.addDataRefreshListener { isEmpty ->
-            // FIXME: find better solution
-            // show empty state only if data was updated due to loaded transactions
-            // and not reseted  due to safe switch
-            if (viewModel.state.value?.viewAction is LoadTransactions && isEmpty)
-                showEmptyState()
-            else
-                showList()
+            if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+                // FIXME: find better solution
+                // show empty state only if data was updated due to loaded transactions
+                // and not reseted  due to safe switch
+                if (viewModel.state.value?.viewAction is LoadTransactions && isEmpty) {
+                    showEmptyState()
+                } else {
+                    showList()
+                }
 
-            binding.refresh.isRefreshing = false
+                binding.refresh.isRefreshing = false
+            }
         }
 
         with(binding.transactions) {

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import androidx.paging.ExperimentalPagingApi
@@ -51,8 +52,10 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
         super.onViewCreated(view, savedInstanceState)
 
         adapter.addLoadStateListener { loadState ->
-            binding.transactions.isVisible = loadState.refresh is LoadState.NotLoading
-            binding.progress.isVisible = loadState.refresh is LoadState.Loading
+            if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+                binding.transactions.isVisible = loadState.refresh is LoadState.NotLoading
+                binding.progress.isVisible = loadState.refresh is LoadState.Loading
+            }
         }
         adapter.addDataRefreshListener { isEmpty ->
             // FIXME: find better solution


### PR DESCRIPTION
Closes #830  .

Changes proposed in this pull request:
- Page loading might return after switching to detail view and after `onDestroyView()` has been called and binding has been nulled Only access binding when this view is still at least STARTED
- Preventing submission in `loadTransactions()` unfortunately is not enough
- 

@gnosis/mobile-devs
