### PR TITLE
Change font for status to 16sp by Using textDark style

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsFragment.kt
@@ -254,6 +254,7 @@ class TransactionDetailsFragment : BaseViewBindingFragment<FragmentTransactionDe
             }
         } else {
             binding.etherscan.visible(false)
+            binding.advancedDivider.visible(false)
         }
     }
 

--- a/app/src/main/res/layout/fragment_transaction_details_creation.xml
+++ b/app/src/main/res/layout/fragment_transaction_details_creation.xml
@@ -158,12 +158,6 @@
                 android:gravity="start|center_vertical"
                 android:text="@string/tx_details_view_on_etherscan" />
 
-            <View
-                android:id="@+id/etherscan_separator"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@color/light_grey"/>
-
         </LinearLayout>
 
     </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/view_tx_status.xml
+++ b/app/src/main/res/layout/view_tx_status.xml
@@ -19,7 +19,7 @@
 
     <TextView
         android:id="@+id/status"
-        style="@style/TextMedium"
+        style="@style/TextDark"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/default_small_margin"
@@ -45,6 +45,7 @@
 
     <TextView
         android:id="@+id/status_long"
+        style="@style/TextDark"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"


### PR DESCRIPTION
Regarding: #807 .

Changes proposed in this pull request:
- Change Font for status to 16sp
- Don't show divider after advanced section if no etherscan link available
- The other issues in #807 have already been addressed

Awaiting Confirmation | Success | Cancelled | Failed 
-----------------------|---------|-----------|-------
![Screenshot_20200921-165523](https://user-images.githubusercontent.com/246473/93783519-0de39280-fc2c-11ea-9ab7-da637db94129.png) | ![Screenshot_20200921-165537](https://user-images.githubusercontent.com/246473/93783535-150aa080-fc2c-11ea-9ecc-aec2aeeab13f.png) | ![Screenshot_20200921-165932](https://user-images.githubusercontent.com/246473/93783572-22c02600-fc2c-11ea-816a-20d57af1ba34.png) | ![Screenshot_20200921-165950](https://user-images.githubusercontent.com/246473/93783593-281d7080-fc2c-11ea-971a-0dd6ed88d4c7.png)








@gnosis/mobile-devs
