### PR TITLE
Firebase Crashlytics: Bumping recommended libs to recommended versions

### DIFF
--- a/buildsystem/versions.gradle
+++ b/buildsystem/versions.gradle
@@ -2,11 +2,11 @@ ext {
     versions = [
             // Plug-Ins
             android_tools                    : '4.0.1',
+            firebase_app_distribution_gradle : '2.0.0',
+            firebase_crashlytics_gradle      : '2.3.0',
             google_services                  : '4.3.3',
             kotlin                           : '1.3.72',
             jacoco                           : '0.8.5',
-            firebase_app_distribution_gradle : '2.0.0',
-            firebase_crashlytics_gradle      : '2.2.0',
 
             // Runtime dependencies
             androidx_app_compat             : '1.1.0',
@@ -23,11 +23,10 @@ ext {
             billing                         : '1.0',
             bivrost                         : '0.8.0',
             bouncycastle                    : '1.61',
-            crashlytics                     : '2.10.1',
             dagger                          : '2.17',
-            firebase_analytics              : '17.4.4',
+            firebase_analytics              : '17.5.0',
             firebase_messaging              : '20.2.4',
-            firebase_crashlytics            : '17.1.1',
+            firebase_crashlytics            : '17.2.1',
             floating_action_button          : '1.6.4',
             geth                            : '1.7.1',
             kethereum                       : '0.79.5',
@@ -53,8 +52,8 @@ ext {
             espresso                        : '3.1.1',
             junit                           : '4.12',
             mockito                         : '2.26.0',
-            powermock                       : '2.0.2',
             mockk                           : '1.9.3',
+            powermock                       : '2.0.2',
 
             // Build time dependencies
             desugar_jdk_libs                : '1.0.5'


### PR DESCRIPTION

Regarding #932 .

Changes proposed in this pull request:
- Bumped several libs to the version recommended in https://firebase.google.com/docs/crashlytics/upgrade-sdk?platform=android

@gnosis/mobile-devs
