### PR TITLE
Show amount (+/-1 <SYMBOL>) instead of name for NFTs

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsFragment.kt
@@ -135,7 +135,6 @@ class TransactionDetailsFragment : BaseViewBindingFragment<FragmentTransactionDe
                             amount = txInfo.formattedAmount(balanceFormatter),
                             logoUri = txInfo.logoUri() ?: "",
                             address = address,
-                            tokenName = transferInfo.tokenName ?: getString(R.string.tx_details_token_name_unknown),
                             tokenId = transferInfo.tokenId
                         )
 

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/view/Erc721View.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/view/Erc721View.kt
@@ -7,6 +7,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import io.gnosis.safe.R
 import io.gnosis.safe.databinding.ViewTxErc721Binding
 import io.gnosis.safe.utils.loadTokenLogo
+import pm.gnosis.svalinn.common.utils.getColorCompat
 
 class Erc721View @JvmOverloads constructor(
     context: Context,
@@ -16,9 +17,16 @@ class Erc721View @JvmOverloads constructor(
 
     private val binding by lazy { ViewTxErc721Binding.inflate(LayoutInflater.from(context), this) }
 
-    fun setToken(logoUri: String, tokenId: String?, tokenName: String?, tokenDescription: String?) {
-        binding.tokenName.text = tokenName
+    fun setToken(logoUri: String, tokenId: String?, outgoing: Boolean, amount: String?) {
         binding.logo.loadTokenLogo(logoUri, R.drawable.ic_nft_placeholder)
         binding.tokenId.text = tokenId
+
+        if (outgoing) {
+            binding.tokenAmount.text = amount
+            binding.tokenAmount.setTextColor(context.getColorCompat(R.color.gnosis_dark_blue))
+        } else {
+            binding.tokenAmount.text = amount
+            binding.tokenAmount.setTextColor(context.getColorCompat(R.color.safe_green))
+        }
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/view/Erc721View.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/view/Erc721View.kt
@@ -17,16 +17,18 @@ class Erc721View @JvmOverloads constructor(
 
     private val binding by lazy { ViewTxErc721Binding.inflate(LayoutInflater.from(context), this) }
 
-    fun setToken(logoUri: String, tokenId: String?, outgoing: Boolean, amount: String?) {
-        binding.logo.loadTokenLogo(logoUri, R.drawable.ic_nft_placeholder)
-        binding.tokenId.text = tokenId
+    fun setToken(logoUri: String, nftId: String?, outgoing: Boolean, amount: String?) {
+        with(binding) {
+            logo.loadTokenLogo(logoUri, R.drawable.ic_nft_placeholder)
+            tokenId.text = nftId
 
-        if (outgoing) {
-            binding.tokenAmount.text = amount
-            binding.tokenAmount.setTextColor(context.getColorCompat(R.color.gnosis_dark_blue))
-        } else {
-            binding.tokenAmount.text = amount
-            binding.tokenAmount.setTextColor(context.getColorCompat(R.color.safe_green))
+            if (outgoing) {
+                tokenAmount.text = amount
+                tokenAmount.setTextColor(context.getColorCompat(R.color.gnosis_dark_blue))
+            } else {
+                tokenAmount.text = amount
+                tokenAmount.setTextColor(context.getColorCompat(R.color.safe_green))
+            }
         }
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/view/TxTransferActionView.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/view/TxTransferActionView.kt
@@ -31,16 +31,14 @@ class TxTransferActionView @JvmOverloads constructor(
         amount: String,
         logoUri: String,
         address: Solidity.Address,
-        tokenName: String = "",
-        tokenId: String = "",
-        tokenDescription: String = ""
+        tokenId: String = ""
     ) {
 
         clear()
 
         if (outgoing) {
-            if (tokenId.isNotEmpty() || tokenName.isNotEmpty() || tokenDescription.isNotEmpty()) {
-                addErc721Item(logoUri, outgoing, tokenId, tokenName, tokenDescription)
+            if (tokenId.isNotEmpty()) {
+                addErc721Item(logoUri, outgoing, tokenId, amount)
             } else {
                 addAmountItem(amount, logoUri, outgoing)
             }
@@ -53,20 +51,20 @@ class TxTransferActionView @JvmOverloads constructor(
         if (outgoing) {
             addAddressItem(address)
         } else {
-            if (tokenId.isNotEmpty() || tokenName.isNotEmpty() || tokenDescription.isNotEmpty()) {
-                addErc721Item(logoUri, outgoing, tokenId, tokenName, tokenDescription)
+            if (tokenId.isNotEmpty()) {
+                addErc721Item(logoUri, outgoing, tokenId, amount)
             } else {
                 addAmountItem(amount, logoUri, outgoing)
             }
         }
     }
 
-    private fun addErc721Item(logoUri: String, outgoing: Boolean, tokenId: String?, tokenName: String?, tokenDescription: String?) {
+    private fun addErc721Item(logoUri: String, outgoing: Boolean, tokenId: String?, amount: String?) {
         val tokenView = Erc721View(context)
         val layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
         layoutParams.setMargins(dpToPx(DEFAULT_MARGIN), 0, 0, 0)
         tokenView.layoutParams = layoutParams
-        tokenView.setToken(logoUri, tokenId, tokenName, tokenDescription)
+        tokenView.setToken(logoUri, tokenId, outgoing, amount)
         addView(tokenView)
     }
 

--- a/app/src/main/res/layout/item_tx_transfer.xml
+++ b/app/src/main/res/layout/item_tx_transfer.xml
@@ -90,8 +90,8 @@
 
     <pm.gnosis.blockies.BlockiesImageView
         android:id="@+id/blockies"
-        android:layout_width="36dp"
-        android:layout_height="36dp"
+        android:layout_width="@dimen/safe_blockie_size"
+        android:layout_height="@dimen/safe_blockie_size"
         android:layout_marginStart="@dimen/default_small_margin"
         android:layout_marginTop="@dimen/default_margin"
         app:layout_constraintStart_toEndOf="@+id/tx_type_icon"

--- a/app/src/main/res/layout/view_tx_erc721.xml
+++ b/app/src/main/res/layout/view_tx_erc721.xml
@@ -20,7 +20,7 @@
         style="@style/TextDark"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/default_small_margin"
+        android:layout_marginStart="@dimen/default_margin"
         tools:text="-1 LBB"
         app:layout_constraintStart_toEndOf="@+id/logo"
         app:layout_constraintTop_toTopOf="@+id/logo" />

--- a/app/src/main/res/layout/view_tx_erc721.xml
+++ b/app/src/main/res/layout/view_tx_erc721.xml
@@ -8,8 +8,8 @@
 
     <ImageView
         android:id="@+id/logo"
-        android:layout_width="36dp"
-        android:layout_height="36dp"
+        android:layout_width="@dimen/safe_blockie_size"
+        android:layout_height="@dimen/safe_blockie_size"
         android:layout_marginTop="@dimen/default_small_margin"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
@@ -29,7 +29,7 @@
         android:id="@+id/token_id"
         style="@style/TextMedium"
         android:layout_width="0dp"
-        android:layout_height="19dp"
+        android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/default_small_margin"
         android:layout_marginEnd="@dimen/default_margin"
         android:layout_marginTop="2dp"

--- a/app/src/main/res/layout/view_tx_erc721.xml
+++ b/app/src/main/res/layout/view_tx_erc721.xml
@@ -8,20 +8,20 @@
 
     <ImageView
         android:id="@+id/logo"
-        android:layout_width="wrap_content"
-        android:layout_height="0dp"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
         android:layout_marginTop="@dimen/default_small_margin"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_nft_placeholder" />
 
     <TextView
-        android:id="@+id/token_name"
+        android:id="@+id/token_amount"
         style="@style/TextDark"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/default_small_margin"
-        tools:text="Earlybird Ticket"
+        tools:text="-1 LBB"
         app:layout_constraintStart_toEndOf="@+id/logo"
         app:layout_constraintTop_toTopOf="@+id/logo" />
 
@@ -29,15 +29,16 @@
         android:id="@+id/token_id"
         style="@style/TextMedium"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="19dp"
         android:layout_marginBottom="@dimen/default_small_margin"
         android:layout_marginEnd="@dimen/default_margin"
+        android:layout_marginTop="2dp"
         android:ellipsize="middle"
         android:singleLine="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/token_name"
-        app:layout_constraintTop_toBottomOf="@+id/token_name"
+        app:layout_constraintStart_toStartOf="@+id/token_amount"
+        app:layout_constraintTop_toBottomOf="@+id/token_amount"
         tools:text="2138746948" />
 
 </merge>


### PR DESCRIPTION
Regading #792 .

Changes proposed in this pull request:
- We don't show the token name only amount (and symbol) and tokenId below 
See: https://zpl.io/2GKm9xE and https://zpl.io/VDyzLp3


ENS | LBB in   | LBB out
---- | -------- | --------
![Screenshot_20200921-160542](https://user-images.githubusercontent.com/246473/93776894-6020b580-fc24-11ea-8a79-8aa78e60e2d9.png) | ![Screenshot_20200921-155704](https://user-images.githubusercontent.com/246473/93776721-25b71880-fc24-11ea-9446-7aae77b2c7cb.png) | ![Screenshot_20200921-160518](https://user-images.githubusercontent.com/246473/93777016-847c9200-fc24-11ea-943a-f621e2c78f2a.png)



@gnosis/mobile-devs
