### PR TITLE
Set appropriate confirmations icon for queued custom transaction item

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
@@ -249,7 +249,6 @@ class ChangeMastercopyQueuedViewHolder(private val viewBinding: ItemTxQueuedChan
 
             confirmations.setTextColor(ResourcesCompat.getColor(resources, viewTransfer.confirmationsTextColor, theme))
             confirmations.text = resources.getString(R.string.tx_list_confirmations, viewTransfer.confirmations, viewTransfer.threshold)
-            confirmationsIcon.visibility = View.VISIBLE
 
             moduleAddress.text = viewTransfer.address?.formatForTxList() ?: ""
             version.visibility = viewTransfer.visibilityVersion

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
@@ -125,8 +125,8 @@ class TransferQueuedViewHolder(private val viewBinding: ItemTxQueuedTransferBind
             blockies.setAddress(viewTransfer.address)
             ellipsizedAddress.text = viewTransfer.address.formatForTxList()
             amount.setTextColor(ResourcesCompat.getColor(resources, viewTransfer.amountColor, theme))
-            confirmations.setTextColor(ResourcesCompat.getColor(resources, viewTransfer.confirmationsTextColor, theme))
             confirmationsIcon.setImageDrawable(ResourcesCompat.getDrawable(resources, viewTransfer.confirmationsIcon, theme))
+            confirmations.setTextColor(ResourcesCompat.getColor(resources, viewTransfer.confirmationsTextColor, theme))
             confirmations.text = resources.getString(R.string.tx_list_confirmations, viewTransfer.confirmations, viewTransfer.threshold)
             nonce.text = viewTransfer.nonce
 
@@ -277,9 +277,9 @@ class CustomTransactionQueuedViewHolder(private val viewBinding: ItemTxQueuedTra
 
             dateTime.text = viewTransfer.dateTimeText
 
+            confirmationsIcon.setImageDrawable(ResourcesCompat.getDrawable(resources, viewTransfer.confirmationsIcon, theme))
             confirmations.setTextColor(ResourcesCompat.getColor(resources, viewTransfer.confirmationsTextColor, theme))
             confirmations.text = resources.getString(R.string.tx_list_confirmations, viewTransfer.confirmations, viewTransfer.threshold)
-            confirmationsIcon.visibility = View.VISIBLE
 
             dataSize.text = viewTransfer.dataSizeText
             amount.text = viewTransfer.amountText

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewHolderFactory.kt
@@ -247,6 +247,7 @@ class ChangeMastercopyQueuedViewHolder(private val viewBinding: ItemTxQueuedChan
             label.setText(viewTransfer.label)
             nonce.text = viewTransfer.nonce
 
+            confirmationsIcon.setImageDrawable(ResourcesCompat.getDrawable(resources, viewTransfer.confirmationsIcon, theme))
             confirmations.setTextColor(ResourcesCompat.getColor(resources, viewTransfer.confirmationsTextColor, theme))
             confirmations.text = resources.getString(R.string.tx_list_confirmations, viewTransfer.confirmations, viewTransfer.threshold)
 


### PR DESCRIPTION
Handles #1028

@gnosis/mobile-devs
