### PR TITLE
Reset owner import result after key removal

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/AppSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/AppSettingsFragment.kt
@@ -78,9 +78,7 @@ class AppSettingsFragment : BaseViewBindingFragment<FragmentSettingsAppBinding>(
                     ownerAddress.text = address.shortChecksumString()
                     remove.setOnClickListener {
                         showRemoveDialog(requireContext(), R.string.signing_owner_dialog_description) {
-                            viewModel.removeSigningOwner()
-                            ownerKey.showNext()
-                            snackbar(requireView(), getString(R.string.signing_owner_key_removed))
+                            onOwnerRemove()
                         }
                     }
                 }
@@ -94,8 +92,19 @@ class AppSettingsFragment : BaseViewBindingFragment<FragmentSettingsAppBinding>(
         }
     }
 
+    private fun onOwnerRemove() {
+        viewModel.removeSigningOwner()
+        binding.ownerKey.showNext()
+        snackbar(requireView(), getString(R.string.signing_owner_key_removed))
+        resetOwnerImported()
+    }
+
     private fun ownerImported(): Boolean {
         return findNavController().currentBackStackEntry?.savedStateHandle?.get<Boolean>(OWNER_IMPORT_RESULT) == true
+    }
+
+    private fun resetOwnerImported() {
+        findNavController().currentBackStackEntry?.savedStateHandle?.set(OWNER_IMPORT_RESULT, false)
     }
 
     companion object {

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/AppSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/AppSettingsFragment.kt
@@ -66,6 +66,7 @@ class AppSettingsFragment : BaseViewBindingFragment<FragmentSettingsAppBinding>(
 
         if(ownerImported()) {
             snackbar(requireView(), getString(R.string.signing_owner_key_imported))
+            resetOwnerImported()
         }
     }
 
@@ -96,7 +97,6 @@ class AppSettingsFragment : BaseViewBindingFragment<FragmentSettingsAppBinding>(
         viewModel.removeSigningOwner()
         binding.ownerKey.showNext()
         snackbar(requireView(), getString(R.string.signing_owner_key_removed))
-        resetOwnerImported()
     }
 
     private fun ownerImported(): Boolean {


### PR DESCRIPTION

Changes proposed in this pull request:
- Fix  snackbar showing import confirmation after key is removed from device

@gnosis/mobile-devs
