### PR TITLE
Calling the right endpoint method for isValidSafe

### DIFF
--- a/app/src/main/java/io/gnosis/safe/di/modules/RepositoryModule.kt
+++ b/app/src/main/java/io/gnosis/safe/di/modules/RepositoryModule.kt
@@ -21,10 +21,9 @@ class RepositoryModule {
     fun provideSafeRepository(
         safeDao: SafeDao,
         preferencesManager: PreferencesManager,
-        ethereumRepository: EthereumRepository,
         transactionServiceApi: TransactionServiceApi
     ): SafeRepository {
-        return SafeRepository(safeDao, preferencesManager, ethereumRepository, transactionServiceApi)
+        return SafeRepository(safeDao, preferencesManager, transactionServiceApi)
     }
 
     @Provides

--- a/data/src/main/java/io/gnosis/data/repositories/SafeRepository.kt
+++ b/data/src/main/java/io/gnosis/data/repositories/SafeRepository.kt
@@ -51,9 +51,9 @@ class SafeRepository(
     suspend fun removeSafe(safe: Safe) = safeDao.delete(safe)
 
     suspend fun isValidSafe(safeAddress: Solidity.Address): Boolean =
-        ethereumRepository.request(EthGetStorageAt(from = safeAddress, location = BigInteger.ZERO, block = Block.LATEST)).let { request ->
-            isSupported(request.checkedResult("Valid safe check failed").asEthereumAddress())
-        }
+        runCatching {
+            transactionServiceApi.getSafeInfo(safeAddress.asEthereumAddressChecksumString())
+        }.exceptionOrNull() == null
 
     suspend fun clearActiveSafe() {
         preferencesManager.prefs.edit {

--- a/data/src/main/java/io/gnosis/data/repositories/SafeRepository.kt
+++ b/data/src/main/java/io/gnosis/data/repositories/SafeRepository.kt
@@ -10,20 +10,15 @@ import io.gnosis.data.models.SafeMetaData
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.*
 import pm.gnosis.crypto.utils.asEthereumAddressChecksumString
-import pm.gnosis.ethereum.Block
-import pm.gnosis.ethereum.EthGetStorageAt
-import pm.gnosis.ethereum.EthereumRepository
 import pm.gnosis.model.Solidity
 import pm.gnosis.svalinn.common.PreferencesManager
 import pm.gnosis.svalinn.common.utils.edit
 import pm.gnosis.utils.asEthereumAddress
 import pm.gnosis.utils.asEthereumAddressString
-import java.math.BigInteger
 
 class SafeRepository(
     private val safeDao: SafeDao,
     private val preferencesManager: PreferencesManager,
-    private val ethereumRepository: EthereumRepository,
     private val transactionServiceApi: TransactionServiceApi
 ) {
 
@@ -102,10 +97,6 @@ class SafeRepository(
 
         fun masterCopyVersion(masterCopy: Solidity.Address?): String? = supportedContracts[masterCopy]
 
-
-        fun isSupported(masterCopy: Solidity.Address?) =
-            supportedContracts.containsKey(masterCopy)
-
         fun isLatestVersion(address: Solidity.Address?): Boolean = address == SAFE_MASTER_COPY_1_1_1
 
         private val supportedContracts = mapOf(
@@ -114,8 +105,6 @@ class SafeRepository(
             SAFE_MASTER_COPY_1_0_0 to "1.0.0",
             SAFE_MASTER_COPY_1_1_1 to "1.1.1"
         )
-
-        fun isSettingsMethod(methodName: String?): Boolean = settingMethodNames.contains(methodName)
 
         const val METHOD_SET_FALLBACK_HANDLER = "setFallbackHandler"
         const val METHOD_ADD_OWNER_WITH_THRESHOLD = "addOwnerWithThreshold"
@@ -126,15 +115,5 @@ class SafeRepository(
         const val METHOD_ENABLE_MODULE = "enableModule"
         const val METHOD_DISABLE_MODULE = "disableModule"
 
-        private val settingMethodNames = listOf(
-            METHOD_SET_FALLBACK_HANDLER,
-            METHOD_ADD_OWNER_WITH_THRESHOLD,
-            METHOD_REMOVE_OWNER,
-            METHOD_SWAP_OWNER,
-            METHOD_CHANGE_THRESHOLD,
-            METHOD_CHANGE_MASTER_COPY,
-            METHOD_ENABLE_MODULE,
-            METHOD_DISABLE_MODULE
-        )
     }
 }

--- a/data/src/test/java/io/gnosis/data/repositories/SafeRepositoryTest.kt
+++ b/data/src/test/java/io/gnosis/data/repositories/SafeRepositoryTest.kt
@@ -21,7 +21,6 @@ import java.math.BigInteger
 class SafeRepositoryTest {
 
     private val safeDao = mockk<SafeDao>()
-    private val ethereumRepository = mockk<EthereumRepository>()
     private val transactionServiceApi = mockk<TransactionServiceApi>()
 
     private lateinit var preferences: TestPreferences
@@ -34,7 +33,7 @@ class SafeRepositoryTest {
             every { getSharedPreferences(any(), any()) } returns preferences
         }
         val preferencesManager = PreferencesManager(application)
-        safeRepository = SafeRepository(safeDao, preferencesManager, ethereumRepository, transactionServiceApi)
+        safeRepository = SafeRepository(safeDao, preferencesManager, transactionServiceApi)
     }
 
     @Test
@@ -132,7 +131,6 @@ class SafeRepositoryTest {
 
         assertEquals(true, actual)
         coVerify(exactly = 1) { transactionServiceApi.getSafeInfo(safeAddress.asEthereumAddressChecksumString()) }
-        coVerify { ethereumRepository wasNot Called }
     }
 
     @Test
@@ -145,7 +143,6 @@ class SafeRepositoryTest {
 
         assertEquals(false, actual)
         coVerify(exactly = 1) { transactionServiceApi.getSafeInfo(safeAddress.asEthereumAddressChecksumString()) }
-        coVerify { ethereumRepository wasNot Called }
     }
 
     @Test
@@ -226,11 +223,6 @@ class SafeRepositoryTest {
         }
         coVerify(exactly = 1) { transactionServiceApi.getSafeInfo(safeAddress.asEthereumAddressString()) }
     }
-
-    private fun buildSuccessfulEthRequest(from: Solidity.Address, masterCopy: Solidity.Address) =
-        EthGetStorageAt(from, BigInteger.ZERO, block = Block.LATEST).apply {
-            response = EthRequest.Response.Success(masterCopy.asEthereumAddressString())
-        }
 
     companion object {
         private const val ACTIVE_SAFE = "prefs.string.active_safe"

--- a/data/src/test/java/io/gnosis/data/repositories/SafeRepositoryTest.kt
+++ b/data/src/test/java/io/gnosis/data/repositories/SafeRepositoryTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import pm.gnosis.crypto.utils.asEthereumAddressChecksumString
 import pm.gnosis.ethereum.*
 import pm.gnosis.model.Solidity
 import pm.gnosis.svalinn.common.PreferencesManager
@@ -113,100 +114,38 @@ class SafeRepositoryTest {
     }
 
     @Test
-    fun `isValidSafe - (safe with master copy v0_0_2) should return true`() = runBlocking {
-        val safeAddress = Solidity.Address(BigInteger.ZERO)
-        val ethRequest = buildSuccessfulEthRequest(safeAddress, SafeRepository.SAFE_MASTER_COPY_0_0_2)
-        coEvery { ethereumRepository.request(any<EthGetStorageAt>()) } returns ethRequest
+    fun `isValidSafe - valid safe`() = runBlocking {
+        val safeAddress = Solidity.Address(BigInteger.ONE)
+        val safeInfoDto = SafeInfoDto(
+            Solidity.Address(BigInteger.ONE),
+            BigInteger.TEN,
+            1,
+            listOf(Solidity.Address(BigInteger.ONE)),
+            Solidity.Address(BigInteger.ONE),
+            listOf(Solidity.Address(BigInteger.ONE)),
+            Solidity.Address(BigInteger.ONE),
+            "v1"
+        )
+        coEvery { transactionServiceApi.getSafeInfo(any()) } returns safeInfoDto
 
         val actual = safeRepository.isValidSafe(safeAddress)
 
         assertEquals(true, actual)
-        coVerify(exactly = 1) { ethereumRepository.request(ethRequest) }
+        coVerify(exactly = 1) { transactionServiceApi.getSafeInfo(safeAddress.asEthereumAddressChecksumString()) }
+        coVerify { ethereumRepository wasNot Called }
     }
 
     @Test
-    fun `isValidSafe - (safe with master copy v0_1_0) should return true`() = runBlocking {
-        val safeAddress = Solidity.Address(BigInteger.ZERO)
-        val ethRequest = buildSuccessfulEthRequest(safeAddress, SafeRepository.SAFE_MASTER_COPY_0_1_0)
-        coEvery { ethereumRepository.request(any<EthGetStorageAt>()) } returns ethRequest
-
-        val actual = safeRepository.isValidSafe(safeAddress)
-
-        assertEquals(true, actual)
-        coVerify(exactly = 1) { ethereumRepository.request(ethRequest) }
-    }
-
-    @Test
-    fun `isValidSafe - (safe with master copy v1_0_0) should return true`() = runBlocking {
-        val safeAddress = Solidity.Address(BigInteger.ZERO)
-        val ethRequest = buildSuccessfulEthRequest(safeAddress, SafeRepository.SAFE_MASTER_COPY_1_0_0)
-        coEvery { ethereumRepository.request(any<EthGetStorageAt>()) } returns ethRequest
-
-        val actual = safeRepository.isValidSafe(safeAddress)
-
-        assertEquals(true, actual)
-        coVerify(exactly = 1) { ethereumRepository.request(ethRequest) }
-    }
-
-    @Test
-    fun `isValidSafe - (safe with master copy v1_1_1) should return true`() = runBlocking {
-        val safeAddress = Solidity.Address(BigInteger.ZERO)
-        val ethRequest = buildSuccessfulEthRequest(safeAddress, SafeRepository.SAFE_MASTER_COPY_1_1_1)
-        coEvery { ethereumRepository.request(any<EthGetStorageAt>()) } returns ethRequest
-
-        val actual = safeRepository.isValidSafe(safeAddress)
-
-        assertEquals(true, actual)
-        coVerify(exactly = 1) { ethereumRepository.request(ethRequest) }
-    }
-
-    @Test
-    fun `isValidSafe - (safe with unknown master copy) should return false`() = runBlocking {
-        val safeAddress = Solidity.Address(BigInteger.ZERO)
-        val ethRequest = buildSuccessfulEthRequest(safeAddress, Solidity.Address(BigInteger.ONE))
-        coEvery { ethereumRepository.request(any<EthGetStorageAt>()) } returns ethRequest
+    fun `isValidSafe - invalid safe`() = runBlocking {
+        val safeAddress = Solidity.Address(BigInteger.ONE)
+        val throwable = Throwable()
+        coEvery { transactionServiceApi.getSafeInfo(any()) } throws throwable
 
         val actual = safeRepository.isValidSafe(safeAddress)
 
         assertEquals(false, actual)
-        coVerify(exactly = 1) { ethereumRepository.request(ethRequest) }
-    }
-
-    @Test
-    fun `isValidSafe - (safe with mastercopy but request failure) should throw`() = runBlocking {
-        val errorMessage = "Error message"
-        val safeAddress = Solidity.Address(BigInteger.ZERO)
-        val ethRequest = EthGetStorageAt(safeAddress, BigInteger.ZERO, block = Block.LATEST).apply {
-            response = EthRequest.Response.Failure(errorMessage)
-        }
-        coEvery { ethereumRepository.request(any<EthGetStorageAt>()) } returns ethRequest
-
-        val actual = runCatching { safeRepository.isValidSafe(safeAddress) }
-
-        with(actual) {
-            assertEquals(true, isFailure)
-            val exception = exceptionOrNull()
-            assert(exception is RequestFailedException && true == exception.message?.contains(errorMessage))
-            coVerify(exactly = 1) { ethereumRepository.request(ethRequest) }
-        }
-    }
-
-    @Test
-    fun `isValidSafe - (safe with mastercopy but request response is null) should throw`() = runBlocking {
-        val safeAddress = Solidity.Address(BigInteger.ZERO)
-        val ethRequest = EthGetStorageAt(safeAddress, BigInteger.ZERO, block = Block.LATEST).apply {
-            response = null
-        }
-        coEvery { ethereumRepository.request(any<EthGetStorageAt>()) } returns ethRequest
-
-        val actual = runCatching { safeRepository.isValidSafe(safeAddress) }
-
-        with(actual) {
-            assertEquals(true, isFailure)
-            val exception = exceptionOrNull()
-            assert(exception is RequestNotExecutedException && exception.message == "Valid safe check failed")
-            coVerify(exactly = 1) { ethereumRepository.request(ethRequest) }
-        }
+        coVerify(exactly = 1) { transactionServiceApi.getSafeInfo(safeAddress.asEthereumAddressChecksumString()) }
+        coVerify { ethereumRepository wasNot Called }
     }
 
     @Test


### PR DESCRIPTION
References #708 .

Changes proposed in this pull request:
- Use `TransactionServiceApi` instead of blockchain validation for valid safe adding


@gnosis/mobile-devs
