### PR TITLE
Using language "en" and devices country to format dates and times.

### DIFF
--- a/app/src/main/java/io/gnosis/safe/utils/DateUtils.kt
+++ b/app/src/main/java/io/gnosis/safe/utils/DateUtils.kt
@@ -6,17 +6,17 @@ import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.*
 
-fun Date.formatBackendDateTime(zoneId: ZoneId = ZoneId.systemDefault(), locale: Locale = Locale.getDefault()): String {
+fun Date.formatBackendDateTime(zoneId: ZoneId = ZoneId.systemDefault(), locale: Locale = Locale("en", Locale.getDefault().country)): String {
     val customFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM).withZone(zoneId).withLocale(locale)
     return customFormatter.format(Instant.ofEpochMilli(time))
 }
 
-fun Date.formatBackendDate(zoneId: ZoneId = ZoneId.systemDefault(), locale: Locale = Locale.getDefault()): String {
+fun Date.formatBackendDate(zoneId: ZoneId = ZoneId.systemDefault(), locale: Locale = Locale("en", Locale.getDefault().country)): String {
     val customFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(zoneId).withLocale(locale)
     return customFormatter.format(Instant.ofEpochMilli(time))
 }
 
-fun Date.formatBackendTimeOfDay(zoneId: ZoneId = ZoneId.systemDefault(), locale: Locale = Locale.getDefault()): String {
+fun Date.formatBackendTimeOfDay(zoneId: ZoneId = ZoneId.systemDefault(), locale: Locale = Locale("en", Locale.getDefault().country)): String {
     val customFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withZone(zoneId).withLocale(locale)
     return customFormatter.format(Instant.ofEpochMilli(time))
 }


### PR DESCRIPTION
Handles #1158

Changes proposed in this pull request:
- Always use language en and take country from devices locale

@gnosis/mobile-devs
