### PR TITLE
Prevent crash when Fragment lost context.

### DIFF
--- a/app/src/main/java/io/gnosis/safe/helpers/AddressInputHelper.kt
+++ b/app/src/main/java/io/gnosis/safe/helpers/AddressInputHelper.kt
@@ -16,6 +16,7 @@ import io.gnosis.safe.utils.handleQrCodeActivityResult
 import io.gnosis.safe.utils.parseEthereumAddress
 import pm.gnosis.model.Solidity
 import pm.gnosis.utils.exceptions.InvalidAddressException
+import timber.log.Timber
 
 class AddressInputHelper(
     fragment: BaseFragment,
@@ -47,7 +48,9 @@ class AddressInputHelper(
                     val input = clipboard.primaryClip?.getItemAt(0)?.text?.trim()
                     (input?.let { parseEthereumAddress(it.toString()) }
                         ?: run {
-                            handleError(InvalidAddressException(fragment.getString(R.string.invalid_ethereum_address)), input.toString())
+                            fragment.context?.let {
+                                handleError(InvalidAddressException(fragment.getString(R.string.invalid_ethereum_address)), input.toString())
+                            } ?: Timber.e(InvalidAddressException(), "Fragment lost context.")
                             null
                         })?.let { addressCallback(it) }
                     dismiss()


### PR DESCRIPTION
Handles #1225

Changes proposed in this pull request:
- Check if fragment.context is null
- Log error via Timber if context is null

@gnosis/mobile-devs
