### PR TITLE
Prevent opening Terms Sheet if already added

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/splash/SplashActivity.kt
@@ -40,7 +40,10 @@ class SplashActivity : BaseActivity() {
                         onAgreeClickListener = {
                             viewModel.handleAgreeClicked()
                         }
-                    }.show(supportFragmentManager, TermsBottomSheetDialog::class.simpleName)
+                    }
+                    if (!termsBottomSheetDialog.isAdded) {
+                        termsBottomSheetDialog.show(supportFragmentManager, TermsBottomSheetDialog::class.simpleName)
+                    }
                 }
                 is SplashViewModel.ShowButton -> {
                     binding.continueButton.visible(true)

--- a/app/src/main/java/io/gnosis/safe/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/splash/SplashActivity.kt
@@ -40,10 +40,17 @@ class SplashActivity : BaseActivity() {
                         onAgreeClickListener = {
                             viewModel.handleAgreeClicked()
                         }
+                        onDismissClickListener = {
+                            viewModel.handleDismissedClicked()
+                            dismiss()
+                        }
                     }
                     if (!termsBottomSheetDialog.isAdded) {
                         termsBottomSheetDialog.show(supportFragmentManager, TermsBottomSheetDialog::class.simpleName)
                     }
+                }
+                is SplashViewModel.HideTerms -> {
+                    // Do nothing. Terms are already dismissed
                 }
                 is SplashViewModel.ShowButton -> {
                     binding.continueButton.visible(true)

--- a/app/src/main/java/io/gnosis/safe/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/splash/SplashViewModel.kt
@@ -54,6 +54,12 @@ constructor(
         }
     }
 
+    fun handleDismissedClicked() {
+        safeLaunch {
+            updateState { TermsAgreed(HideTerms) }
+        }
+    }
+
     fun skipGetStartedButtonWhenTermsAgreed() {
         safeLaunch {
             if (termsChecker.getTermsAgreed()) {
@@ -67,5 +73,6 @@ constructor(
     data class TermsAgreed(override var viewAction: ViewAction?) : State
 
     object ShowTerms : ViewAction
+    object HideTerms : ViewAction
     object ShowButton : ViewAction
 }

--- a/app/src/main/java/io/gnosis/safe/ui/terms/TermsBottomSheetDialog.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/terms/TermsBottomSheetDialog.kt
@@ -18,6 +18,7 @@ import pm.gnosis.svalinn.common.utils.openUrl
 class TermsBottomSheetDialog : BaseBottomSheetDialogFragment<BottomSheetTermsAndConditionsBinding>() {
 
     lateinit var onAgreeClickListener: () -> Unit
+    lateinit var onDismissClickListener: () -> Unit
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -37,7 +38,7 @@ class TermsBottomSheetDialog : BaseBottomSheetDialogFragment<BottomSheetTermsAnd
             }
 
             bottomSheetTermsAndConditionsReject.setOnClickListener {
-                dismiss()
+                onDismissClickListener()
             }
         }
     }


### PR DESCRIPTION
Handles #970

Changes proposed in this pull request:
- Prevents opening the Terms Sheet if it is already added
- Also does not re-open it (when it was dismissed) when coming back from background, because the last event is HideTerms in that case.


@gnosis/mobile-devs
