### PR TITLE
Hide input dialog if fragment is detached from context

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeFragment.kt
@@ -65,6 +65,11 @@ class AddSafeFragment : BaseViewBindingFragment<FragmentAddSafeBinding>() {
         })
     }
 
+    override fun onStop() {
+        super.onStop()
+        addressInputHelper.hideDialog()
+    }
+
     private fun handleError(throwable: Throwable) {
         Timber.e(throwable)
         with(binding) {


### PR DESCRIPTION
Handles #971 
Handles #972

After thorough investigation I was able to reproduce both crashes. The reason for both crashlytics issues is that fragment is not attached to context as callbacks are being invoked. This can happen if the input dialog is open and the user clicks on an incoming notification that navigates away from AddSafeFragment, not leaving the app. The input bottom sheet remains open though, thus any click on bottom sheet items results in a crash. 
Hiding input dialog solves the problem.


@gnosis/mobile-devs
