### PR TITLE
Adds UI elements for navigation/removal for owner key interactions

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/AppSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/AppSettingsFragment.kt
@@ -4,29 +4,50 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageButton
+import android.widget.ImageView
 import androidx.navigation.fragment.findNavController
+import androidx.viewbinding.ViewBinding
+import io.gnosis.data.repositories.SafeRepository
 import io.gnosis.safe.BuildConfig
 import io.gnosis.safe.R
 import io.gnosis.safe.ScreenId
 import io.gnosis.safe.databinding.FragmentSettingsAppBinding
+import io.gnosis.safe.databinding.ItemImportOwnerKeyBinding
+import io.gnosis.safe.databinding.ItemRemoveOwnerKeyBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.ui.base.fragment.BaseViewBindingFragment
 import io.gnosis.safe.ui.settings.SettingsFragmentDirections
+import io.gnosis.safe.ui.settings.view.SettingItem
+import pm.gnosis.blockies.BlockiesImageView
 import pm.gnosis.svalinn.common.utils.openUrl
+import pm.gnosis.svalinn.common.utils.snackbar
+import pm.gnosis.utils.asEthereumAddress
+import javax.inject.Inject
+import kotlin.random.Random
 
 class AppSettingsFragment : BaseViewBindingFragment<FragmentSettingsAppBinding>() {
 
+    @Inject
+    lateinit var safeRepository: SafeRepository
+
     override fun screenId() = ScreenId.SETTINGS_APP
 
-    override fun inject(component: ViewComponent) {}
+    override fun inject(component: ViewComponent) {
+        component.inject(this)
+    }
 
     override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentSettingsAppBinding =
         FragmentSettingsAppBinding.inflate(inflater, container, false)
+
+    private lateinit var ownerKeyStubBinding: ViewBinding
+
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         with(binding) {
+            setupOwnerKeyView()
             terms.setOnClickListener {
                 requireContext().openUrl(getString(R.string.link_terms_of_use))
             }
@@ -43,6 +64,29 @@ class AppSettingsFragment : BaseViewBindingFragment<FragmentSettingsAppBinding>(
             network.value = BuildConfig.BLOCKCHAIN_NAME
             advanced.setOnClickListener {
                 findNavController().navigate(SettingsFragmentDirections.actionSettingsFragmentToAdvancedAppSettingsFragment())
+            }
+        }
+    }
+
+    private fun setupOwnerKeyView() {
+        with(binding) {
+            if (Random.nextBoolean()) {
+                val viewStub = stubRemoveOwnerKey
+                if (viewStub.parent != null) {
+                    ownerKeyStubBinding = ItemRemoveOwnerKeyBinding.bind(viewStub.inflate())
+                }
+                with(ownerKeyStubBinding as ItemRemoveOwnerKeyBinding) {
+                    remove.setOnClickListener { snackbar(requireView(), "Remove key navigation") }
+                    blockies.setAddress("0x1C8b9B78e3085866521FE206fa4c1a67F49f153A".asEthereumAddress())
+                }
+            } else {
+                val viewStub = stubImportOwnerKey
+                if (viewStub.parent != null) {
+                    ownerKeyStubBinding = ItemImportOwnerKeyBinding.bind(viewStub.inflate())
+                }
+                with(ownerKeyStubBinding as ItemImportOwnerKeyBinding) {
+                    importOwnerKey.setOnClickListener { snackbar(requireView(), "Import key navigation") }
+                }
             }
         }
     }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/AppSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/AppSettingsFragment.kt
@@ -4,8 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageButton
-import android.widget.ImageView
 import androidx.navigation.fragment.findNavController
 import androidx.viewbinding.ViewBinding
 import io.gnosis.data.repositories.SafeRepository
@@ -18,8 +16,6 @@ import io.gnosis.safe.databinding.ItemRemoveOwnerKeyBinding
 import io.gnosis.safe.di.components.ViewComponent
 import io.gnosis.safe.ui.base.fragment.BaseViewBindingFragment
 import io.gnosis.safe.ui.settings.SettingsFragmentDirections
-import io.gnosis.safe.ui.settings.view.SettingItem
-import pm.gnosis.blockies.BlockiesImageView
 import pm.gnosis.svalinn.common.utils.openUrl
 import pm.gnosis.svalinn.common.utils.snackbar
 import pm.gnosis.utils.asEthereumAddress

--- a/app/src/main/res/layout/fragment_settings_app.xml
+++ b/app/src/main/res/layout/fragment_settings_app.xml
@@ -10,7 +10,6 @@
         android:layout_height="match_parent">
 
         <LinearLayout
-            android:id="@+id/container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">

--- a/app/src/main/res/layout/fragment_settings_app.xml
+++ b/app/src/main/res/layout/fragment_settings_app.xml
@@ -10,9 +10,25 @@
         android:layout_height="match_parent">
 
         <LinearLayout
+            android:id="@+id/container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
+
+            <ViewStub
+                android:id="@+id/stub_import_owner_key"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inflatedId="@+id/app_settings"
+                android:layout="@layout/item_import_owner_key" />
+
+            <ViewStub
+                android:id="@+id/stub_remove_owner_key"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inflatedId="@+id/app_settings"
+                android:layout="@layout/item_remove_owner_key" />
+
 
             <io.gnosis.safe.ui.settings.view.SettingItem
                 android:id="@+id/terms"

--- a/app/src/main/res/layout/item_import_owner_key.xml
+++ b/app/src/main/res/layout/item_import_owner_key.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<io.gnosis.safe.ui.settings.view.SettingItem
+    android:id="@+id/import_owner_key"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="64dp"
+    android:background="@drawable/background_selectable_white"
+    app:setting_name="@string/settings_app_import_owner_key"
+    app:setting_openable="true" />

--- a/app/src/main/res/layout/item_remove_owner_key.xml
+++ b/app/src/main/res/layout/item_remove_owner_key.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="68dp"
+    android:background="@drawable/background_selectable_white"
+    android:minHeight="68dp">
+
+    <TextView
+        android:id="@+id/title"
+        style="@style/TextDark.Bold"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/settings_app_imported_owner_key"
+        app:layout_constraintBottom_toTopOf="@id/owner_address"
+        app:layout_constraintEnd_toStartOf="@id/remove"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintStart_toStartOf="@id/owner_address"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <TextView
+        android:id="@+id/owner_address"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:fontFamily="sans-serif-medium"
+        android:maxLines="1"
+        android:text="0x1C8b..153A"
+        android:textColor="@color/medium_grey"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/remove"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintStart_toEndOf="@+id/blockies"
+        app:layout_constraintTop_toBottomOf="@id/title"
+        app:layout_constraintVertical_chainStyle="packed"
+        app:layout_goneMarginLeft="16dp"
+        tools:text="0x123456..1235" />
+
+    <ImageView
+        android:id="@+id/remove"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginHorizontal="16dp"
+        android:visibility="visible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/owner_address"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_remove" />
+
+    <pm.gnosis.blockies.BlockiesImageView
+        android:id="@+id/blockies"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_margin="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/owner_address"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,8 @@
     <string name="settings_tab_app">APP SETTINGS</string>
     <string name="settings_app_fiat">Fiat currency</string>
     <string name="settings_app_appearance">Appearance</string>
+    <string name="settings_app_import_owner_key">Import owner key</string>
+    <string name="settings_app_imported_owner_key">Imported owner key</string>
     <string name="settings_app_terms_of_use">Terms of use</string>
     <string name="settings_app_privacy_policy">Privacy policy</string>
     <string name="settings_app_licenses">Licenses</string>


### PR DESCRIPTION
Handles #946 

Changes proposed in this pull request:
- Adds UI elements in `App Settings` fragment
- Provides callbacks with `snackbars` for now to which the actions should be attached once they are implemented

@gnosis/mobile-devs