### PR TITLE
Prevent previous error being shown for new address; keep entered invalid safe address visible for reference

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeFragment.kt
@@ -96,6 +96,11 @@ class AddSafeFragment : BaseViewBindingFragment<FragmentAddSafeBinding>() {
     }
 
     private fun updateAddress(address: Solidity.Address) {
+        with(binding) {
+            nextButton.isEnabled = false
+            addSafeAddressInputLayout.address = address
+            addSafeAddressInputLayout.error = null
+        }
         viewModel.validate(address)
     }
 


### PR DESCRIPTION
Handles #991 
Handles #990


@gnosis/mobile-devs
