### PR TITLE
Make NFT icons circles

### DIFF
--- a/app/src/main/res/layout/view_tx_erc721.xml
+++ b/app/src/main/res/layout/view_tx_erc721.xml
@@ -6,14 +6,21 @@
     android:layout_height="wrap_content"
     tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
-    <ImageView
+    <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/logo"
-        android:layout_width="@dimen/safe_blockie_size"
-        android:layout_height="@dimen/safe_blockie_size"
-        android:layout_marginTop="@dimen/default_small_margin"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:paddingStart="5dp"
+        android:paddingEnd="5dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/ic_nft_placeholder" />
+        app:srcCompat="@drawable/ic_nft_placeholder"
+        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.Circle"
+        app:strokeWidth="0.01dp"
+        app:strokeColor="@color/illustration_background" />
 
     <TextView
         android:id="@+id/token_amount"

--- a/app/src/main/res/layout/view_tx_erc721.xml
+++ b/app/src/main/res/layout/view_tx_erc721.xml
@@ -8,10 +8,10 @@
 
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/logo"
-        android:layout_width="36dp"
-        android:layout_height="36dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"
+        android:layout_width="@dimen/safe_blockie_size"
+        android:layout_height="@dimen/safe_blockie_size"
+        android:layout_marginTop="@dimen/default_small_margin"
+        android:layout_marginBottom="@dimen/default_small_margin"
         android:paddingStart="5dp"
         android:paddingEnd="5dp"
         app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
Handles #1204 

Changes proposed in this pull request:
- Use ShapeableImageView with circle appearance overlay

Before | After
------ | ------
![Screenshot_20210128-154404](https://user-images.githubusercontent.com/246473/106155118-9cd75d00-6180-11eb-9eb9-b45124c8a607.png) | ![Screenshot_20210128-154449](https://user-images.githubusercontent.com/246473/106155161-a791f200-6180-11eb-92d9-81656e5c3854.png)


@gnosis/mobile-devs
