### PR TITLE
Update client gateway urls for staging

### DIFF
--- a/data/build.gradle
+++ b/data/build.gradle
@@ -19,17 +19,17 @@ android {
 
         debug {
             buildConfigField javaTypes.STRING, "TRANSACTION_SERVICE_URL", asString(getKey("TRANSACTION_SERVICE_URL", "https://safe-transaction.staging.gnosisdev.com/api/"))
-            buildConfigField javaTypes.STRING, "CLIENT_GATEWAY_URL", asString(getKey("CLIENT_GATEWAY_URL", "https://safe-client-rinkeby.staging.gnosisdev.com/"))
+            buildConfigField javaTypes.STRING, "CLIENT_GATEWAY_URL", asString(getKey("CLIENT_GATEWAY_URL", "https://safe-client.rinkeby.staging.gnosisdev.com/"))
         }
 
         unsafe {
             buildConfigField javaTypes.STRING, "TRANSACTION_SERVICE_URL", asString(getKey("TRANSACTION_SERVICE_URL", "https://safe-transaction.staging.gnosisdev.com/api/"))
-            buildConfigField javaTypes.STRING, "CLIENT_GATEWAY_URL", asString(getKey("CLIENT_GATEWAY_URL", "https://safe-client-rinkeby.staging.gnosisdev.com/"))
+            buildConfigField javaTypes.STRING, "CLIENT_GATEWAY_URL", asString(getKey("CLIENT_GATEWAY_URL", "https://safe-client.rinkeby.staging.gnosisdev.com/"))
         }
 
         internal {
             buildConfigField javaTypes.STRING, "TRANSACTION_SERVICE_URL", asString(getKey("TRANSACTION_SERVICE_URL", "https://safe-transaction.staging.gnosisdev.com/api/"))
-            buildConfigField javaTypes.STRING, "CLIENT_GATEWAY_URL", asString(getKey("CLIENT_GATEWAY_URL", "https://safe-client-rinkeby.staging.gnosisdev.com/"))
+            buildConfigField javaTypes.STRING, "CLIENT_GATEWAY_URL", asString(getKey("CLIENT_GATEWAY_URL", "https://safe-client.rinkeby.staging.gnosisdev.com/"))
         }
 
         rinkeby {
@@ -39,7 +39,7 @@ android {
 
         mainnet_staging {
             buildConfigField javaTypes.STRING, "TRANSACTION_SERVICE_URL", asString(getKey("TRANSACTION_SERVICE_URL", "https://safe-transaction.mainnet.staging.gnosisdev.com/api/"))
-            buildConfigField javaTypes.STRING, "CLIENT_GATEWAY_URL", asString(getKey("CLIENT_GATEWAY_URL", "https://safe-client-mainnet.staging.gnosisdev.com/"))
+            buildConfigField javaTypes.STRING, "CLIENT_GATEWAY_URL", asString(getKey("CLIENT_GATEWAY_URL", "https://safe-client.mainnet.staging.gnosisdev.com/"))
         }
 
         release {


### PR DESCRIPTION
Handles #1092

Changes proposed in this pull request:
- https://safe-client-mainnet.staging.gnosisdev.com/ -> https://safe-client.mainnet.staging.gnosisdev.com/
- https://safe-client-rinkeby.staging.gnosisdev.com/ -> https://safe-client.rinkeby.staging.gnosisdev.com/

@gnosis/mobile-devs
