### PR TITLE
Add flavour profile and activate leak canary for it

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,6 +75,13 @@ android {
             buildConfigField javaTypes.STRING, "SAFE_CREATION_FUNDER", asString(getKey("SAFE_CREATION_FUNDER", "0xAb8C18E66135561676f0781555D05CF6B22024A3"))
         }
 
+        //Only this profile will have LeakCanary enabled (see dependencies)
+        profile {
+            initWith debug
+            applicationIdSuffix ".profile"
+            versionNameSuffix "-profile"
+        }
+
         unsafe {
             initWith debug
             applicationIdSuffix ".unsafe"
@@ -290,7 +297,7 @@ dependencies {
 
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$versions.desugar_jdk_libs"
 
-    //debugImplementation "com.squareup.leakcanary:leakcanary-android:$versions.leak_canary"
+    profileImplementation "com.squareup.leakcanary:leakcanary-android:$versions.leak_canary"
 }
 
 

--- a/buildsystem/android_library.gradle
+++ b/buildsystem/android_library.gradle
@@ -21,6 +21,9 @@ android {
         debug {
         }
 
+        profile {
+        }
+
         unsafe {
         }
 

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -22,6 +22,11 @@ android {
             buildConfigField javaTypes.STRING, "CLIENT_GATEWAY_URL", asString(getKey("CLIENT_GATEWAY_URL", "https://safe-client.rinkeby.staging.gnosisdev.com/"))
         }
 
+        profile {
+            buildConfigField javaTypes.STRING, "TRANSACTION_SERVICE_URL", asString(getKey("TRANSACTION_SERVICE_URL", "https://safe-transaction.staging.gnosisdev.com/api/"))
+            buildConfigField javaTypes.STRING, "CLIENT_GATEWAY_URL", asString(getKey("CLIENT_GATEWAY_URL", "https://safe-client.rinkeby.staging.gnosisdev.com/"))
+        }
+
         unsafe {
             buildConfigField javaTypes.STRING, "TRANSACTION_SERVICE_URL", asString(getKey("TRANSACTION_SERVICE_URL", "https://safe-transaction.staging.gnosisdev.com/api/"))
             buildConfigField javaTypes.STRING, "CLIENT_GATEWAY_URL", asString(getKey("CLIENT_GATEWAY_URL", "https://safe-client.rinkeby.staging.gnosisdev.com/"))


### PR DESCRIPTION
Handles #868

Changes proposed in this pull request:
- adds flavor profile
- Activate leak canary for this flavor

**Remark: You need to add a "profile" client  config in google-services.json to build with this flavor**

@gnosis/mobile-devs
