### PR TITLE
Share safe dialog

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
@@ -119,14 +119,27 @@ class StartActivity : BaseActivity(), SafeOverviewNavigationHandler {
     private fun setSafe(safe: Safe) {
         with(toolbarBinding) {
             safeImage.setOnClickListener {
-                Navigation.findNavController(this@StartActivity, R.id.nav_host).navigate(R.id.shareSafeDialog)
+                navigateToShareSafeDialog()
             }
             safeImage.setAddress(safe.address)
+
             safeName.visible(true)
             safeName.text = safe.localName
+            safeName.setOnClickListener {
+                navigateToShareSafeDialog()
+            }
+
             safeAddress.text = safe.address.asEthereumAddressChecksumString().abbreviateEthAddress()
+            safeAddress.setOnClickListener {
+                navigateToShareSafeDialog()
+            }
+
             safeSelection.visible(true)
         }
+    }
+
+    private fun navigateToShareSafeDialog() {
+        Navigation.findNavController(this@StartActivity, R.id.nav_host).navigate(R.id.shareSafeDialog)
     }
 
     override fun screenId() = null

--- a/app/src/main/java/io/gnosis/safe/ui/safe/share/ShareSafeDialog.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/share/ShareSafeDialog.kt
@@ -75,8 +75,8 @@ class ShareSafeDialog : BaseViewBindingDialogFragment<DialogShareSafeBinding>() 
             safeDetails.safe.address.let { address ->
                 safeAddress.text = safeDetails.safe.address.formatEthAddress(requireContext(), addMiddleLinebreak = false)
                 safeAddress.setOnClickListener {
-                    requireContext().copyToClipboard(getString(R.string.url_copied), address.asEthereumAddressChecksumString()) {
-                        snackbar(requireView(), getString(R.string.url_copied_success))
+                    requireContext().copyToClipboard(getString(R.string.address_copied), address.asEthereumAddressChecksumString()) {
+                        snackbar(requireView(), getString(R.string.copied_success))
                     }
                 }
                 link.setOnClickListener {


### PR DESCRIPTION
Regarding #910 & #736  .

Changes proposed in this pull request:
- Show correct Snackbar text when tapping address in dialog
- Open dialog when tapping address or name in app bar
- 

@gnosis/mobile-devs
