### PR TITLE
Add missing transfer info to non-multisend decoding details

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsFragment.kt
@@ -31,6 +31,7 @@ import io.gnosis.safe.utils.*
 import pm.gnosis.svalinn.common.utils.openUrl
 import pm.gnosis.svalinn.common.utils.snackbar
 import pm.gnosis.svalinn.common.utils.visible
+import pm.gnosis.utils.asEthereumAddressString
 import java.math.BigInteger
 import javax.inject.Inject
 
@@ -220,7 +221,9 @@ class TransactionDetailsFragment : BaseViewBindingFragment<FragmentTransactionDe
                                     TransactionDetailsFragmentDirections.actionTransactionDetailsFragmentToTransactionDetailsActionFragment(
                                         it.dataDecoded?.method ?: "",
                                         it.hexData ?: "",
-                                        it.dataDecoded?.let { paramSerializer.serializeDecodedData(it) }
+                                        it.dataDecoded?.let { paramSerializer.serializeDecodedData(it) },
+                                        it.to.asEthereumAddressString(),
+                                        it.value?.let { balanceFormatter.formatAmount(it, true) }
                                     )
                                 )
                             }


### PR DESCRIPTION


Changes proposed in this pull request:
- Transfer details were missing for non-multisend decoded details

@gnosis/mobile-devs
