### PR TITLE
Always load transaction to display latest state; remove caching

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
@@ -54,7 +54,7 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
         adapter.addLoadStateListener { loadState ->
             if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
 
-                binding.progress.isVisible = loadState.refresh is LoadState.Loading
+                binding.progress.isVisible = loadState.refresh is LoadState.Loading && adapter.itemCount == 0
                 binding.refresh.isRefreshing = false
 
                 val append = loadState.append
@@ -85,7 +85,7 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
         binding.refresh.setOnRefreshListener { viewModel.load() }
 
         viewModel.state.observe(viewLifecycleOwner, Observer { state ->
-            binding.progress.visible(state.isLoading)
+
             binding.contentNoData.root.visible(false)
 
             state.viewAction.let { viewAction ->

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
@@ -54,6 +54,14 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
         adapter.addLoadStateListener { loadState ->
             if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
                 binding.progress.isVisible = loadState.refresh is LoadState.Loading
+                val append = loadState.append
+                if(append is LoadState.Error) {
+                    handleError(append.error)
+                }
+                val prepend = loadState.prepend
+                if(prepend is LoadState.Error) {
+                    handleError(prepend.error)
+                }
             }
         }
         adapter.addDataRefreshListener { isEmpty ->
@@ -102,14 +110,7 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
                         binding.progress.visible(false)
                         binding.contentNoData.root.visible(true)
 
-                        when (val errorException = viewAction.error) {
-                            is Offline -> {
-                                snackbar(requireView(), R.string.error_no_internet)
-                            }
-                            else -> {
-                                snackbar(requireView(), errorException.getErrorResForException())
-                            }
-                        }
+                        handleError(viewAction.error)
                     }
                     else -> {
                     }
@@ -121,6 +122,17 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
     override fun onResume() {
         super.onResume()
         viewModel.load()
+    }
+
+    private fun handleError(error: Throwable) {
+        when (error) {
+            is Offline -> {
+                snackbar(requireView(), R.string.error_no_internet)
+            }
+            else -> {
+                snackbar(requireView(), error.getErrorResForException())
+            }
+        }
     }
 
     private fun loadNoSafeFragment() {

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
@@ -53,30 +53,24 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
 
         adapter.addLoadStateListener { loadState ->
             if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+
                 binding.progress.isVisible = loadState.refresh is LoadState.Loading
+                binding.refresh.isRefreshing = false
+
                 val append = loadState.append
-                if(append is LoadState.Error) {
+                if (append is LoadState.Error) {
                     handleError(append.error)
                 }
                 val prepend = loadState.prepend
-                if(prepend is LoadState.Error) {
+                if (prepend is LoadState.Error) {
                     handleError(prepend.error)
                 }
-            }
-        }
-        adapter.addDataRefreshListener { isEmpty ->
-            if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
-                // FIXME: find better solution
-                // show empty state only if data was updated due to loaded transactions
-                // and not reseted  due to safe switch
-                if (viewModel.state.value?.viewAction is LoadTransactions && isEmpty) {
+
+                if (viewModel.state.value?.viewAction is LoadTransactions && loadState.refresh is LoadState.NotLoading && adapter.itemCount == 0) {
                     showEmptyState()
                 } else {
                     showList()
-                    binding.transactions.scrollToPosition(0)
                 }
-
-                binding.refresh.isRefreshing = false
             }
         }
 
@@ -121,6 +115,7 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
 
     override fun onResume() {
         super.onResume()
+        binding.transactions.scrollToPosition(0)
         viewModel.load()
     }
 

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
@@ -92,8 +92,13 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
                     is NoSafeSelected -> loadNoSafeFragment()
                     is ActiveSafeChanged -> {
                         handleActiveSafe(viewAction.activeSafe)
+                        lifecycleScope.launch {
+                            // if safe changes we need to reset data for recycler
+                            adapter.submitData(PagingData.empty())
+                        }
                     }
                     is ShowError -> {
+                        binding.refresh.isRefreshing = false
                         binding.progress.visible(false)
                         binding.contentNoData.root.visible(true)
 

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
@@ -53,7 +53,6 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
 
         adapter.addLoadStateListener { loadState ->
             if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
-                binding.transactions.isVisible = loadState.refresh is LoadState.NotLoading
                 binding.progress.isVisible = loadState.refresh is LoadState.Loading
             }
         }
@@ -66,6 +65,7 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
                     showEmptyState()
                 } else {
                     showList()
+                    binding.transactions.scrollToPosition(0)
                 }
 
                 binding.refresh.isRefreshing = false
@@ -92,10 +92,6 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
                     is NoSafeSelected -> loadNoSafeFragment()
                     is ActiveSafeChanged -> {
                         handleActiveSafe(viewAction.activeSafe)
-                        lifecycleScope.launch {
-                            // if safe changes we need to reset data for recycler to be at the top of the list
-                            adapter.submitData(PagingData.empty())
-                        }
                     }
                     is ShowError -> {
                         binding.progress.visible(false)

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListFragment.kt
@@ -80,7 +80,7 @@ class TransactionListFragment : SafeOverviewBaseFragment<FragmentTransactionList
             layoutManager = LinearLayoutManager(requireContext())
             addItemDecoration(DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL))
         }
-        binding.refresh.setOnRefreshListener { viewModel.load(true) }
+        binding.refresh.setOnRefreshListener { viewModel.load() }
 
         viewModel.state.observe(viewLifecycleOwner, Observer { state ->
             binding.progress.visible(state.isLoading)

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
@@ -3,9 +3,7 @@ package io.gnosis.safe.ui.transactions
 import android.view.View
 import androidx.annotation.StringRes
 import androidx.lifecycle.viewModelScope
-import androidx.paging.PagingData
-import androidx.paging.cachedIn
-import androidx.paging.insertSeparators
+import androidx.paging.*
 import io.gnosis.data.models.Safe
 import io.gnosis.data.models.SafeInfo
 import io.gnosis.data.models.Transaction

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
@@ -44,16 +44,16 @@ class TransactionListViewModel
 
     init {
         safeLaunch {
-            safeRepository.activeSafeFlow().collect { load() }
+            safeRepository.activeSafeFlow().collect { load(true) }
         }
     }
 
     override fun initialState(): TransactionsViewState = TransactionsViewState(null, true)
 
-    fun load() {
+    fun load(safeChange: Boolean = false) {
         safeLaunch {
             val safe = safeRepository.getActiveSafe()
-            updateState { TransactionsViewState(isLoading = true, viewAction = ActiveSafeChanged(safe)) }
+            updateState { TransactionsViewState(isLoading = true, viewAction = if (safeChange) ActiveSafeChanged(safe) else ViewAction.None) }
             if (safe != null) {
                 val safeInfo = safeRepository.getSafeInfo(safe.address)
                 getTransactions(safe.address, safeInfo).collectLatest {

--- a/buildsystem/versions.gradle
+++ b/buildsystem/versions.gradle
@@ -19,7 +19,7 @@ ext {
             androidx_room                   : '2.2.5',
             androidx_navigation             : '2.2.2',
             androidx_fragment               : '1.2.4',
-            androidx_paging                 : '3.0.0-alpha02',
+            androidx_paging                 : '3.0.0-alpha05',
             billing                         : '1.0',
             bivrost                         : '0.8.0',
             bouncycastle                    : '1.61',


### PR DESCRIPTION
Handles #623
Handles #809
Handles #828
Handles #835
Handles #855 
Handles #858
Handles #860

Changes proposed in this pull request:
- Always load the latest state of the transactions
- Remove caching from tx list
- Fix retry handling for tx list
- Show retry error messages
- Fix tx list flashing issues
- Update list when navigating back from tx details
- Keep showing old data in case of an error on the pull to refresh

@gnosis/mobile-devs
