### PR TITLE
Add workaround for displaying fallback handler version

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
@@ -8,6 +8,9 @@ import io.gnosis.data.backend.dto.ServiceTokenInfo
 import io.gnosis.data.models.*
 import io.gnosis.data.models.Transaction.*
 import io.gnosis.data.repositories.SafeRepository
+import io.gnosis.data.repositories.SafeRepository.Companion.DEFAULT_FALLBACK_HANDLER
+import io.gnosis.data.repositories.SafeRepository.Companion.DEFAULT_FALLBACK_HANDLER_DISPLAY_STRING
+import io.gnosis.data.repositories.SafeRepository.Companion.DEFAULT_FALLBACK_HANDLER_UNKNOWN_DISPLAY_STRING
 import io.gnosis.data.repositories.SafeRepository.Companion.METHOD_CHANGE_MASTER_COPY
 import io.gnosis.data.repositories.SafeRepository.Companion.METHOD_DISABLE_MODULE
 import io.gnosis.data.repositories.SafeRepository.Companion.METHOD_ENABLE_MODULE
@@ -291,6 +294,9 @@ class TransactionListViewModel
     private fun queuedSetFallbackHandler(transaction: SettingsChange, threshold: Int): TransactionView.SettingsChangeVariantQueued {
         val thresholdMet = checkThreshold(threshold, transaction.confirmations)
         val address = getAddress(transaction, "handler")
+        val version =
+            if (address == DEFAULT_FALLBACK_HANDLER) DEFAULT_FALLBACK_HANDLER_DISPLAY_STRING else DEFAULT_FALLBACK_HANDLER_UNKNOWN_DISPLAY_STRING
+
 
         return TransactionView.SettingsChangeVariantQueued(
             id = transaction.id,
@@ -298,7 +304,7 @@ class TransactionListViewModel
             statusText = displayString(transaction.status),
             statusColorRes = statusTextColor(transaction.status),
             dateTimeText = transaction.date?.formatBackendDate() ?: "",
-            version = "DefaultFallbackHandler",
+            version = version,
             address = address,
             label = R.string.tx_list_set_fallback_handler,
             confirmations = transaction.confirmations ?: 0,
@@ -322,6 +328,8 @@ class TransactionListViewModel
 
     private fun historicSetFallbackHandler(transaction: SettingsChange): TransactionView.SettingsChangeVariant {
         val address = getAddress(transaction, "handler")
+        val version =
+            if (address == DEFAULT_FALLBACK_HANDLER) DEFAULT_FALLBACK_HANDLER_DISPLAY_STRING else DEFAULT_FALLBACK_HANDLER_UNKNOWN_DISPLAY_STRING
 
         return TransactionView.SettingsChangeVariant(
             id = transaction.id,
@@ -330,7 +338,7 @@ class TransactionListViewModel
             statusColorRes = statusTextColor(transaction.status),
             dateTimeText = transaction.date?.formatBackendDate() ?: "",
             alpha = alpha(transaction),
-            version = "DefaultFallbackHandler",
+            version = version,
             address = address,
             label = R.string.tx_list_set_fallback_handler,
             nonce = transaction.nonce.toString()

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
@@ -9,6 +9,7 @@ import io.gnosis.data.models.*
 import io.gnosis.data.models.TransactionStatus.*
 import io.gnosis.data.repositories.SafeRepository
 import io.gnosis.data.repositories.SafeRepository.Companion.DEFAULT_FALLBACK_HANDLER_DISPLAY_STRING
+import io.gnosis.data.repositories.SafeRepository.Companion.DEFAULT_FALLBACK_HANDLER_UNKNOWN_DISPLAY_STRING
 import io.gnosis.data.repositories.SafeRepository.Companion.METHOD_CHANGE_MASTER_COPY
 import io.gnosis.data.repositories.SafeRepository.Companion.METHOD_DISABLE_MODULE
 import io.gnosis.data.repositories.SafeRepository.Companion.METHOD_ENABLE_MODULE
@@ -729,7 +730,7 @@ class TransactionListViewModelTest {
                         confirmationsTextColor = R.color.medium_grey,
                         confirmationsIcon = R.drawable.ic_confirmations_grey_16dp,
                         nonce = "1",
-                        version = DEFAULT_FALLBACK_HANDLER_DISPLAY_STRING,
+                        version = DEFAULT_FALLBACK_HANDLER_UNKNOWN_DISPLAY_STRING,
                         address = null,
                         visibilityVersion = View.VISIBLE,
                         visibilityModuleAddress = View.GONE,

--- a/data/src/main/java/io/gnosis/data/repositories/SafeRepository.kt
+++ b/data/src/main/java/io/gnosis/data/repositories/SafeRepository.kt
@@ -93,6 +93,8 @@ class SafeRepository(
 
         val DEFAULT_FALLBACK_HANDLER = BuildConfig.DEFAULT_FALLBACK_HANDLER.asEthereumAddress()!!
         const val DEFAULT_FALLBACK_HANDLER_DISPLAY_STRING = "DefaultFallbackHandler"
+        const val DEFAULT_FALLBACK_HANDLER_UNKNOWN_DISPLAY_STRING = "Unknown"
+
         const val SAFE_MASTER_COPY_UNKNOWN_DISPLAY_STRING = "Unknown"
 
         fun masterCopyVersion(masterCopy: Solidity.Address?): String? = supportedContracts[masterCopy]


### PR DESCRIPTION
Handles #719

hardcoded string extraction will happen in scope of https://app.zenhub.com/workspaces/safe-multisig---mobile-5c1b98250e13551e8aae81eb/issues/gnosis/safe-android/964

@gnosis/mobile-devs
