### PR TITLE
Creation layout

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/settings/safe/AdvancedSafeSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/safe/AdvancedSafeSettingsFragment.kt
@@ -104,6 +104,7 @@ class AdvancedSafeSettingsFragment : BaseViewBindingFragment<FragmentSettingsSaf
             layoutParams = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
             this.address = address
             this.name = label
+            showSeparator = true
         }
     }
 

--- a/app/src/main/java/io/gnosis/safe/ui/settings/view/AddressItem.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/view/AddressItem.kt
@@ -86,6 +86,6 @@ class AddressItem @JvmOverloads constructor(
     }
 
     private fun applyAttributes(context: Context, a: TypedArray) {
-        binding.addressDivider.visible(a.getBoolean(R.styleable.AddressItem_show_separator, false))
+        binding.addressDivider.visible(a.getBoolean(R.styleable.AddressItem_show_address_separator, false))
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/view/NamedAddressItem.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/view/NamedAddressItem.kt
@@ -1,6 +1,7 @@
 package io.gnosis.safe.ui.settings.view
 
 import android.content.Context
+import android.content.res.TypedArray
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -13,6 +14,7 @@ import pm.gnosis.svalinn.common.utils.copyToClipboard
 import pm.gnosis.svalinn.common.utils.openUrl
 import pm.gnosis.svalinn.common.utils.snackbar
 import pm.gnosis.svalinn.common.utils.visible
+import timber.log.Timber
 
 class NamedAddressItem @JvmOverloads constructor(
     context: Context,
@@ -21,6 +23,10 @@ class NamedAddressItem @JvmOverloads constructor(
 ) : ConstraintLayout(context, attrs, defStyleAttr) {
 
     private val binding by lazy { ViewNamedAddressItemBinding.inflate(LayoutInflater.from(context), this) }
+
+    init {
+        readAttributesAndSetupFields(context, attrs)
+    }
 
     var address: Solidity.Address? = null
         set(value) {
@@ -48,7 +54,7 @@ class NamedAddressItem @JvmOverloads constructor(
 
     var name: String? = null
         set(value) {
-            if(value.isNullOrBlank()) {
+            if (value.isNullOrBlank()) {
                 binding.name.visible(false)
             } else {
                 binding.name.visible(true)
@@ -56,4 +62,28 @@ class NamedAddressItem @JvmOverloads constructor(
             }
             field = value
         }
+
+    private fun readAttributesAndSetupFields(context: Context, attrs: AttributeSet?) {
+        context.theme.obtainStyledAttributes(
+            attrs,
+            R.styleable.NamedAddressItem,
+            0, 0
+        ).also {
+            runCatching {
+                applyAttributes(context, it)
+            }
+                .onFailure { Timber.e(it) }
+            it.recycle()
+        }
+    }
+
+    var showSeparator: Boolean = false
+        set(value) {
+            binding.namedAddressItemSeparator.visible(value)
+            field = value
+        }
+
+    private fun applyAttributes(context: Context, a: TypedArray) {
+        binding.namedAddressItemSeparator.visible(a.getBoolean(R.styleable.NamedAddressItem_show_named_address_separator, false))
+    }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsActionFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsActionFragment.kt
@@ -153,10 +153,11 @@ class TransactionDetailsActionFragment : BaseViewBindingFragment<FragmentTransac
 
     private fun getDivider(): View {
         val item = View(requireContext())
-        val layoutParams = LayoutParams(MATCH_PARENT, dpToPx(1))
+        val height = resources.getDimension(R.dimen.item_separator_height).toInt()
+        val layoutParams = LayoutParams(MATCH_PARENT, height)
         layoutParams.setMargins(0, dpToPx(16), 0, 0)
         item.layoutParams = layoutParams
-        item.setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.light_grey))
+        item.setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.item_separator))
         return item
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/view/TxSettingsActionView.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/view/TxSettingsActionView.kt
@@ -70,6 +70,7 @@ class TxSettingsActionView @JvmOverloads constructor(
         val addressItem = NamedAddressItem(context)
         addressItem.address = address
         addressItem.name = label
+        addressItem.showSeparator = false
         addView(addressItem)
     }
 

--- a/app/src/main/res/layout/fragment_collectibles_details.xml
+++ b/app/src/main/res/layout/fragment_collectibles_details.xml
@@ -113,7 +113,9 @@
                 android:id="@+id/collectible_contract"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="@drawable/background_selectable_white"/>
+                android:background="@drawable/background_selectable_white"
+                app:show_named_address_separator="true"
+                />
 
             <TextView
                 android:id="@+id/collectible_uri"

--- a/app/src/main/res/layout/fragment_get_in_touch.xml
+++ b/app/src/main/res/layout/fragment_get_in_touch.xml
@@ -65,7 +65,7 @@
             <View
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_separator_size"
-                android:background="@color/background"/>
+                android:background="@color/item_separator"/>
 
             <io.gnosis.safe.ui.settings.view.SettingItem
                 android:id="@+id/discord"
@@ -79,7 +79,7 @@
             <View
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_separator_size"
-                android:background="@color/background"/>
+                android:background="@color/item_separator"/>
 
             <io.gnosis.safe.ui.settings.view.SettingItem
                 android:id="@+id/twitter"
@@ -93,7 +93,7 @@
             <View
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_separator_size"
-                android:background="@color/background"/>
+                android:background="@color/item_separator"/>
 
             <io.gnosis.safe.ui.settings.view.SettingItem
                 android:id="@+id/help_center"
@@ -107,7 +107,7 @@
             <View
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_separator_size"
-                android:background="@color/background"/>
+                android:background="@color/item_separator"/>
 
             <io.gnosis.safe.ui.settings.view.SettingItem
                 android:id="@+id/feature_suggestion"
@@ -121,7 +121,7 @@
             <View
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_separator_size"
-                android:background="@color/background"/>
+                android:background="@color/item_separator"/>
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_get_in_touch.xml
+++ b/app/src/main/res/layout/fragment_get_in_touch.xml
@@ -64,7 +64,7 @@
 
             <View
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/item_setting_separator_size"
+                android:layout_height="@dimen/item_separator_height"
                 android:background="@color/item_separator"/>
 
             <io.gnosis.safe.ui.settings.view.SettingItem
@@ -78,7 +78,7 @@
 
             <View
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/item_setting_separator_size"
+                android:layout_height="@dimen/item_separator_height"
                 android:background="@color/item_separator"/>
 
             <io.gnosis.safe.ui.settings.view.SettingItem
@@ -92,7 +92,7 @@
 
             <View
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/item_setting_separator_size"
+                android:layout_height="@dimen/item_separator_height"
                 android:background="@color/item_separator"/>
 
             <io.gnosis.safe.ui.settings.view.SettingItem
@@ -106,7 +106,7 @@
 
             <View
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/item_setting_separator_size"
+                android:layout_height="@dimen/item_separator_height"
                 android:background="@color/item_separator"/>
 
             <io.gnosis.safe.ui.settings.view.SettingItem
@@ -120,7 +120,7 @@
 
             <View
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/item_setting_separator_size"
+                android:layout_height="@dimen/item_separator_height"
                 android:background="@color/item_separator"/>
 
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_settings_app.xml
+++ b/app/src/main/res/layout/fragment_settings_app.xml
@@ -37,7 +37,7 @@
                 android:id="@+id/terms"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_openable_height"
-                android:layout_marginTop="@dimen/item_separator_height"
+                android:layout_marginTop="@dimen/item_setting_margin"
                 android:background="@drawable/background_selectable_white"
                 app:setting_name="@string/settings_app_terms_of_use"
                 app:setting_openable="true" />
@@ -46,7 +46,7 @@
                 android:id="@+id/privacy"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_openable_height"
-                android:layout_marginTop="@dimen/item_separator_height"
+                android:layout_marginTop="@dimen/item_setting_margin"
                 android:background="@drawable/background_selectable_white"
                 app:setting_name="@string/settings_app_privacy_policy"
                 app:setting_openable="true" />
@@ -55,7 +55,7 @@
                 android:id="@+id/licenses"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_openable_height"
-                android:layout_marginTop="@dimen/item_separator_height"
+                android:layout_marginTop="@dimen/item_setting_margin"
                 android:background="@drawable/background_selectable_white"
                 app:setting_name="@string/settings_app_licenses"
                 app:setting_openable="true" />
@@ -64,7 +64,7 @@
                 android:id="@+id/get_in_touch"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_openable_height"
-                android:layout_marginTop="@dimen/item_separator_height"
+                android:layout_marginTop="@dimen/item_setting_margin"
                 android:background="@drawable/background_selectable_white"
                 app:setting_name="@string/settings_app_get_in_touch"
                 app:setting_openable="true" />
@@ -73,7 +73,7 @@
                 android:id="@+id/version"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_non_openable_height"
-                android:layout_marginTop="@dimen/item_separator_height"
+                android:layout_marginTop="@dimen/item_setting_margin"
                 android:background="@drawable/background_selectable_white"
                 app:setting_name="@string/settings_app_version"
                 app:setting_openable="false" />
@@ -82,7 +82,7 @@
                 android:id="@+id/network"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_non_openable_height"
-                android:layout_marginTop="@dimen/item_separator_height"
+                android:layout_marginTop="@dimen/item_setting_margin"
                 android:background="@drawable/background_selectable_white"
                 app:setting_name="@string/settings_app_network"
                 app:setting_openable="false" />

--- a/app/src/main/res/layout/fragment_settings_app.xml
+++ b/app/src/main/res/layout/fragment_settings_app.xml
@@ -37,7 +37,7 @@
                 android:id="@+id/terms"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_openable_height"
-                android:layout_marginTop="@dimen/item_setting_separator_size"
+                android:layout_marginTop="@dimen/item_separator_height"
                 android:background="@drawable/background_selectable_white"
                 app:setting_name="@string/settings_app_terms_of_use"
                 app:setting_openable="true" />
@@ -46,7 +46,7 @@
                 android:id="@+id/privacy"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_openable_height"
-                android:layout_marginTop="@dimen/item_setting_separator_size"
+                android:layout_marginTop="@dimen/item_separator_height"
                 android:background="@drawable/background_selectable_white"
                 app:setting_name="@string/settings_app_privacy_policy"
                 app:setting_openable="true" />
@@ -55,7 +55,7 @@
                 android:id="@+id/licenses"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_openable_height"
-                android:layout_marginTop="@dimen/item_setting_separator_size"
+                android:layout_marginTop="@dimen/item_separator_height"
                 android:background="@drawable/background_selectable_white"
                 app:setting_name="@string/settings_app_licenses"
                 app:setting_openable="true" />
@@ -64,7 +64,7 @@
                 android:id="@+id/get_in_touch"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_openable_height"
-                android:layout_marginTop="@dimen/item_setting_separator_size"
+                android:layout_marginTop="@dimen/item_separator_height"
                 android:background="@drawable/background_selectable_white"
                 app:setting_name="@string/settings_app_get_in_touch"
                 app:setting_openable="true" />
@@ -73,7 +73,7 @@
                 android:id="@+id/version"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_non_openable_height"
-                android:layout_marginTop="@dimen/item_setting_separator_size"
+                android:layout_marginTop="@dimen/item_separator_height"
                 android:background="@drawable/background_selectable_white"
                 app:setting_name="@string/settings_app_version"
                 app:setting_openable="false" />
@@ -82,7 +82,7 @@
                 android:id="@+id/network"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_non_openable_height"
-                android:layout_marginTop="@dimen/item_setting_separator_size"
+                android:layout_marginTop="@dimen/item_separator_height"
                 android:background="@drawable/background_selectable_white"
                 app:setting_name="@string/settings_app_network"
                 app:setting_openable="false" />

--- a/app/src/main/res/layout/fragment_settings_app_advanced.xml
+++ b/app/src/main/res/layout/fragment_settings_app_advanced.xml
@@ -77,7 +77,7 @@
             <View
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_separator_size"
-                android:background="@color/background"/>
+                android:background="@color/item_separator"/>
 
             <io.gnosis.safe.ui.settings.view.EndpointItem
                 android:id="@+id/tx_service"
@@ -89,7 +89,7 @@
             <View
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_separator_size"
-                android:background="@color/background"/>
+                android:background="@color/item_separator"/>
 
             <io.gnosis.safe.ui.settings.view.EndpointItem
                 android:id="@+id/client_gateway_service"
@@ -101,7 +101,7 @@
             <View
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_setting_separator_size"
-                android:background="@color/background"/>
+                android:background="@color/item_separator"/>
         </LinearLayout>
 
     </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_settings_app_advanced.xml
+++ b/app/src/main/res/layout/fragment_settings_app_advanced.xml
@@ -76,7 +76,7 @@
 
             <View
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/item_setting_separator_size"
+                android:layout_height="@dimen/item_separator_height"
                 android:background="@color/item_separator"/>
 
             <io.gnosis.safe.ui.settings.view.EndpointItem
@@ -88,7 +88,7 @@
 
             <View
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/item_setting_separator_size"
+                android:layout_height="@dimen/item_separator_height"
                 android:background="@color/item_separator"/>
 
             <io.gnosis.safe.ui.settings.view.EndpointItem
@@ -100,7 +100,7 @@
 
             <View
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/item_setting_separator_size"
+                android:layout_height="@dimen/item_separator_height"
                 android:background="@color/item_separator"/>
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_settings_safe.xml
+++ b/app/src/main/res/layout/fragment_settings_safe.xml
@@ -109,7 +109,7 @@
                 <View
                     android:id="@+id/master_copy_separator"
                     android:layout_width="match_parent"
-                    android:layout_height="2dp"
+                    android:layout_height="@dimen/item_separator_height"
                     android:background="@color/item_separator"
                     app:layout_constraintBottom_toBottomOf="parent" />
 

--- a/app/src/main/res/layout/fragment_settings_safe.xml
+++ b/app/src/main/res/layout/fragment_settings_safe.xml
@@ -106,6 +106,13 @@
                     android:background="@drawable/background_selectable_white"
                     app:setting_openable="false" />
 
+                <View
+                    android:id="@+id/master_copy_separator"
+                    android:layout_width="match_parent"
+                    android:layout_height="2dp"
+                    android:background="@color/background"
+                    app:layout_constraintBottom_toBottomOf="parent" />
+
                 <TextView
                     style="@style/Header"
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_settings_safe.xml
+++ b/app/src/main/res/layout/fragment_settings_safe.xml
@@ -110,7 +110,7 @@
                     android:id="@+id/master_copy_separator"
                     android:layout_width="match_parent"
                     android:layout_height="2dp"
-                    android:background="@color/very_light_pink_two"
+                    android:background="@color/item_separator"
                     app:layout_constraintBottom_toBottomOf="parent" />
 
                 <TextView

--- a/app/src/main/res/layout/fragment_settings_safe.xml
+++ b/app/src/main/res/layout/fragment_settings_safe.xml
@@ -110,7 +110,7 @@
                     android:id="@+id/master_copy_separator"
                     android:layout_width="match_parent"
                     android:layout_height="2dp"
-                    android:background="@color/background"
+                    android:background="@color/very_light_pink_two"
                     app:layout_constraintBottom_toBottomOf="parent" />
 
                 <TextView

--- a/app/src/main/res/layout/fragment_transaction_details.xml
+++ b/app/src/main/res/layout/fragment_transaction_details.xml
@@ -102,8 +102,8 @@
                 <View
                     android:id="@+id/tx_confirmations_divider"
                     android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:background="@color/light_grey" />
+                    android:layout_height="@dimen/item_separator_height"
+                    android:background="@color/item_separator" />
 
                 <io.gnosis.safe.ui.transactions.details.view.LabeledValueItem
                     android:id="@+id/created"
@@ -115,8 +115,8 @@
                 <View
                     android:id="@+id/created_divider"
                     android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:background="@color/light_grey" />
+                    android:layout_height="@dimen/item_separator_height"
+                    android:background="@color/item_separator" />
 
                 <io.gnosis.safe.ui.transactions.details.view.LabeledValueItem
                     android:id="@+id/executed"
@@ -128,8 +128,8 @@
                 <View
                     android:id="@+id/executed_divider"
                     android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:background="@color/light_grey" />
+                    android:layout_height="@dimen/item_separator_height"
+                    android:background="@color/item_separator" />
 
                 <io.gnosis.safe.ui.settings.view.SettingItem
                     android:id="@+id/advanced"
@@ -141,8 +141,8 @@
                 <View
                     android:id="@+id/advanced_divider"
                     android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:background="@color/light_grey" />
+                    android:layout_height="@dimen/item_separator_height"
+                    android:background="@color/item_separator" />
 
                 <TextView
                     android:id="@+id/etherscan"

--- a/app/src/main/res/layout/fragment_transaction_details_advanced.xml
+++ b/app/src/main/res/layout/fragment_transaction_details_advanced.xml
@@ -61,9 +61,10 @@
                 app:item_label="@string/tx_details_advanced_nonce" />
 
             <View
+                android:id="@+id/nonce_separator"
                 android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@color/light_grey"/>
+                android:layout_height="@dimen/item_separator_height"
+                android:background="@color/item_separator"/>
 
             <io.gnosis.safe.ui.transactions.details.view.LabeledValueItem
                 android:id="@+id/operation_item"
@@ -73,9 +74,10 @@
                 app:item_label="@string/tx_details_advanced_operation" />
 
             <View
+                android:id="@+id/operation_separator"
                 android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@color/light_grey"/>
+                android:layout_height="@dimen/item_separator_height"
+                android:background="@color/item_separator"/>
 
             <io.gnosis.safe.ui.transactions.details.view.LabeledValueItem
                 android:id="@+id/hash_item"
@@ -87,8 +89,8 @@
             <View
                 android:id="@+id/hash_separator"
                 android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@color/light_grey"/>
+                android:layout_height="@dimen/item_separator_height"
+                android:background="@color/item_separator"/>
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_transaction_details_creation.xml
+++ b/app/src/main/res/layout/fragment_transaction_details_creation.xml
@@ -63,7 +63,7 @@
             <View
                 android:id="@+id/status_separator"
                 android:layout_width="match_parent"
-                android:layout_height="1dp"
+                android:layout_height="@dimen/item_setting_separator_size"
                 android:background="@color/light_grey" />
 
             <io.gnosis.safe.ui.transactions.details.view.LabeledValueItem
@@ -77,8 +77,8 @@
             <View
                 android:id="@+id/tx_hash_separator"
                 android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@color/very_light_pink_two" />
+                android:layout_height="@dimen/item_setting_separator_size"
+                android:background="@color/item_separator" />
 
             <TextView
                 android:id="@+id/creator_item_title"
@@ -99,8 +99,8 @@
             <View
                 android:id="@+id/creator_separator"
                 android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@color/very_light_pink_two" />
+                android:layout_height="@dimen/item_setting_separator_size"
+                android:background="@color/item_separator" />
 
             <TextView
                 android:id="@+id/implementation_title"
@@ -130,8 +130,8 @@
             <View
                 android:id="@+id/implementation_separator"
                 android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@color/very_light_pink_two" />
+                android:layout_height="@dimen/item_setting_separator_size"
+                android:background="@color/item_separator" />
 
             <TextView
                 android:id="@+id/factory_title"
@@ -163,8 +163,8 @@
             <View
                 android:id="@+id/factory_separator"
                 android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@color/very_light_pink_two"/>
+                android:layout_height="@dimen/item_setting_separator_size"
+                android:background="@color/item_separator"/>
 
             <io.gnosis.safe.ui.transactions.details.view.LabeledValueItem
                 android:id="@+id/created_item"
@@ -176,8 +176,8 @@
             <View
                 android:id="@+id/created_separator"
                 android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@color/very_light_pink_two" />
+                android:layout_height="@dimen/item_setting_separator_size"
+                android:background="@color/item_separator" />
 
             <TextView
                 android:id="@+id/etherscan_item"

--- a/app/src/main/res/layout/fragment_transaction_details_creation.xml
+++ b/app/src/main/res/layout/fragment_transaction_details_creation.xml
@@ -63,7 +63,7 @@
             <View
                 android:id="@+id/status_separator"
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/item_setting_separator_size"
+                android:layout_height="@dimen/item_separator_height"
                 android:background="@color/light_grey" />
 
             <io.gnosis.safe.ui.transactions.details.view.LabeledValueItem
@@ -77,7 +77,7 @@
             <View
                 android:id="@+id/tx_hash_separator"
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/item_setting_separator_size"
+                android:layout_height="@dimen/item_separator_height"
                 android:background="@color/item_separator" />
 
             <TextView
@@ -99,7 +99,7 @@
             <View
                 android:id="@+id/creator_separator"
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/item_setting_separator_size"
+                android:layout_height="@dimen/item_separator_height"
                 android:background="@color/item_separator" />
 
             <TextView
@@ -130,7 +130,7 @@
             <View
                 android:id="@+id/implementation_separator"
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/item_setting_separator_size"
+                android:layout_height="@dimen/item_separator_height"
                 android:background="@color/item_separator" />
 
             <TextView
@@ -163,7 +163,7 @@
             <View
                 android:id="@+id/factory_separator"
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/item_setting_separator_size"
+                android:layout_height="@dimen/item_separator_height"
                 android:background="@color/item_separator"/>
 
             <io.gnosis.safe.ui.transactions.details.view.LabeledValueItem
@@ -176,7 +176,7 @@
             <View
                 android:id="@+id/created_separator"
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/item_setting_separator_size"
+                android:layout_height="@dimen/item_separator_height"
                 android:background="@color/item_separator" />
 
             <TextView

--- a/app/src/main/res/layout/fragment_transaction_details_creation.xml
+++ b/app/src/main/res/layout/fragment_transaction_details_creation.xml
@@ -64,7 +64,7 @@
                 android:id="@+id/status_separator"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/item_separator_height"
-                android:background="@color/light_grey" />
+                android:background="@color/item_separator" />
 
             <io.gnosis.safe.ui.transactions.details.view.LabeledValueItem
                 android:id="@+id/tx_hash_item"

--- a/app/src/main/res/layout/fragment_transaction_details_creation.xml
+++ b/app/src/main/res/layout/fragment_transaction_details_creation.xml
@@ -70,7 +70,9 @@
                 android:id="@+id/tx_hash_item"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:item_label="@string/tx_details_advanced_operation" />
+                app:item_label="@string/tx_details_advanced_operation"
+                android:layout_marginBottom="@dimen/default_margin"
+                />
 
             <View
                 android:id="@+id/tx_hash_separator"
@@ -167,7 +169,9 @@
             <io.gnosis.safe.ui.transactions.details.view.LabeledValueItem
                 android:id="@+id/created_item"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/default_margin"
+                />
 
             <View
                 android:id="@+id/created_separator"

--- a/app/src/main/res/layout/fragment_transaction_details_creation.xml
+++ b/app/src/main/res/layout/fragment_transaction_details_creation.xml
@@ -61,6 +61,7 @@
                 android:layout_height="wrap_content" />
 
             <View
+                android:id="@+id/status_separator"
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:background="@color/light_grey" />
@@ -72,9 +73,10 @@
                 app:item_label="@string/tx_details_advanced_operation" />
 
             <View
+                android:id="@+id/tx_hash_separator"
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
-                android:background="@color/light_grey" />
+                android:background="@color/very_light_pink_two" />
 
             <TextView
                 android:id="@+id/creator_item_title"
@@ -96,7 +98,7 @@
                 android:id="@+id/creator_separator"
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
-                android:background="@color/light_grey" />
+                android:background="@color/very_light_pink_two" />
 
             <TextView
                 android:id="@+id/implementation_title"
@@ -127,7 +129,7 @@
                 android:id="@+id/implementation_separator"
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
-                android:background="@color/light_grey" />
+                android:background="@color/very_light_pink_two" />
 
             <TextView
                 android:id="@+id/factory_title"
@@ -160,7 +162,7 @@
                 android:id="@+id/factory_separator"
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
-                android:background="@color/light_grey"/>
+                android:background="@color/very_light_pink_two"/>
 
             <io.gnosis.safe.ui.transactions.details.view.LabeledValueItem
                 android:id="@+id/created_item"
@@ -171,7 +173,7 @@
                 android:id="@+id/created_separator"
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
-                android:background="@color/light_grey" />
+                android:background="@color/very_light_pink_two" />
 
             <TextView
                 android:id="@+id/etherscan_item"

--- a/app/src/main/res/layout/tx_details_custom.xml
+++ b/app/src/main/res/layout/tx_details_custom.xml
@@ -15,8 +15,8 @@
 
     <View
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/light_grey" />
+        android:layout_height="@dimen/item_separator_height"
+        android:background="@color/item_separator" />
 
     <io.gnosis.safe.ui.settings.view.SettingItem
         android:id="@+id/tx_data_decoded"
@@ -27,8 +27,8 @@
     <View
         android:id="@+id/tx_data_decoded_separator"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/light_grey" />
+        android:layout_height="@dimen/item_separator_height"
+        android:background="@color/item_separator" />
 
     <io.gnosis.safe.ui.transactions.details.view.TxDataView
         android:id="@+id/tx_data"
@@ -39,8 +39,8 @@
     <View
         android:id="@+id/tx_data_separator"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/light_grey" />
+        android:layout_height="@dimen/item_separator_height"
+        android:background="@color/item_separator" />
 
     <io.gnosis.safe.ui.transactions.details.view.TxStatusView
         android:id="@+id/tx_status"
@@ -48,7 +48,8 @@
         android:layout_height="wrap_content" />
 
     <View
+        android:id="@+id/tx_status_separator"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/light_grey" />
+        android:layout_height="@dimen/item_separator_height"
+        android:background="@color/item_separator" />
 </LinearLayout>

--- a/app/src/main/res/layout/tx_details_settings_change.xml
+++ b/app/src/main/res/layout/tx_details_settings_change.xml
@@ -11,9 +11,10 @@
         android:layout_marginTop="16dp" />
 
     <View
+        android:id="@+id/action_separator"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/light_grey" />
+        android:layout_height="@dimen/item_separator_height"
+        android:background="@color/item_separator" />
 
     <io.gnosis.safe.ui.transactions.details.view.TxStatusView
         android:id="@+id/tx_status"
@@ -21,8 +22,9 @@
         android:layout_height="wrap_content" />
 
     <View
+        android:id="@+id/status_separator"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/light_grey" />
+        android:layout_height="@dimen/item_separator_height"
+        android:background="@color/item_separator" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/tx_details_transfer.xml
+++ b/app/src/main/res/layout/tx_details_transfer.xml
@@ -13,9 +13,10 @@
         android:layout_marginTop="16dp" />
 
     <View
+        android:id="@+id/action_separator"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/light_grey" />
+        android:layout_height="@dimen/item_separator_height"
+        android:background="@color/item_separator" />
 
     <io.gnosis.safe.ui.settings.view.NamedAddressItem
         android:id="@+id/contract_address"
@@ -25,8 +26,8 @@
     <View
         android:id="@+id/contract_separator"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/light_grey" />
+        android:layout_height="@dimen/item_separator_height"
+        android:background="@color/item_separator" />
 
     <io.gnosis.safe.ui.transactions.details.view.TxStatusView
         android:id="@+id/tx_status"
@@ -34,8 +35,9 @@
         android:layout_height="wrap_content" />
 
     <View
+        android:id="@+id/status_separator"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/light_grey" />
+        android:layout_height="@dimen/item_separator_height"
+        android:background="@color/item_separator" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/tx_details_transfer.xml
+++ b/app/src/main/res/layout/tx_details_transfer.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     tools:visibility="visible">
 
@@ -21,7 +23,9 @@
     <io.gnosis.safe.ui.settings.view.NamedAddressItem
         android:id="@+id/contract_address"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        app:show_named_address_separator="false"
+        />
 
     <View
         android:id="@+id/contract_separator"

--- a/app/src/main/res/layout/view_address_item.xml
+++ b/app/src/main/res/layout/view_address_item.xml
@@ -49,7 +49,7 @@
     <View
         android:id="@+id/address_divider"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/item_setting_separator_size"
+        android:layout_height="@dimen/item_separator_height"
         android:background="@color/item_separator"
         app:layout_constraintBottom_toBottomOf="parent"
         android:visibility="gone" />

--- a/app/src/main/res/layout/view_address_item.xml
+++ b/app/src/main/res/layout/view_address_item.xml
@@ -49,8 +49,8 @@
     <View
         android:id="@+id/address_divider"
         android:layout_width="match_parent"
-        android:layout_height="2dp"
-        android:background="@color/background"
+        android:layout_height="@dimen/item_setting_separator_size"
+        android:background="@color/item_separator"
         app:layout_constraintBottom_toBottomOf="parent"
         android:visibility="gone" />
 </merge>

--- a/app/src/main/res/layout/view_mastercopy_item.xml
+++ b/app/src/main/res/layout/view_mastercopy_item.xml
@@ -79,9 +79,4 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="2dp"
-        android:background="@color/background"
-        app:layout_constraintBottom_toBottomOf="parent" />
 </merge>

--- a/app/src/main/res/layout/view_multisend_action.xml
+++ b/app/src/main/res/layout/view_multisend_action.xml
@@ -76,8 +76,8 @@
     <View
         android:id="@+id/divider"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/light_grey"
+        android:layout_height="@dimen/item_separator_height"
+        android:background="@color/item_separator"
         app:layout_constraintBottom_toBottomOf="parent" />
 
 </merge>

--- a/app/src/main/res/layout/view_named_address_item.xml
+++ b/app/src/main/res/layout/view_named_address_item.xml
@@ -61,8 +61,9 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <View
+        android:id="@+id/named_address_item_separator"
         android:layout_width="match_parent"
-        android:layout_height="2dp"
-        android:background="@color/background"
+        android:layout_height="@dimen/item_setting_separator_size"
+        android:background="@color/item_separator"
         app:layout_constraintBottom_toBottomOf="parent" />
 </merge>

--- a/app/src/main/res/layout/view_named_address_item.xml
+++ b/app/src/main/res/layout/view_named_address_item.xml
@@ -63,7 +63,7 @@
     <View
         android:id="@+id/named_address_item_separator"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/item_setting_separator_size"
+        android:layout_height="@dimen/item_separator_height"
         android:background="@color/item_separator"
         app:layout_constraintBottom_toBottomOf="parent" />
 </merge>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -18,6 +18,10 @@
     </declare-styleable>
 
     <declare-styleable name="AddressItem">
-        <attr name="show_separator" format="boolean" />
+        <attr name="show_address_separator" format="boolean" />
+    </declare-styleable>
+
+    <declare-styleable name="NamedAddressItem">
+        <attr name="show_named_address_separator" format="boolean" />
     </declare-styleable>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,6 +7,7 @@
     <color name="toolbar_action">@color/blue</color>
 
     <color name="background">@color/very_light_pink_two</color>
+    <color name="item_separator">@color/very_light_pink_two</color>
 
     <color name="whitesmoke_two">#f0efee</color>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -14,6 +14,7 @@
     <dimen name="item_tx_l_height">112dp</dimen>
     <dimen name="item_setting_openable_height">64dp</dimen>
     <dimen name="item_setting_non_openable_height">48dp</dimen>
+    <dimen name="item_setting_margin">2dp</dimen>
     <dimen name="item_separator_height">2dp</dimen>
     <dimen name="header_height">44dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -14,6 +14,6 @@
     <dimen name="item_tx_l_height">112dp</dimen>
     <dimen name="item_setting_openable_height">64dp</dimen>
     <dimen name="item_setting_non_openable_height">48dp</dimen>
-    <dimen name="item_setting_separator_size">2dp</dimen>
+    <dimen name="item_separator_height">2dp</dimen>
     <dimen name="header_height">44dp</dimen>
 </resources>


### PR DESCRIPTION
Handles #936 

**I think we need to make a decision on whether the last separator should be part of a custom view. And then make this consistent throughout the app.**

Changes proposed in this pull request:
- Remove additional separator by extracting it from the mastercopy custom view
- Changing color of item separator in tx list (according to the zeplin layouts)
- Fixing height of several separators
- Fixing bottom margin for tx hash
- Fixing bottom margin for created date
- Fixing separator color and height for detail views
- Added ids to several separators to make layout debugging easier
- Added custom attribut to NamedAddressItem to disable/enable separator

**Notes for QA**: This might break the layout of tx list, tx details,  app settings, collectible details and safe settings. 

Design: https://zpl.io/amAw7dK


Before | After 
------- | -------
![Screenshot_20201028-134751](https://user-images.githubusercontent.com/246473/97437904-6b9e8500-1924-11eb-92b6-3927422bb3df.png) | ![Screenshot_20201028-134541](https://user-images.githubusercontent.com/246473/97437938-73f6c000-1924-11eb-9e03-ef42c9dd2ba6.png)



@gnosis/mobile-devs
