### PR TITLE
View collectible details

### DIFF
--- a/app/src/main/java/io/gnosis/safe/di/components/ViewComponent.kt
+++ b/app/src/main/java/io/gnosis/safe/di/components/ViewComponent.kt
@@ -7,6 +7,7 @@ import io.gnosis.safe.ui.StartActivity
 import io.gnosis.safe.ui.assets.AssetsFragment
 import io.gnosis.safe.ui.assets.coins.CoinsFragment
 import io.gnosis.safe.ui.assets.collectibles.CollectiblesFragment
+import io.gnosis.safe.ui.assets.collectibles.details.CollectiblesDetailsFragment
 import io.gnosis.safe.ui.dialogs.EnsInputDialog
 import io.gnosis.safe.ui.safe.add.AddSafeFragment
 import io.gnosis.safe.ui.safe.add.AddSafeNameFragment
@@ -68,6 +69,8 @@ interface ViewComponent {
     fun inject(fragment: CoinsFragment)
 
     fun inject(fragment: CollectiblesFragment)
+
+    fun inject(fragment: CollectiblesDetailsFragment)
 
     fun inject(fragment: AdvancedSafeSettingsFragment)
 

--- a/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsFragment.kt
@@ -85,7 +85,6 @@ class CoinsFragment : BaseViewBindingFragment<FragmentCoinsBinding>() {
                 }
             }
         })
-        viewModel.load()
     }
 
     private fun hideLoading() {

--- a/app/src/main/java/io/gnosis/safe/ui/assets/collectibles/CollectiblesViewHolderFactory.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/collectibles/CollectiblesViewHolderFactory.kt
@@ -5,17 +5,20 @@ import android.graphics.drawable.Drawable
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.ImageView
+import androidx.navigation.Navigation
 import androidx.viewbinding.ViewBinding
 import com.squareup.picasso.Picasso
 import com.squareup.picasso.Target
 import io.gnosis.safe.R
 import io.gnosis.safe.databinding.ItemCollectibleCollectibleBinding
 import io.gnosis.safe.databinding.ItemCollectibleNftHeaderBinding
+import io.gnosis.safe.ui.assets.AssetsFragmentDirections
 import io.gnosis.safe.ui.base.adapter.Adapter
 import io.gnosis.safe.ui.base.adapter.BaseFactory
 import io.gnosis.safe.ui.base.adapter.UnsupportedViewType
 import pm.gnosis.svalinn.common.utils.getColorCompat
 import pm.gnosis.svalinn.common.utils.visible
+import pm.gnosis.utils.asEthereumAddressString
 
 enum class CollectiblesViewType {
     NFT_HEADER,
@@ -75,6 +78,18 @@ class CollectibleItemViewHolder(private val viewBinding: ItemCollectibleCollecti
             }
             description.text = data.collectible.description
             logo.loadCollectibleImage(data.collectible.imageUri, this@CollectibleItemViewHolder)
+            root.setOnClickListener {
+                Navigation.findNavController(it).navigate(
+                    AssetsFragmentDirections.actionAssetsFragmentToCollectiblesDetailsFragment(
+                        data.collectible.address.asEthereumAddressString(),
+                        data.collectible.name,
+                        data.collectible.id,
+                        data.collectible.description,
+                        data.collectible.uri,
+                        data.collectible.imageUri
+                    )
+                )
+            }
         }
     }
 
@@ -98,7 +113,7 @@ fun ImageView.setCollectiblePlaceholder() {
 }
 
 fun ImageView.setCollectibleBitmap(bitmap: Bitmap?) {
-    scaleType = ImageView.ScaleType.FIT_CENTER
+    scaleType = ImageView.ScaleType.CENTER_CROP
     background = null
     setImageBitmap(bitmap)
 }

--- a/app/src/main/java/io/gnosis/safe/ui/assets/collectibles/details/CollectiblesDetailsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/collectibles/details/CollectiblesDetailsFragment.kt
@@ -47,7 +47,11 @@ class CollectiblesDetailsFragment : BaseViewBindingFragment<FragmentCollectibles
             collectibleImage.loadCollectibleImage(imageUri)
             collectibleName.text = name ?: getString(R.string.collectibles_unknown)
             collectibleId.text = id
-            collectibleDescription.text = description
+            if (description != null) {
+                collectibleDescription.text = description
+            } else {
+                collectibleDescription.visible(false)
+            }
             collectibleContract.label = getString(R.string.collectibles_asset_contract)
             collectibleContract.address = contract.asEthereumAddress()
 

--- a/app/src/main/java/io/gnosis/safe/ui/assets/collectibles/details/CollectiblesDetailsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/collectibles/details/CollectiblesDetailsFragment.kt
@@ -1,0 +1,62 @@
+package io.gnosis.safe.ui.assets.collectibles.details
+
+import android.net.Uri
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.navigation.Navigation
+import androidx.navigation.fragment.navArgs
+import io.gnosis.safe.R
+import io.gnosis.safe.ScreenId
+import io.gnosis.safe.databinding.FragmentCollectiblesDetailsBinding
+import io.gnosis.safe.di.components.ViewComponent
+import io.gnosis.safe.ui.base.fragment.BaseViewBindingFragment
+import pm.gnosis.svalinn.common.utils.openUrl
+import pm.gnosis.svalinn.common.utils.visible
+import pm.gnosis.utils.asEthereumAddress
+
+class CollectiblesDetailsFragment : BaseViewBindingFragment<FragmentCollectiblesDetailsBinding>() {
+
+    override fun screenId() = ScreenId.ASSETS_COLLECTIBLES_DETAILS
+
+    private val navArgs by navArgs<CollectiblesDetailsFragmentArgs>()
+    private val contract by lazy { navArgs.contract }
+    private val name by lazy { navArgs.name }
+    private val id by lazy { navArgs.id }
+    private val description by lazy { navArgs.description }
+    private val uri by lazy { navArgs.uri }
+    private val imageUri by lazy { navArgs.imageUri }
+
+    override fun inject(component: ViewComponent) {
+        component.inject(this)
+    }
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentCollectiblesDetailsBinding =
+        FragmentCollectiblesDetailsBinding.inflate(inflater, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        with(binding) {
+
+            collectibleName.text = name
+            collectibleId.text = id
+            collectibleDescription.text = description
+            collectibleContract.label = getString(R.string.collectibles_asset_contract)
+            collectibleContract.address = contract.asEthereumAddress()
+
+            if (uri != null) {
+                collectibleUri.text = getString(R.string.collectibles_view_on, Uri.parse(uri).let { it.encodedAuthority })
+                collectibleUri.setOnClickListener {
+                    requireContext().openUrl(uri!!)
+                }
+            } else {
+                collectibleUri.visible(false)
+            }
+
+            backButton.setOnClickListener {
+                Navigation.findNavController(it).navigateUp()
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/gnosis/safe/ui/assets/collectibles/details/CollectiblesDetailsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/collectibles/details/CollectiblesDetailsFragment.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import android.widget.LinearLayout
 import androidx.navigation.Navigation
 import androidx.navigation.fragment.navArgs
 import com.squareup.picasso.Picasso
@@ -17,6 +18,7 @@ import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentCollectiblesDetailsBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.ui.base.fragment.BaseViewBindingFragment
+import io.gnosis.safe.utils.dpToPx
 import pm.gnosis.svalinn.common.utils.openUrl
 import pm.gnosis.svalinn.common.utils.visible
 import pm.gnosis.utils.asEthereumAddress
@@ -44,6 +46,8 @@ class CollectiblesDetailsFragment : BaseViewBindingFragment<FragmentCollectibles
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         with(binding) {
+            collectibleImage.layoutParams.width = resources.displayMetrics.widthPixels - dpToPx(32)
+            collectibleImage.layoutParams.height = resources.displayMetrics.widthPixels - dpToPx(32)
             collectibleImage.loadCollectibleImage(imageUri)
             collectibleName.text = name ?: getString(R.string.collectibles_unknown)
             collectibleId.text = id

--- a/app/src/main/java/io/gnosis/safe/ui/assets/collectibles/details/CollectiblesDetailsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/collectibles/details/CollectiblesDetailsFragment.kt
@@ -89,6 +89,7 @@ fun ImageView.loadCollectibleImage(logo: String?) {
                 }
 
                 override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
+                    (parent as View).visible(true)
                     setImageBitmap(bitmap)
                 }
             })

--- a/app/src/main/java/io/gnosis/safe/ui/assets/collectibles/details/CollectiblesDetailsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/collectibles/details/CollectiblesDetailsFragment.kt
@@ -1,12 +1,17 @@
 package io.gnosis.safe.ui.assets.collectibles.details
 
+import android.graphics.Bitmap
+import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import androidx.navigation.Navigation
 import androidx.navigation.fragment.navArgs
+import com.squareup.picasso.Picasso
+import com.squareup.picasso.Target
 import io.gnosis.safe.R
 import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentCollectiblesDetailsBinding
@@ -15,6 +20,7 @@ import io.gnosis.safe.ui.base.fragment.BaseViewBindingFragment
 import pm.gnosis.svalinn.common.utils.openUrl
 import pm.gnosis.svalinn.common.utils.visible
 import pm.gnosis.utils.asEthereumAddress
+import java.lang.Exception
 
 class CollectiblesDetailsFragment : BaseViewBindingFragment<FragmentCollectiblesDetailsBinding>() {
 
@@ -38,8 +44,8 @@ class CollectiblesDetailsFragment : BaseViewBindingFragment<FragmentCollectibles
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         with(binding) {
-
-            collectibleName.text = name
+            collectibleImage.loadCollectibleImage(imageUri)
+            collectibleName.text = name ?: getString(R.string.collectibles_unknown)
             collectibleId.text = id
             collectibleDescription.text = description
             collectibleContract.label = getString(R.string.collectibles_asset_contract)
@@ -58,5 +64,26 @@ class CollectiblesDetailsFragment : BaseViewBindingFragment<FragmentCollectibles
                 Navigation.findNavController(it).navigateUp()
             }
         }
+    }
+}
+
+fun ImageView.loadCollectibleImage(logo: String?) {
+    if (!logo.isNullOrBlank()) {
+        Picasso.get()
+            .load(logo)
+            .into(object : Target {
+
+                override fun onPrepareLoad(placeHolderDrawable: Drawable?) {}
+
+                override fun onBitmapFailed(e: Exception?, errorDrawable: Drawable?) {
+                    visible(false)
+                }
+
+                override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
+                    setImageBitmap(bitmap)
+                }
+            })
+    } else {
+        visible(false)
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/assets/collectibles/details/CollectiblesDetailsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/collectibles/details/CollectiblesDetailsFragment.kt
@@ -46,8 +46,9 @@ class CollectiblesDetailsFragment : BaseViewBindingFragment<FragmentCollectibles
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         with(binding) {
-            collectibleImage.layoutParams.width = resources.displayMetrics.widthPixels - dpToPx(32)
-            collectibleImage.layoutParams.height = resources.displayMetrics.widthPixels - dpToPx(32)
+            val width = resources.displayMetrics.widthPixels - dpToPx(32)
+            collectibleImageContainer.layoutParams.width = width
+            collectibleImageContainer.layoutParams.height = width
             collectibleImage.loadCollectibleImage(imageUri)
             collectibleName.text = name ?: getString(R.string.collectibles_unknown)
             collectibleId.text = id
@@ -84,7 +85,7 @@ fun ImageView.loadCollectibleImage(logo: String?) {
                 override fun onPrepareLoad(placeHolderDrawable: Drawable?) {}
 
                 override fun onBitmapFailed(e: Exception?, errorDrawable: Drawable?) {
-                    visible(false)
+                    (parent as View).visible(false)
                 }
 
                 override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
@@ -92,6 +93,6 @@ fun ImageView.loadCollectibleImage(logo: String?) {
                 }
             })
     } else {
-        visible(false)
+        (parent as View).visible(false)
     }
 }

--- a/app/src/main/res/layout/fragment_collectibles_details.xml
+++ b/app/src/main/res/layout/fragment_collectibles_details.xml
@@ -65,7 +65,8 @@
                 android:layout_marginTop="16dp"
                 android:layout_marginEnd="16dp"
                 app:cardBackgroundColor="@color/white"
-                app:cardCornerRadius="8dp">
+                app:cardCornerRadius="8dp"
+                android:visibility="gone">
 
                 <ImageView
                     android:id="@+id/collectible_image"

--- a/app/src/main/res/layout/fragment_collectibles_details.xml
+++ b/app/src/main/res/layout/fragment_collectibles_details.xml
@@ -58,7 +58,7 @@
                 android:id="@+id/collectible_image"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:scaleType="fitCenter"
+                android:scaleType="centerCrop"
                 android:layout_marginTop="16dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp" />

--- a/app/src/main/res/layout/fragment_collectibles_details.xml
+++ b/app/src/main/res/layout/fragment_collectibles_details.xml
@@ -95,7 +95,8 @@
             <io.gnosis.safe.ui.settings.view.LabeledAddressItem
                 android:id="@+id/collectible_contract"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content"
+                android:background="@drawable/background_selectable_white"/>
 
             <TextView
                 android:id="@+id/collectible_uri"

--- a/app/src/main/res/layout/fragment_collectibles_details.xml
+++ b/app/src/main/res/layout/fragment_collectibles_details.xml
@@ -54,14 +54,24 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <ImageView
-                android:id="@+id/collectible_image"
+            <androidx.cardview.widget.CardView
+                android:id="@+id/collectible_image_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:scaleType="centerCrop"
-                android:layout_marginTop="16dp"
+                android:layout_gravity="center"
                 android:layout_marginStart="16dp"
-                android:layout_marginEnd="16dp" />
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                app:cardBackgroundColor="@color/white"
+                app:cardCornerRadius="8dp">
+
+                <ImageView
+                    android:id="@+id/collectible_image"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:scaleType="centerCrop" />
+
+            </androidx.cardview.widget.CardView>
 
             <TextView
                 android:id="@+id/collectible_name"

--- a/app/src/main/res/layout/fragment_collectibles_details.xml
+++ b/app/src/main/res/layout/fragment_collectibles_details.xml
@@ -17,7 +17,8 @@
             android:id="@+id/toolbar_layout"
             style="@style/Toolbar"
             android:gravity="center_vertical"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            app:layout_scrollFlags="scroll|enterAlways">
 
             <ImageButton
                 android:id="@+id/back_button"
@@ -52,6 +53,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:paddingBottom="16dp"
             android:orientation="vertical">
 
             <androidx.cardview.widget.CardView

--- a/app/src/main/res/layout/fragment_collectibles_details.xml
+++ b/app/src/main/res/layout/fragment_collectibles_details.xml
@@ -57,7 +57,11 @@
             <ImageView
                 android:id="@+id/collectible_image"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content"
+                android:scaleType="fitCenter"
+                android:layout_marginTop="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp" />
 
             <TextView
                 android:id="@+id/collectible_name"

--- a/app/src/main/res/layout/fragment_collectibles_details.xml
+++ b/app/src/main/res/layout/fragment_collectibles_details.xml
@@ -124,8 +124,10 @@
                 android:layout_marginEnd="16dp"
                 android:drawableEnd="@drawable/ic_link_green_24dp"
                 android:drawablePadding="6dp"
+                android:ellipsize="middle"
                 android:gravity="start|center_vertical"
-                tools:text="View on dappcon.io" />
+                tools:text="View on dappcon.io"
+                android:singleLine="true" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_collectibles_details.xml
+++ b/app/src/main/res/layout/fragment_collectibles_details.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/white">
+
+        <LinearLayout
+            android:id="@+id/toolbar_layout"
+            style="@style/Toolbar"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ImageButton
+                android:id="@+id/back_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_weight="0"
+                android:background="@android:color/transparent"
+                android:gravity="center_vertical"
+                android:src="@drawable/ic_baseline_arrow_back_24" />
+
+            <TextView
+                android:id="@+id/title"
+                style="@style/ToolbarTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_weight="1"
+                android:gravity="start"
+                android:text="@string/collectibles_details" />
+
+        </LinearLayout>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <ImageView
+                android:id="@+id/collectible_image"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:id="@+id/collectible_name"
+                style="@style/TextDark.Bold"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp" />
+
+            <TextView
+                android:id="@+id/collectible_id"
+                style="@style/TextLight.Small"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp" />
+
+            <TextView
+                android:id="@+id/collectible_description"
+                style="@style/TextDark"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginTop="18dp"
+                android:background="@color/whitesmoke_two" />
+
+            <io.gnosis.safe.ui.settings.view.LabeledAddressItem
+                android:id="@+id/collectible_contract"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:id="@+id/collectible_uri"
+                style="@style/TextLink"
+                android:layout_width="wrap_content"
+                android:layout_height="@dimen/item_setting_openable_height"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:drawableEnd="@drawable/ic_link_green_24dp"
+                android:drawablePadding="6dp"
+                android:gravity="start|center_vertical"
+                tools:text="View on dappcon.io" />
+
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/navigation/main_nav.xml
+++ b/app/src/main/res/navigation/main_nav.xml
@@ -36,7 +36,55 @@
         android:id="@+id/assetsFragment"
         android:name="io.gnosis.safe.ui.assets.AssetsFragment"
         android:label="AssetsFragment"
-        tools:layout="@layout/fragment_assets" />
+        tools:layout="@layout/fragment_assets">
+
+        <action
+            android:id="@+id/action_assetsFragment_to_collectiblesDetailsFragment"
+            app:destination="@id/collectiblesDetailsFragment" />
+
+    </fragment>
+
+    <fragment
+        android:id="@+id/collectiblesDetailsFragment"
+        android:name="io.gnosis.safe.ui.assets.collectibles.details.CollectiblesDetailsFragment"
+        android:label="CollectiblesDetailsFragment"
+        tools:layout="@layout/fragment_collectibles_details">
+
+        <argument
+            android:name="contract"
+            app:argType="string" />
+
+        <argument
+            android:name="name"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
+
+        <argument
+            android:name="id"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
+
+        <argument
+            android:name="description"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
+
+        <argument
+            android:name="uri"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
+
+        <argument
+            android:name="imageUri"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
+
+    </fragment>
 
     <fragment
         android:id="@+id/settingsFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,9 @@
 
     <string name="collectibles_empty">Collectibles will appear here</string>
     <string name="collectibles_unknown">Unknown</string>
+    <string name="collectibles_details">Collectible details</string>
+    <string name="collectibles_asset_contract">Asset Contract</string>
+    <string name="collectibles_view_on">View on %1$s</string>
 
     <string name="settings_tab_safe">SAFE SETTINGS</string>
     <string name="settings_tab_app">APP SETTINGS</string>


### PR DESCRIPTION
Handles #846 

Changes proposed in this pull request:
- Add fragment for collectible details
- Navigate to collectible details screen from collectibles list
- Center-crop collectible list images

@gnosis/mobile-devs
