### PR TITLE
Set active tab to history when navigating from transfer push

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
@@ -14,6 +14,7 @@ import io.gnosis.safe.R
 import io.gnosis.safe.databinding.ToolbarSafeOverviewBinding
 import io.gnosis.safe.ui.base.SafeOverviewNavigationHandler
 import io.gnosis.safe.ui.base.activity.BaseActivity
+import io.gnosis.safe.ui.transactions.TxPagerAdapter
 import io.gnosis.safe.utils.abbreviateEthAddress
 import kotlinx.coroutines.launch
 import pm.gnosis.crypto.utils.asEthereumAddressChecksumString
@@ -68,7 +69,7 @@ class StartActivity : BaseActivity(), SafeOverviewNavigationHandler {
                     }
                     if (txId == null) {
                         Navigation.findNavController(this@StartActivity, R.id.nav_host).navigate(R.id.transactionsFragment, Bundle().apply {
-                            putInt("activeTab", 1) // open history tab
+                            putInt("activeTab", TxPagerAdapter.Tabs.HISTORY.ordinal) // open history tab
                         })
                     } else {
                         Navigation.findNavController(this@StartActivity, R.id.nav_host).navigate(R.id.transactionDetailsFragment, Bundle().apply {

--- a/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
@@ -66,9 +66,10 @@ class StartActivity : BaseActivity(), SafeOverviewNavigationHandler {
                         safeRepository.setActiveSafe(it)
                         setSafeData(it)
                     }
-                    //TODO: figure out which tab (QUEUE vs HISTORY) to open
                     if (txId == null) {
-                        Navigation.findNavController(this@StartActivity, R.id.nav_host).navigate(R.id.transactionsFragment)
+                        Navigation.findNavController(this@StartActivity, R.id.nav_host).navigate(R.id.transactionsFragment, Bundle().apply {
+                            putInt("activeTab", 1) // open history tab
+                        })
                     } else {
                         Navigation.findNavController(this@StartActivity, R.id.nav_host).navigate(R.id.transactionDetailsFragment, Bundle().apply {
                             putString("txId", txId)

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/fiat/FiatListAdapter.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/fiat/FiatListAdapter.kt
@@ -36,7 +36,7 @@ class FiatListAdapter : RecyclerView.Adapter<FiatListAdapter.FiatViewHolder>() {
 
     override fun onBindViewHolder(holder: FiatViewHolder, position: Int) {
         val item = items[position]
-        val displayName = Currency.getInstance(item).displayName
+        val displayName = Currency.getInstance(item).getDisplayName(Locale("en", Locale.getDefault().country))
         holder.bind(item, displayName, item == selectedItem)
     }
 

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionsFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
+import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.google.android.material.tabs.TabLayoutMediator
@@ -21,6 +22,9 @@ import pm.gnosis.svalinn.common.utils.visible
 import javax.inject.Inject
 
 class TransactionsFragment : SafeOverviewBaseFragment<FragmentTransactionsBinding>() {
+
+    private val navArgs by navArgs<TransactionsFragmentArgs>()
+    private val activeTab by lazy { navArgs.activeTab }
 
     @Inject
     lateinit var viewModel: TransactionsViewModel
@@ -51,6 +55,7 @@ class TransactionsFragment : SafeOverviewBaseFragment<FragmentTransactionsBindin
                     }
                 }
             }.attach()
+            txContent.setCurrentItem(activeTab, false)
         }
         viewModel.state.observe(viewLifecycleOwner, Observer { state ->
             when (state) {

--- a/app/src/main/res/layout/item_tx_queued_transfer.xml
+++ b/app/src/main/res/layout/item_tx_queued_transfer.xml
@@ -60,6 +60,8 @@
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
         android:gravity="end"
+        android:ellipsize="end"
+        android:maxLines="1"
         app:layout_constraintBottom_toBottomOf="@+id/action"
         app:layout_constraintEnd_toStartOf="@+id/chevron"
         app:layout_constraintStart_toEndOf="@+id/action"

--- a/app/src/main/res/layout/item_tx_transfer.xml
+++ b/app/src/main/res/layout/item_tx_transfer.xml
@@ -47,6 +47,8 @@
         android:layout_marginStart="@dimen/default_small_margin"
         android:layout_marginEnd="@dimen/default_small_margin"
         android:gravity="end"
+        android:ellipsize="end"
+        android:maxLines="1"
         android:textColor="@color/primary"
         app:layout_constraintBottom_toBottomOf="@+id/action"
         app:layout_constraintEnd_toStartOf="@+id/chevron"

--- a/app/src/main/res/navigation/main_nav.xml
+++ b/app/src/main/res/navigation/main_nav.xml
@@ -194,6 +194,11 @@
             android:id="@+id/action_transactionsFragment_to_transactionCreationDetailsFragment"
             app:destination="@id/creationTransactionDetailsFragment" />
 
+        <argument
+            android:name="activeTab"
+            android:defaultValue="0"
+            app:argType="integer" />
+
     </fragment>
 
     <fragment


### PR DESCRIPTION
Handles #1190

Changes
- Ellipsize long token names for amounts
- Use en layout for currency names
- Open history tx tab when navigation from push notifications about transfers

@gnosis/mobile-devs
