### PR TITLE
Add background after logo was loaded

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/settings/view/KnownAddressLogoView.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/view/KnownAddressLogoView.kt
@@ -5,9 +5,11 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
+import androidx.core.content.ContextCompat
 import com.google.android.material.imageview.ShapeableImageView
 import com.squareup.picasso.Picasso
 import com.squareup.picasso.Target
+import io.gnosis.safe.R
 import pm.gnosis.blockies.Blockies
 import pm.gnosis.blockies.BlockiesPainter
 import pm.gnosis.model.Solidity
@@ -44,6 +46,7 @@ open class KnownAddressLogoView(context: Context, attributeSet: AttributeSet?) :
     override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
         setAddress(null)
         setImageBitmap(bitmap)
+        background = ContextCompat.getDrawable(context, R.drawable.circle)
     }
 
     fun loadKnownAddressLogo(logoUri: String?, address: Solidity.Address, target: Target = this) {
@@ -56,5 +59,4 @@ open class KnownAddressLogoView(context: Context, attributeSet: AttributeSet?) :
             }
         }
     }
-
 }


### PR DESCRIPTION
Handles #1165 

Changes proposed in this pull request:
Before | After
-------| -----
![Screenshot_20210212-112927](https://user-images.githubusercontent.com/246473/107757318-af779780-6d25-11eb-97c4-fbcbb5c66f6d.png) | ![Screenshot_20210212-112833](https://user-images.githubusercontent.com/246473/107757273-9f5fb800-6d25-11eb-989a-2c6258d7693a.png)


@gnosis/mobile-devs
