### PR TITLE
Parse isCancellation flag 

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
@@ -246,7 +246,8 @@ class TransactionListViewModel
             alpha = alpha(txStatus),
             nonce = executionInfo?.nonce?.toString() ?: "",
             methodName = txInfo.methodName,
-            addressInfo = addressInfo
+            addressInfo = addressInfo,
+            isCancellation = txInfo.isCancellation
         )
     }
 
@@ -275,7 +276,8 @@ class TransactionListViewModel
             confirmationsIcon = if (thresholdMet) R.drawable.ic_confirmations_green_16dp else R.drawable.ic_confirmations_grey_16dp,
             nonce = if (isConflict) "" else executionInfo?.nonce?.toString() ?: "",
             methodName = txInfo.methodName,
-            addressInfo = addressInfo
+            addressInfo = addressInfo,
+            isCancellation = txInfo.isCancellation
         )
     }
 

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionListViewModel.kt
@@ -112,7 +112,13 @@ class TransactionListViewModel
             return when (val txInfo = txInfo) {
                 is TransactionInfo.Transfer -> toTransferView(txInfo, awaitingYourConfirmation, isConflict)
                 is TransactionInfo.SettingsChange -> toSettingsChangeView(txInfo, awaitingYourConfirmation, isConflict)
-                is TransactionInfo.Custom -> toCustomTransactionView(txInfo, safes, awaitingYourConfirmation, isConflict)
+                is TransactionInfo.Custom -> {
+                    if (txInfo.isCancellation) {
+                        toRejectionTransactionView(txInfo, safes, awaitingYourConfirmation, isConflict)
+                    } else {
+                        toCustomTransactionView(txInfo, safes, awaitingYourConfirmation, isConflict)
+                    }
+                }
                 is TransactionInfo.Creation -> toHistoryCreation(txInfo)
                 TransactionInfo.Unknown -> TransactionView.Unknown
             }
@@ -246,8 +252,7 @@ class TransactionListViewModel
             alpha = alpha(txStatus),
             nonce = executionInfo?.nonce?.toString() ?: "",
             methodName = txInfo.methodName,
-            addressInfo = addressInfo,
-            isCancellation = txInfo.isCancellation
+            addressInfo = addressInfo
         )
     }
 
@@ -276,8 +281,63 @@ class TransactionListViewModel
             confirmationsIcon = if (thresholdMet) R.drawable.ic_confirmations_green_16dp else R.drawable.ic_confirmations_grey_16dp,
             nonce = if (isConflict) "" else executionInfo?.nonce?.toString() ?: "",
             methodName = txInfo.methodName,
-            addressInfo = addressInfo,
-            isCancellation = txInfo.isCancellation
+            addressInfo = addressInfo
+        )
+    }
+
+    private fun Transaction.toRejectionTransactionView(
+        txInfo: TransactionInfo.Custom,
+        safes: List<Safe>,
+        awaitingYourConfirmation: Boolean,
+        isConflict: Boolean
+    ): TransactionView =
+        if (!isCompleted(txStatus)) queuedRejectionTransaction(txInfo, safes, awaitingYourConfirmation, isConflict)
+        else historicRejectionTransaction(txInfo, safes)
+
+    private fun Transaction.historicRejectionTransaction(
+        txInfo: TransactionInfo.Custom,
+        safes: List<Safe>
+    ): TransactionView.RejectionTransaction {
+
+        val addressInfo = resolveKnownAddress(txInfo.to, txInfo.toInfo, safes)
+
+        return TransactionView.RejectionTransaction(
+            id = id,
+            status = txStatus,
+            statusText = displayString(txStatus),
+            statusColorRes = statusTextColor(txStatus),
+            dateTimeText = timestamp.formatBackendTimeOfDay(),
+            alpha = alpha(txStatus),
+            nonce = executionInfo?.nonce?.toString() ?: "",
+            addressInfo = addressInfo
+        )
+    }
+
+    private fun Transaction.queuedRejectionTransaction(
+        txInfo: TransactionInfo.Custom,
+        safes: List<Safe>,
+        awaitingYourConfirmation: Boolean,
+        isConflict: Boolean
+    ): TransactionView.RejectionTransactionQueued {
+
+        //FIXME this wouldn't make sense for incoming Ethereum TXs
+        val threshold = executionInfo?.confirmationsRequired ?: -1
+        val thresholdMet = checkThreshold(threshold, executionInfo?.confirmationsSubmitted)
+
+        val addressInfo = resolveKnownAddress(txInfo.to, txInfo.toInfo, safes)
+
+        return TransactionView.RejectionTransactionQueued(
+            id = id,
+            status = txStatus,
+            statusText = displayString(txStatus, awaitingYourConfirmation),
+            statusColorRes = statusTextColor(txStatus),
+            dateTime = timestamp,
+            confirmations = executionInfo?.confirmationsSubmitted ?: 0,
+            threshold = threshold,
+            confirmationsTextColor = if (thresholdMet) R.color.primary else R.color.text_emphasis_low,
+            confirmationsIcon = if (thresholdMet) R.drawable.ic_confirmations_green_16dp else R.drawable.ic_confirmations_grey_16dp,
+            nonce = if (isConflict) "" else executionInfo?.nonce?.toString() ?: "",
+            addressInfo = addressInfo
         )
     }
 

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionView.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionView.kt
@@ -85,8 +85,7 @@ sealed class TransactionView(
         val alpha: Float,
         val nonce: String,
         val methodName: String?,
-        val addressInfo: AddressInfoData,
-        val isCancellation: Boolean
+        val addressInfo: AddressInfoData
     ) : TransactionView(status, id)
 
     data class CustomTransactionQueued(
@@ -101,8 +100,7 @@ sealed class TransactionView(
         @DrawableRes val confirmationsIcon: Int,
         val nonce: String,
         val methodName: String?,
-        val addressInfo: AddressInfoData,
-        val isCancellation: Boolean
+        val addressInfo: AddressInfoData
     ) : TransactionView(status, id)
 
     data class Creation(
@@ -124,6 +122,31 @@ sealed class TransactionView(
         val factory: String?,
         val transactionHash: String
     )
+
+    data class RejectionTransaction(
+        override val id: String,
+        override val status: TransactionStatus,
+        @StringRes val statusText: Int,
+        @ColorRes val statusColorRes: Int,
+        val dateTimeText: String,
+        val alpha: Float,
+        val nonce: String,
+        val addressInfo: AddressInfoData
+    ) : TransactionView(status, id)
+
+    data class RejectionTransactionQueued(
+        override val id: String,
+        override val status: TransactionStatus,
+        @StringRes val statusText: Int,
+        @ColorRes val statusColorRes: Int,
+        val dateTime: Date,
+        val confirmations: Int,
+        val threshold: Int,
+        @ColorRes val confirmationsTextColor: Int,
+        @DrawableRes val confirmationsIcon: Int,
+        val nonce: String,
+        val addressInfo: AddressInfoData
+    ) : TransactionView(status, id)
 
     data class SectionDateHeader(val date: Date, override val id: String = "<unused>") : TransactionView(null, id)
     data class SectionLabelHeader(val label: LabelType, override val id: String = "<unused>") : TransactionView(null, id)

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionView.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/TransactionView.kt
@@ -85,7 +85,8 @@ sealed class TransactionView(
         val alpha: Float,
         val nonce: String,
         val methodName: String?,
-        val addressInfo: AddressInfoData
+        val addressInfo: AddressInfoData,
+        val isCancellation: Boolean
     ) : TransactionView(status, id)
 
     data class CustomTransactionQueued(
@@ -100,7 +101,8 @@ sealed class TransactionView(
         @DrawableRes val confirmationsIcon: Int,
         val nonce: String,
         val methodName: String?,
-        val addressInfo: AddressInfoData
+        val addressInfo: AddressInfoData,
+        val isCancellation: Boolean
     ) : TransactionView(status, id)
 
     data class Creation(

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/viewdata/TransactionDetailsViewData.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/viewdata/TransactionDetailsViewData.kt
@@ -28,7 +28,8 @@ sealed class TransactionInfoViewData(
         val addressUri: String?,
         val dataSize: Int,
         val value: BigInteger,
-        val methodName: String?
+        val methodName: String?,
+        val isCancellation: Boolean
     ) : TransactionInfoViewData(TransactionType.Custom)
 
     data class SettingsChange(
@@ -123,7 +124,8 @@ internal fun TransactionInfo.toTransactionInfoViewData(safes: List<Safe>): Trans
                 addressUri = addressUri,
                 dataSize = dataSize,
                 value = value,
-                methodName = methodName
+                methodName = methodName,
+                isCancellation = isCancellation
             )
         }
         is TransactionInfo.Creation -> TransactionInfoViewData.Creation(creator, transactionHash, implementation, factory)

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/viewdata/TransactionDetailsViewData.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/viewdata/TransactionDetailsViewData.kt
@@ -28,8 +28,7 @@ sealed class TransactionInfoViewData(
         val addressUri: String?,
         val dataSize: Int,
         val value: BigInteger,
-        val methodName: String?,
-        val isCancellation: Boolean
+        val methodName: String?
     ) : TransactionInfoViewData(TransactionType.Custom)
 
     data class SettingsChange(
@@ -51,6 +50,12 @@ sealed class TransactionInfoViewData(
         val implementation: Solidity.Address?,
         val factory: Solidity.Address?
     ) : TransactionInfoViewData(TransactionType.Creation)
+
+    data class Rejection(
+        val to: Solidity.Address,
+        val addressName: String?,
+        val addressUri: String?
+    ) : TransactionInfoViewData(TransactionType.Custom)
 
     object Unknown : TransactionInfoViewData(TransactionType.Unknown)
 }
@@ -118,15 +123,22 @@ internal fun TransactionInfo.toTransactionInfoViewData(safes: List<Safe>): Trans
                 is AddressInfoData.Remote -> toInfo.name
                 else -> null
             }
-            TransactionInfoViewData.Custom(
-                to = to,
-                addressName = addressName,
-                addressUri = addressUri,
-                dataSize = dataSize,
-                value = value,
-                methodName = methodName,
-                isCancellation = isCancellation
-            )
+            if (isCancellation) {
+                TransactionInfoViewData.Rejection(
+                    to = to,
+                    addressName = addressName,
+                    addressUri = addressUri
+                )
+            } else {
+                TransactionInfoViewData.Custom(
+                    to = to,
+                    addressName = addressName,
+                    addressUri = addressUri,
+                    dataSize = dataSize,
+                    value = value,
+                    methodName = methodName
+                )
+            }
         }
         is TransactionInfo.Creation -> TransactionInfoViewData.Creation(creator, transactionHash, implementation, factory)
         is TransactionInfo.SettingsChange -> TransactionInfoViewData.SettingsChange(

--- a/app/src/main/java/io/gnosis/safe/utils/TxUtils.kt
+++ b/app/src/main/java/io/gnosis/safe/utils/TxUtils.kt
@@ -7,9 +7,9 @@ import io.gnosis.data.models.transaction.TransferInfo
 import io.gnosis.data.repositories.SafeRepository
 import io.gnosis.safe.R
 import io.gnosis.safe.ui.transactions.AddressInfoData
+import io.gnosis.safe.ui.transactions.details.view.ActionInfoItem
 import io.gnosis.safe.ui.transactions.details.viewdata.SettingsInfoViewData
 import io.gnosis.safe.ui.transactions.details.viewdata.TransactionInfoViewData
-import io.gnosis.safe.ui.transactions.details.view.ActionInfoItem
 import pm.gnosis.model.Solidity
 import java.math.BigInteger
 
@@ -58,6 +58,7 @@ fun TransactionInfoViewData.formattedAmount(balanceFormatter: BalanceFormatter):
         }
         is TransactionInfoViewData.SettingsChange -> "0 ${BuildConfig.NATIVE_CURRENCY_SYMBOL}"
         is TransactionInfoViewData.Creation -> "0 ${BuildConfig.NATIVE_CURRENCY_SYMBOL}"
+        is TransactionInfoViewData.Rejection -> "0 ${BuildConfig.NATIVE_CURRENCY_SYMBOL}"
         TransactionInfoViewData.Unknown -> "0 ${BuildConfig.NATIVE_CURRENCY_SYMBOL}"
     }
 
@@ -74,7 +75,11 @@ fun TransactionInfoViewData.logoUri(): String? =
                 "local::native_currency"
             }
         }
-        is TransactionInfoViewData.Custom, is TransactionInfoViewData.SettingsChange, is TransactionInfoViewData.Creation, TransactionInfoViewData.Unknown -> "local::native_currency"
+        is TransactionInfoViewData.Custom,
+        is TransactionInfoViewData.SettingsChange,
+        is TransactionInfoViewData.Creation,
+        is TransactionInfoViewData.Rejection,
+        TransactionInfoViewData.Unknown -> "local::native_currency"
     }
 
 fun TransactionInfoViewData.SettingsChange.txActionInfoItems(resources: Resources): List<ActionInfoItem> {

--- a/app/src/main/res/layout/item_tx_queued_rejection.xml
+++ b/app/src/main/res/layout/item_tx_queued_rejection.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/surface_01"
+    android:minHeight="@dimen/item_tx_m_height">
+
+    <ImageView
+        android:id="@+id/chevron"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_chevron_right" />
+
+    <ImageView
+        android:id="@+id/confirmations_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="6dp"
+        app:layout_constraintBottom_toBottomOf="@+id/status"
+        app:layout_constraintEnd_toStartOf="@+id/confirmations"
+        app:layout_constraintTop_toTopOf="@+id/status"
+        app:srcCompat="@drawable/ic_confirmations_grey_16dp" />
+
+    <TextView
+        android:id="@+id/address_name"
+        style="@style/TextDark"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:singleLine="true"
+        app:layout_constrainedWidth="true"
+        app:layout_constraintBottom_toBottomOf="@+id/address_logo"
+        app:layout_constraintEnd_toStartOf="@+id/action"
+        app:layout_constraintStart_toEndOf="@+id/address_logo"
+        app:layout_constraintTop_toTopOf="@+id/address_logo"
+        tools:text="@string/tx_list_rejection" />
+
+    <TextView
+        android:id="@+id/nonce"
+        style="@style/TextMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/address_logo"
+        tools:text="10" />
+
+    <TextView
+        android:id="@+id/date_time"
+        style="@style/TextMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        app:layout_constraintBottom_toBottomOf="@+id/nonce"
+        app:layout_constraintStart_toEndOf="@+id/nonce"
+        app:layout_constraintTop_toTopOf="@+id/nonce"
+        tools:text="Apr 27, 2020 — 1:01:42PM" />
+
+    <TextView
+        android:id="@+id/status_pending"
+        style="@style/TextMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:textColor="@color/secondary"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/date_time"
+        app:layout_constraintStart_toEndOf="@+id/date_time"
+        app:layout_constraintTop_toTopOf="@+id/date_time"
+        tools:text="\u2022 Pending" />
+
+    <TextView
+        android:id="@+id/status"
+        style="@style/TextMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:textColor="@color/secondary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/date_time"
+        tools:text="\u2022 Awaiting execution" />
+
+    <TextView
+        android:id="@+id/confirmations"
+        style="@style/TextMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        app:layout_constraintBottom_toBottomOf="@+id/confirmations_icon"
+        app:layout_constraintEnd_toStartOf="@+id/chevron"
+        app:layout_constraintTop_toTopOf="@+id/confirmations_icon"
+        tools:text="2 out of 2" />
+
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/not_pending"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="visible"
+        app:constraint_referenced_ids="confirmations_icon,status,confirmations" />
+
+    <!-- When making status_pending visible, make group "not_pending" "gone" -->
+    <io.gnosis.safe.ui.settings.view.KnownAddressLogoView
+        android:id="@+id/address_logo"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:src="@drawable/ic_code_16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.Circle"
+        app:strokeWidth="0.01dp"
+        app:strokeColor="@color/illustration_background" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_tx_rejection.xml
+++ b/app/src/main/res/layout/item_tx_rejection.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/surface_01"
+    android:minHeight="@dimen/item_tx_s_height">
+
+    <ImageView
+        android:id="@+id/chevron"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/default_margin"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_chevron_right" />
+
+    <TextView
+        android:id="@+id/nonce"
+        style="@style/TextMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/address_logo"
+        tools:text="10" />
+
+
+
+    <TextView
+        android:id="@+id/date_time"
+        style="@style/TextMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        app:layout_constraintBottom_toBottomOf="@+id/nonce"
+        app:layout_constraintStart_toEndOf="@+id/nonce"
+        app:layout_constraintTop_toTopOf="@+id/nonce"
+        tools:text="Apr 27, 2020 — 1:01:42PM" />
+
+    <TextView
+        android:id="@+id/address_name"
+        style="@style/TextDark"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:singleLine="true"
+        app:layout_constrainedWidth="true"
+        app:layout_constraintBottom_toBottomOf="@+id/address_logo"
+        app:layout_constraintEnd_toStartOf="@+id/action"
+        app:layout_constraintStart_toEndOf="@+id/address_logo"
+        app:layout_constraintTop_toTopOf="@+id/address_logo"
+        tools:text="@string/tx_list_rejection" />
+
+    <TextView
+        android:id="@+id/final_status"
+        style="@style/TextMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="6dp"
+        android:textColor="@color/primary"
+        android:visibility="visible"
+        app:layout_constraintBottom_toBottomOf="@+id/date_time"
+        app:layout_constraintStart_toEndOf="@+id/date_time"
+        app:layout_constraintTop_toTopOf="@+id/date_time"
+        tools:text="Success" />
+
+    <io.gnosis.safe.ui.settings.view.KnownAddressLogoView
+        android:id="@+id/address_logo"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:layout_marginStart="@dimen/default_margin"
+        android:layout_marginTop="16dp"
+        android:src="@drawable/ic_code_16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.Circle"
+        app:strokeWidth="0.01dp"
+        app:strokeColor="@color/illustration_background" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -340,6 +340,7 @@
     <string name="unknown_module">Unknown</string>
     <string name="unknown_implementation_version">Unknown</string>
     <string name="tx_list_contract_interaction">Contract interaction</string>
+    <string name="tx_list_rejection">ON-CHAIN REJECTION</string>
     <string name="tx_list_conflict_header_explainer">These transactions conflict as they use the same nonce. Executing one will automatically replace the other(s).</string>
     <string name="tx_list_conflict_header_learn_more">Learn more</string>
     <string name="label_type_next">Next</string>

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
@@ -489,7 +489,8 @@ class TransactionListViewModelTest {
                 confirmationsTextColor = R.color.primary,
                 threshold = 2,
                 confirmations = 2,
-                addressInfo = AddressInfoData.Default
+                addressInfo = AddressInfoData.Default,
+                isCancellation = false
             ),
             transactionViews[0]
         )
@@ -506,7 +507,8 @@ class TransactionListViewModelTest {
                 confirmationsIcon = R.drawable.ic_confirmations_grey_16dp,
                 nonce = "1",
                 confirmations = 0,
-                addressInfo = AddressInfoData.Default
+                addressInfo = AddressInfoData.Default,
+                isCancellation = false
             ),
             transactionViews[1]
         )
@@ -520,7 +522,8 @@ class TransactionListViewModelTest {
                 methodName = "multiSend",
                 alpha = OPACITY_FULL,
                 nonce = "1",
-                addressInfo = AddressInfoData.Local(defaultSafeName, defaultSafeAddress.asEthereumAddressString())
+                addressInfo = AddressInfoData.Local(defaultSafeName, defaultSafeAddress.asEthereumAddressString()),
+                isCancellation = false
             ),
             transactionViews[2]
         )
@@ -534,7 +537,8 @@ class TransactionListViewModelTest {
                 methodName = "multiSend",
                 alpha = OPACITY_HALF,
                 nonce = "1",
-                addressInfo = AddressInfoData.Default
+                addressInfo = AddressInfoData.Default,
+                isCancellation = false
             ),
             transactionViews[3]
         )
@@ -548,7 +552,8 @@ class TransactionListViewModelTest {
                 methodName = "multiSend",
                 alpha = OPACITY_HALF,
                 nonce = "1",
-                addressInfo = AddressInfoData.Default
+                addressInfo = AddressInfoData.Default,
+                isCancellation = false
             ),
             transactionViews[4]
         )
@@ -929,7 +934,8 @@ class TransactionListViewModelTest {
                 methodName = "multiSend",
                 alpha = OPACITY_FULL,
                 nonce = "1",
-                addressInfo = AddressInfoData.Local(defaultSafeName, defaultSafeAddress.asEthereumAddressString())
+                addressInfo = AddressInfoData.Local(defaultSafeName, defaultSafeAddress.asEthereumAddressString()),
+                isCancellation = false
             ),
             transactionViews[0]
         )
@@ -944,7 +950,8 @@ class TransactionListViewModelTest {
                 methodName = "multiSend",
                 alpha = OPACITY_FULL,
                 nonce = "1",
-                addressInfo = AddressInfoData.Remote(defaultKnownAddressName, defaultKnownAddressLogo, defaultKnownAddressAddress.asEthereumAddressString())
+                addressInfo = AddressInfoData.Remote(defaultKnownAddressName, defaultKnownAddressLogo, defaultKnownAddressAddress.asEthereumAddressString()),
+                isCancellation = false
             ),
             transactionViews[1]
         )
@@ -959,7 +966,8 @@ class TransactionListViewModelTest {
                 methodName = "multiSend",
                 alpha = OPACITY_FULL,
                 nonce = "1",
-                addressInfo = AddressInfoData.Default
+                addressInfo = AddressInfoData.Default,
+                isCancellation = false
             ),
             transactionViews[2]
         )
@@ -974,7 +982,8 @@ class TransactionListViewModelTest {
                 methodName = "multiSend",
                 alpha = OPACITY_FULL,
                 nonce = "1",
-                addressInfo = AddressInfoData.Local(defaultSafeName, defaultSafeAddress.asEthereumAddressString())
+                addressInfo = AddressInfoData.Local(defaultSafeName, defaultSafeAddress.asEthereumAddressString()),
+                isCancellation = false
             ),
             transactionViews[3]
         )
@@ -1094,7 +1103,7 @@ class TransactionListViewModelTest {
         Transaction(
             id = "",
             txStatus = status,
-            txInfo = TransactionInfo.Custom(to = address, dataSize = dataSize, value = value, methodName = "multiSend", toInfo = toInfo),
+            txInfo = TransactionInfo.Custom(to = address, dataSize = dataSize, value = value, methodName = "multiSend", toInfo = toInfo, isCancellation = false),
             executionInfo = ExecutionInfo(
                 nonce = nonce,
                 confirmationsRequired = defaultThreshold,

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
@@ -489,8 +489,7 @@ class TransactionListViewModelTest {
                 confirmationsTextColor = R.color.primary,
                 threshold = 2,
                 confirmations = 2,
-                addressInfo = AddressInfoData.Default,
-                isCancellation = false
+                addressInfo = AddressInfoData.Default
             ),
             transactionViews[0]
         )
@@ -507,8 +506,7 @@ class TransactionListViewModelTest {
                 confirmationsIcon = R.drawable.ic_confirmations_grey_16dp,
                 nonce = "1",
                 confirmations = 0,
-                addressInfo = AddressInfoData.Default,
-                isCancellation = false
+                addressInfo = AddressInfoData.Default
             ),
             transactionViews[1]
         )
@@ -522,8 +520,7 @@ class TransactionListViewModelTest {
                 methodName = "multiSend",
                 alpha = OPACITY_FULL,
                 nonce = "1",
-                addressInfo = AddressInfoData.Local(defaultSafeName, defaultSafeAddress.asEthereumAddressString()),
-                isCancellation = false
+                addressInfo = AddressInfoData.Local(defaultSafeName, defaultSafeAddress.asEthereumAddressString())
             ),
             transactionViews[2]
         )
@@ -537,8 +534,7 @@ class TransactionListViewModelTest {
                 methodName = "multiSend",
                 alpha = OPACITY_HALF,
                 nonce = "1",
-                addressInfo = AddressInfoData.Default,
-                isCancellation = false
+                addressInfo = AddressInfoData.Default
             ),
             transactionViews[3]
         )
@@ -552,8 +548,7 @@ class TransactionListViewModelTest {
                 methodName = "multiSend",
                 alpha = OPACITY_HALF,
                 nonce = "1",
-                addressInfo = AddressInfoData.Default,
-                isCancellation = false
+                addressInfo = AddressInfoData.Default
             ),
             transactionViews[4]
         )
@@ -934,8 +929,7 @@ class TransactionListViewModelTest {
                 methodName = "multiSend",
                 alpha = OPACITY_FULL,
                 nonce = "1",
-                addressInfo = AddressInfoData.Local(defaultSafeName, defaultSafeAddress.asEthereumAddressString()),
-                isCancellation = false
+                addressInfo = AddressInfoData.Local(defaultSafeName, defaultSafeAddress.asEthereumAddressString())
             ),
             transactionViews[0]
         )
@@ -950,8 +944,7 @@ class TransactionListViewModelTest {
                 methodName = "multiSend",
                 alpha = OPACITY_FULL,
                 nonce = "1",
-                addressInfo = AddressInfoData.Remote(defaultKnownAddressName, defaultKnownAddressLogo, defaultKnownAddressAddress.asEthereumAddressString()),
-                isCancellation = false
+                addressInfo = AddressInfoData.Remote(defaultKnownAddressName, defaultKnownAddressLogo, defaultKnownAddressAddress.asEthereumAddressString())
             ),
             transactionViews[1]
         )
@@ -966,8 +959,7 @@ class TransactionListViewModelTest {
                 methodName = "multiSend",
                 alpha = OPACITY_FULL,
                 nonce = "1",
-                addressInfo = AddressInfoData.Default,
-                isCancellation = false
+                addressInfo = AddressInfoData.Default
             ),
             transactionViews[2]
         )
@@ -982,8 +974,7 @@ class TransactionListViewModelTest {
                 methodName = "multiSend",
                 alpha = OPACITY_FULL,
                 nonce = "1",
-                addressInfo = AddressInfoData.Local(defaultSafeName, defaultSafeAddress.asEthereumAddressString()),
-                isCancellation = false
+                addressInfo = AddressInfoData.Local(defaultSafeName, defaultSafeAddress.asEthereumAddressString())
             ),
             transactionViews[3]
         )

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/details/viewdata/TransactionDetailsViewDataTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/details/viewdata/TransactionDetailsViewDataTest.kt
@@ -105,26 +105,21 @@ class TransactionDetailsViewDataTest {
 
 
     @Test
-    fun `toTransactionInfoViewData() (TransactionInfo_Custom with AddressInfo) should return TransactionInfoViewData_Custom `() {
+    fun `toTransactionInfoViewData() (TransactionInfo_Custom with AddressInfo and isCancellation) should return TransactionInfoViewData_Rejection `() {
         val transactionInfo = TransactionInfo.Custom(anyAddress, AddressInfo("Remote Name", null), 1, BigInteger.ZERO, "dummyName", true)
         val safes = listOf(Safe(anotherAddress, "Local Name"))
 
         val result = transactionInfo.toTransactionInfoViewData(safes)
 
         assertEquals(
-            TransactionInfoViewData.Custom(
+            TransactionInfoViewData.Rejection(
                 to = anyAddress,
                 addressName = "Remote Name",
-                addressUri = null,
-                dataSize = 1,
-                value = BigInteger.ZERO,
-                methodName = "dummyName",
-                isCancellation = true
+                addressUri = null
             ),
             result
         )
     }
-
 
     @Test
     fun `toTransactionInfoViewData() (TransactionInfo_SettingsChange with AddressInfo) should return TransactionInfoViewData_SettingsChange `() {

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/details/viewdata/TransactionDetailsViewDataTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/details/viewdata/TransactionDetailsViewDataTest.kt
@@ -106,7 +106,7 @@ class TransactionDetailsViewDataTest {
 
     @Test
     fun `toTransactionInfoViewData() (TransactionInfo_Custom with AddressInfo) should return TransactionInfoViewData_Custom `() {
-        val transactionInfo = TransactionInfo.Custom(anyAddress, AddressInfo("Remote Name", null), 1, BigInteger.ZERO, "dummyName")
+        val transactionInfo = TransactionInfo.Custom(anyAddress, AddressInfo("Remote Name", null), 1, BigInteger.ZERO, "dummyName", true)
         val safes = listOf(Safe(anotherAddress, "Local Name"))
 
         val result = transactionInfo.toTransactionInfoViewData(safes)
@@ -118,7 +118,8 @@ class TransactionDetailsViewDataTest {
                 addressUri = null,
                 dataSize = 1,
                 value = BigInteger.ZERO,
-                methodName = "dummyName"
+                methodName = "dummyName",
+                isCancellation = true
             ),
             result
         )

--- a/app/src/test/java/io/gnosis/safe/utils/TxUtilsKtTest.kt
+++ b/app/src/test/java/io/gnosis/safe/utils/TxUtilsKtTest.kt
@@ -59,8 +59,7 @@ class TxUtilsKtTest {
             value = BigInteger.ZERO,
             methodName = null,
             addressName = null,
-            addressUri = null,
-            isCancellation = false
+            addressUri = null
         )
         val result = txInfo.formattedAmount(balanceFormatter)
 
@@ -76,8 +75,7 @@ class TxUtilsKtTest {
             value = "1000000000000000000".decimalAsBigInteger(),
             methodName = null,
             addressName = null,
-            addressUri = null,
-            isCancellation = false
+            addressUri = null
         )
         val result = txInfo.formattedAmount(balanceFormatter)
 

--- a/app/src/test/java/io/gnosis/safe/utils/TxUtilsKtTest.kt
+++ b/app/src/test/java/io/gnosis/safe/utils/TxUtilsKtTest.kt
@@ -59,8 +59,8 @@ class TxUtilsKtTest {
             value = BigInteger.ZERO,
             methodName = null,
             addressName = null,
-            addressUri = null
-
+            addressUri = null,
+            isCancellation = false
         )
         val result = txInfo.formattedAmount(balanceFormatter)
 
@@ -76,7 +76,8 @@ class TxUtilsKtTest {
             value = "1000000000000000000".decimalAsBigInteger(),
             methodName = null,
             addressName = null,
-            addressUri = null
+            addressUri = null,
+            isCancellation = false
         )
         val result = txInfo.formattedAmount(balanceFormatter)
 

--- a/data/src/main/java/io/gnosis/data/models/transaction/TransactionInfo.kt
+++ b/data/src/main/java/io/gnosis/data/models/transaction/TransactionInfo.kt
@@ -15,7 +15,8 @@ sealed class TransactionInfo(
         @Json(name = "toInfo") val toInfo: AddressInfo?,
         @Json(name = "dataSize") val dataSize: Int,
         @Json(name = "value") val value: BigInteger,
-        @Json(name = "methodName") val methodName: String?
+        @Json(name = "methodName") val methodName: String?,
+        @Json(name = "isCancellation") val isCancellation: Boolean?
     ) : TransactionInfo(TransactionType.Custom)
 
     @JsonClass(generateAdapter = true)

--- a/data/src/main/java/io/gnosis/data/models/transaction/TransactionInfo.kt
+++ b/data/src/main/java/io/gnosis/data/models/transaction/TransactionInfo.kt
@@ -16,7 +16,7 @@ sealed class TransactionInfo(
         @Json(name = "dataSize") val dataSize: Int,
         @Json(name = "value") val value: BigInteger,
         @Json(name = "methodName") val methodName: String?,
-        @Json(name = "isCancellation") val isCancellation: Boolean?
+        @Json(name = "isCancellation") val isCancellation: Boolean
     ) : TransactionInfo(TransactionType.Custom)
 
     @JsonClass(generateAdapter = true)

--- a/data/src/test/java/io/gnosis/data/adapters/DataMoshiTest.kt
+++ b/data/src/test/java/io/gnosis/data/adapters/DataMoshiTest.kt
@@ -70,7 +70,8 @@ class DataMoshiTest {
                 to = "0x2134Bb3DE97813678daC21575E7A77a95079FC51".asEthereumAddress()!!,
                 toInfo = AddressInfo("Foo Bar", "https://gnosis-safe-token-logos.s3.amazonaws.com/0x2134Bb3DE97813678daC21575E7A77a95079FC51.png"),
                 value = "3140000000000000000".toBigInteger(),
-                methodName = null
+                methodName = null,
+                isCancellation = true
             ),
             executionInfo = ExecutionInfo(
                 nonce = 8.toBigInteger(),

--- a/data/src/test/java/io/gnosis/data/repositories/TransactionRepositoryTest.kt
+++ b/data/src/test/java/io/gnosis/data/repositories/TransactionRepositoryTest.kt
@@ -320,7 +320,8 @@ private fun buildCustomTxInfo(
         to = to,
         dataSize = dataSize,
         methodName = null,
-        toInfo = null
+        toInfo = null,
+        isCancellation = false
     )
 
 private fun buildCreationTxInfo(

--- a/data/src/test/resources/custom.json
+++ b/data/src/test/resources/custom.json
@@ -10,7 +10,8 @@
     "toInfo": {
       "name": "Foo Bar",
       "logoUri": "https://gnosis-safe-token-logos.s3.amazonaws.com/0x2134Bb3DE97813678daC21575E7A77a95079FC51.png"
-    }
+    },
+    "isCancellation": true
   },
   "executionInfo": {
     "nonce": 8,

--- a/data/src/test/resources/tx_details_custom.json
+++ b/data/src/test/resources/tx_details_custom.json
@@ -10,7 +10,8 @@
     "toInfo": {
       "name": "Foo Bar",
       "logoUri": "https://gnosis-safe-token-logos.s3.amazonaws.com/0x1230B3d59858296A31053C1b8562Ecf89A2f888b.png"
-    }
+    },
+    "isCancellation": true
   },
   "txData": {
     "hexData": null,


### PR DESCRIPTION
Handles #1267

Changes proposed in this pull request:
- Add `isCancellation` to `TransactionInfo.Custom`
- Populate `isCancellation` to `TransactionView.CustomTransaction` and `TransactionView.CustomTransactionQueued`
- Adjust tests

@gnosis/mobile-devs
