### PR TITLE
This is not used anymore

### DIFF
--- a/buildsystem/versions.gradle
+++ b/buildsystem/versions.gradle
@@ -45,7 +45,6 @@ ext {
             status_keycard                  : '3.0.1',
             svalinn                         : 'v0.12.1',
             timber                          : '4.7.1',
-            wallet_connect                  : '0.9.6',
             zxing                           : '3.3.1',
             kotlinx_coroutines              : '1.3.5',
 


### PR DESCRIPTION
kinda sad to see there is no @walletconnect in gnosis safe anymore. But if removing it should be gone completely.
Wondering if you plan to add again at some point? If so it would be great to have an eye on (and maybe approve): https://github.com/WalletConnect/kotlin-walletconnect-lib/pulls

@gnosis/mobile-devs
