### PR TITLE
Fetch tags before trying to read it

### DIFF
--- a/ci/prepare_env_buildkite.sh
+++ b/ci/prepare_env_buildkite.sh
@@ -3,11 +3,9 @@
 set -e
 
 export APP_VERSION_CODE=$((BUILDKITE_BUILD_NUMBER))
+# get newest tags from origin
+git fetch
 # strip the first char as that should always be "v" (as tags should be in the format "vX.X.X")
 description="$(git describe --tags --always)"
 export APP_VERSION_NAME=${description:1}
 export APP_RELEASE_NOTES=$BUILDKITE_MESSAGE
-
-
-
-


### PR DESCRIPTION
Closes #874  .

Changes proposed in this pull request:
- Add fetch before accessing tags with git
- Fetch shouldn't break anything and it makes the tag available
- 

@gnosis/mobile-devs
