### PR TITLE
Notification channels

### DIFF
--- a/app/src/main/java/io/gnosis/safe/di/modules/ApplicationModule.kt
+++ b/app/src/main/java/io/gnosis/safe/di/modules/ApplicationModule.kt
@@ -198,8 +198,9 @@ class ApplicationModule(private val application: Application) {
     fun providesNotificationManager(
         @ApplicationContext context: Context,
         preferencesManager: PreferencesManager,
-        balanceFormatter: BalanceFormatter
-    ): NotificationManager = NotificationManager(context, preferencesManager, balanceFormatter)
+        balanceFormatter: BalanceFormatter,
+        safeRepository: SafeRepository
+    ): NotificationManager = NotificationManager(context, preferencesManager, balanceFormatter, safeRepository)
 
     @Provides
     @Singleton

--- a/app/src/main/java/io/gnosis/safe/di/modules/ApplicationModule.kt
+++ b/app/src/main/java/io/gnosis/safe/di/modules/ApplicationModule.kt
@@ -200,7 +200,7 @@ class ApplicationModule(private val application: Application) {
         preferencesManager: PreferencesManager,
         balanceFormatter: BalanceFormatter,
         safeRepository: SafeRepository
-    ): NotificationManager = NotificationManager(context, preferencesManager, balanceFormatter, safeRepository)
+    ): NotificationManager = NotificationManager(context, preferencesManager, balanceFormatter)
 
     @Provides
     @Singleton

--- a/app/src/main/java/io/gnosis/safe/di/modules/ApplicationModule.kt
+++ b/app/src/main/java/io/gnosis/safe/di/modules/ApplicationModule.kt
@@ -200,7 +200,7 @@ class ApplicationModule(private val application: Application) {
         preferencesManager: PreferencesManager,
         balanceFormatter: BalanceFormatter,
         safeRepository: SafeRepository
-    ): NotificationManager = NotificationManager(context, preferencesManager, balanceFormatter)
+    ): NotificationManager = NotificationManager(context, preferencesManager, balanceFormatter, safeRepository)
 
     @Provides
     @Singleton

--- a/app/src/main/java/io/gnosis/safe/notifications/NotificationManager.kt
+++ b/app/src/main/java/io/gnosis/safe/notifications/NotificationManager.kt
@@ -35,7 +35,9 @@ class NotificationManager(
             // For upgrading users. Can be removed in a future release?
             runBlocking {
                 safeRepository.getSafes().forEach { safe ->
-                    createNotificationChannelGroup(safe)
+                    if (notificationManager.getNotificationChannelGroup(safe.address.asEthereumAddressChecksumString()) == null) {
+                        createNotificationChannelGroup(safe)
+                    }
                 }
                 notificationManager.deleteNotificationChannel(CHANNEL_ID)
             }

--- a/app/src/main/java/io/gnosis/safe/notifications/NotificationManager.kt
+++ b/app/src/main/java/io/gnosis/safe/notifications/NotificationManager.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.runBlocking
 import pm.gnosis.crypto.utils.asEthereumAddressChecksumString
 import pm.gnosis.svalinn.common.PreferencesManager
 import pm.gnosis.svalinn.common.utils.edit
-import timber.log.Timber
 
 class NotificationManager(
     private val context: Context,
@@ -42,7 +41,6 @@ class NotificationManager(
             }
         }
     }
-
 
     private var latestNotificationId: Int
         get() = preferencesManager.prefs.getInt(LATEST_NOTIFICATION_ID, -1)
@@ -156,7 +154,7 @@ class NotificationManager(
 
         val resId = subChannelForPushNotificationSubType(pushNotification).resId
         val channelId = safe.address.asEthereumAddressChecksumString() + "." + context.getString(resId)
-        Timber.i("---> channelId: $channelId")
+
         return builder(title, text, channelId, intent)
     }
 

--- a/app/src/main/java/io/gnosis/safe/notifications/NotificationManager.kt
+++ b/app/src/main/java/io/gnosis/safe/notifications/NotificationManager.kt
@@ -38,6 +38,7 @@ class NotificationManager(
                 safeRepository.getSafes().forEach { safe ->
                     createNotificationChannelGroup(safe)
                 }
+                notificationManager.deleteNotificationChannel(CHANNEL_ID)
             }
         }
     }

--- a/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeNameViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeNameViewModel.kt
@@ -3,6 +3,7 @@ package io.gnosis.safe.ui.safe.add
 import io.gnosis.data.models.Safe
 import io.gnosis.data.repositories.SafeRepository
 import io.gnosis.safe.Tracker
+import io.gnosis.safe.notifications.NotificationManager
 import io.gnosis.safe.notifications.NotificationRepository
 import io.gnosis.safe.ui.base.AppDispatchers
 import io.gnosis.safe.ui.base.BaseStateViewModel
@@ -17,6 +18,7 @@ class AddSafeNameViewModel
     private val notificationRepository: NotificationRepository,
     private val ownerCredentialsRepository: OwnerCredentialsRepository,
     private val settingsHandler: SettingsHandler,
+    private val notificationManager: NotificationManager,
     appDispatchers: AppDispatchers,
     private val tracker: Tracker
 ) : BaseStateViewModel<BaseStateViewModel.State>(appDispatchers) {
@@ -31,7 +33,8 @@ class AddSafeNameViewModel
             runCatching {
                 val safe = Safe(address, localName.trim())
                 safeRepository.saveSafe(safe)
-                notificationRepository.registerSafe(safe.address)
+                notificationRepository.registerSafe(safe)
+                notificationManager.createNotificationChannelGroup(safe)
                 safeRepository.setActiveSafe(safe)
             }.onFailure {
                 updateState { AddSafeNameState(ViewAction.ShowError(it)) }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/owner/list/OwnerSelectionViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/owner/list/OwnerSelectionViewModel.kt
@@ -77,11 +77,11 @@ class OwnerSelectionViewModel
             settingsHandler.showOwnerScreen = false
             tracker.logKeyImported(privateKey == null)
             tracker.setNumKeysImported(1)
-            updateState {
-                OwnerSelectionState(ViewAction.CloseScreen)
-            }
             OwnerCredentials(address = addresses[0], key = key).let {
                 notificationRepository.registerOwner(it.key)
+            }
+            updateState {
+                OwnerSelectionState(ViewAction.CloseScreen)
             }
         }
     }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/safe/SafeSettingsEditNameViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/safe/SafeSettingsEditNameViewModel.kt
@@ -1,6 +1,7 @@
 package io.gnosis.safe.ui.settings.safe
 
 import io.gnosis.data.repositories.SafeRepository
+import io.gnosis.safe.notifications.NotificationManager
 import io.gnosis.safe.ui.base.AppDispatchers
 import io.gnosis.safe.ui.base.BaseStateViewModel
 import kotlinx.coroutines.flow.collect
@@ -9,6 +10,7 @@ import javax.inject.Inject
 class SafeSettingsEditNameViewModel
 @Inject constructor(
     private val safeRepository: SafeRepository,
+    private val notificationManager: NotificationManager,
     appDispatchers: AppDispatchers
 ) : BaseStateViewModel<EditNameState>(appDispatchers) {
 
@@ -29,6 +31,7 @@ class SafeSettingsEditNameViewModel
                 val safeUpdate = it.copy(localName = name)
                 safeRepository.saveSafe(safeUpdate)
                 safeRepository.setActiveSafe(safeUpdate)
+                notificationManager.updateNotificationChannelGroupForSafe(safeUpdate)
                 updateState { EditNameState(safeUpdate.localName, ViewAction.CloseScreen) }
             }
         }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/safe/SafeSettingsViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/safe/SafeSettingsViewModel.kt
@@ -6,6 +6,7 @@ import io.gnosis.data.models.SafeInfo
 import io.gnosis.data.repositories.EnsRepository
 import io.gnosis.data.repositories.SafeRepository
 import io.gnosis.safe.Tracker
+import io.gnosis.safe.notifications.NotificationManager
 import io.gnosis.safe.notifications.NotificationRepository
 import io.gnosis.safe.ui.base.AppDispatchers
 import io.gnosis.safe.ui.base.BaseStateViewModel
@@ -18,6 +19,7 @@ class SafeSettingsViewModel @Inject constructor(
     private val safeRepository: SafeRepository,
     private val ensRepository: EnsRepository,
     private val notificationRepository: NotificationRepository,
+    private val notificationManager: NotificationManager,
     private val tracker: Tracker,
     appDispatchers: AppDispatchers
 ) : BaseStateViewModel<SafeSettingsState>(appDispatchers) {
@@ -80,6 +82,7 @@ class SafeSettingsViewModel @Inject constructor(
                     updateState { SafeSettingsState(safe, null, null, SafeRemoved) }
                     tracker.setNumSafes(safeRepository.getSafeCount())
                     notificationRepository.unregisterSafe(safe.address)
+                    notificationManager.deleteNotificationChannelGroup(safe)
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -334,6 +334,11 @@
 
     <string name="channel_tx_notifications_name">Tx Notifications</string>
     <string name="channel_tx_notifications_description">Notifications about incoming transfers and processed transactions.</string>
+    <string name="channel_tx_confirmation_request">Confirmation Requests</string>
+    <string name="channel_tx_executed_transactions">Executed Transactions</string>
+    <string name="channel_tx_incoming_tokens">Incoming Tokens</string>
+    <string name="channel_tx_incoming_ether">Incoming Ether</string>
+
     <string name="enter_seed_phrase_description">Enter the seed phrase from your hardware wallet or MetaMask or the private key from any wallet.\n\nA seed phrase is typically 12 (sometimes 24) words separated by single spaces.\nA private key is a string of 64 characters.</string>
     <string name="enter_seed_phrase_hint">Enter private key or seed phrase</string>
     <string name="enter_seed_phrase_error">Seed phrase is not valid</string>

--- a/app/src/test/java/io/gnosis/safe/ui/safe/add/AddSafeNameViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/safe/add/AddSafeNameViewModelTest.kt
@@ -5,6 +5,7 @@ import io.gnosis.data.repositories.SafeRepository
 import io.gnosis.safe.TestLifecycleRule
 import io.gnosis.safe.Tracker
 import io.gnosis.safe.appDispatchers
+import io.gnosis.safe.notifications.NotificationManager
 import io.gnosis.safe.notifications.NotificationRepository
 import io.gnosis.safe.test
 import io.gnosis.safe.ui.base.BaseStateViewModel
@@ -20,7 +21,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import pm.gnosis.utils.asEthereumAddress
-import java.lang.IllegalStateException
 
 class AddSafeNameViewModelTest {
 
@@ -29,6 +29,9 @@ class AddSafeNameViewModelTest {
 
     private val tracker: Tracker = mockk()
     private val notificationRepository = mockk<NotificationRepository>()
+    private val notificationManager = mockk<NotificationManager>().apply {
+        coEvery { createNotificationChannelGroup(any()) } just Runs
+    }
     private val safeRepository = mockk<SafeRepository>()
     private val ownerCredentialsRepository = mockk<OwnerCredentialsRepository>()
     private val settingsHandler = mockk<SettingsHandler>()
@@ -37,7 +40,15 @@ class AddSafeNameViewModelTest {
 
     @Before
     fun setup() {
-        viewModel = AddSafeNameViewModel(safeRepository, notificationRepository, ownerCredentialsRepository, settingsHandler, appDispatchers, tracker)
+        viewModel = AddSafeNameViewModel(
+            safeRepository,
+            notificationRepository,
+            ownerCredentialsRepository,
+            settingsHandler,
+            notificationManager,
+            appDispatchers,
+            tracker
+        )
         Dispatchers.setMain(TestCoroutineDispatcher())
     }
 
@@ -115,7 +126,8 @@ class AddSafeNameViewModelTest {
             )
         coVerifySequence {
             safeRepository.saveSafe(Safe(VALID_SAFE_ADDRESS, "Name"))
-            notificationRepository.registerSafe(VALID_SAFE_ADDRESS)
+            notificationRepository.registerSafe(Safe(VALID_SAFE_ADDRESS, "Name"))
+            notificationManager.createNotificationChannelGroup(Safe(VALID_SAFE_ADDRESS, "Name"))
             safeRepository.setActiveSafe(Safe(VALID_SAFE_ADDRESS, "Name"))
             safeRepository.getSafeCount()
             tracker.setNumSafes(0)
@@ -141,7 +153,8 @@ class AddSafeNameViewModelTest {
             )
         coVerifySequence {
             safeRepository.saveSafe(Safe(VALID_SAFE_ADDRESS, "Name"))
-            notificationRepository.registerSafe(VALID_SAFE_ADDRESS)
+            notificationRepository.registerSafe(Safe(VALID_SAFE_ADDRESS, "Name"))
+            notificationManager.createNotificationChannelGroup(Safe(VALID_SAFE_ADDRESS, "Name"))
             safeRepository.setActiveSafe(Safe(VALID_SAFE_ADDRESS, "Name"))
             safeRepository.getSafeCount()
             tracker.setNumSafes(0)
@@ -167,7 +180,8 @@ class AddSafeNameViewModelTest {
             )
         coVerifySequence {
             safeRepository.saveSafe(Safe(VALID_SAFE_ADDRESS, "Name"))
-            notificationRepository.registerSafe(VALID_SAFE_ADDRESS)
+            notificationRepository.registerSafe(Safe(VALID_SAFE_ADDRESS, "Name"))
+            notificationManager.createNotificationChannelGroup(Safe(VALID_SAFE_ADDRESS, "Name"))
             safeRepository.setActiveSafe(Safe(VALID_SAFE_ADDRESS, "Name"))
             safeRepository.getSafeCount()
             tracker.setNumSafes(0)

--- a/app/src/test/java/io/gnosis/safe/ui/settings/SafeSettingsViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/settings/SafeSettingsViewModelTest.kt
@@ -5,6 +5,7 @@ import io.gnosis.data.models.SafeInfo
 import io.gnosis.data.repositories.EnsRepository
 import io.gnosis.data.repositories.SafeRepository
 import io.gnosis.safe.*
+import io.gnosis.safe.notifications.NotificationManager
 import io.gnosis.safe.notifications.NotificationRepository
 import io.gnosis.safe.ui.base.BaseStateViewModel
 import io.gnosis.safe.ui.settings.safe.SafeRemoved
@@ -17,6 +18,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import pm.gnosis.model.Solidity
@@ -33,6 +35,9 @@ class SafeSettingsViewModelTest {
 
     private val safeRepository = mockk<SafeRepository>()
     private val notificationRepository = mockk<NotificationRepository>()
+    private val notificationManager = mockk<NotificationManager>().apply {
+        coEvery { deleteNotificationChannelGroup(any()) } just Runs
+    }
     private val tracker = mockk<Tracker>()
     private val ensRepository = mockk<EnsRepository>().apply {
         coEvery { reverseResolve(any()) } returns null
@@ -45,7 +50,8 @@ class SafeSettingsViewModelTest {
         coEvery { safeRepository.activeSafeFlow() } returns emptyFlow()
         val testObserver = TestLiveDataObserver<SafeSettingsState>()
 
-        safeSettingsViewModel = SafeSettingsViewModel(safeRepository, ensRepository, notificationRepository, tracker, appDispatchers)
+        safeSettingsViewModel =
+            SafeSettingsViewModel(safeRepository, ensRepository, notificationRepository, notificationManager, tracker, appDispatchers)
         safeSettingsViewModel.state.observeForever(testObserver)
 
         testObserver.assertValueCount(1)
@@ -71,7 +77,8 @@ class SafeSettingsViewModelTest {
         coEvery { ensRepository.reverseResolve(any()) } returnsMany listOf(ensName1, ensName2)
         val testObserver = TestLiveDataObserver<SafeSettingsState>()
 
-        safeSettingsViewModel = SafeSettingsViewModel(safeRepository, ensRepository, notificationRepository, tracker, appDispatchers)
+        safeSettingsViewModel =
+            SafeSettingsViewModel(safeRepository, ensRepository, notificationRepository, notificationManager, tracker, appDispatchers)
         safeSettingsViewModel.state.observeForever(testObserver)
 
         testObserver.assertValueCount(1)
@@ -95,7 +102,8 @@ class SafeSettingsViewModelTest {
         coEvery { safeRepository.activeSafeFlow() } returns emptyFlow()
         coEvery { safeRepository.getActiveSafe() } returns null
         val testObserver = TestLiveDataObserver<SafeSettingsState>()
-        safeSettingsViewModel = SafeSettingsViewModel(safeRepository, ensRepository, notificationRepository, tracker, appDispatchers)
+        safeSettingsViewModel =
+            SafeSettingsViewModel(safeRepository, ensRepository, notificationRepository, notificationManager, tracker, appDispatchers)
 
         safeSettingsViewModel.reload()
         safeSettingsViewModel.state.observeForever(testObserver)
@@ -125,7 +133,8 @@ class SafeSettingsViewModelTest {
         coEvery { safeRepository.activeSafeFlow() } returns emptyFlow()
         coEvery { ensRepository.reverseResolve(any()) } returns ensName
         val testObserver = TestLiveDataObserver<SafeSettingsState>()
-        safeSettingsViewModel = SafeSettingsViewModel(safeRepository, ensRepository, notificationRepository, tracker, appDispatchers)
+        safeSettingsViewModel =
+            SafeSettingsViewModel(safeRepository, ensRepository, notificationRepository, notificationManager, tracker, appDispatchers)
 
         safeSettingsViewModel.reload()
         safeSettingsViewModel.state.observeForever(testObserver)
@@ -156,7 +165,8 @@ class SafeSettingsViewModelTest {
         coEvery { ensRepository.reverseResolve(any()) } throws throwable
         mockkStatic(Timber::class)
         val testObserver = TestLiveDataObserver<SafeSettingsState>()
-        safeSettingsViewModel = SafeSettingsViewModel(safeRepository, ensRepository, notificationRepository, tracker, appDispatchers)
+        safeSettingsViewModel =
+            SafeSettingsViewModel(safeRepository, ensRepository, notificationRepository, notificationManager, tracker, appDispatchers)
 
         safeSettingsViewModel.reload()
         safeSettingsViewModel.state.observeForever(testObserver)
@@ -185,7 +195,8 @@ class SafeSettingsViewModelTest {
         coEvery { safeRepository.getSafeInfo(any()) } throws throwable
         coEvery { safeRepository.activeSafeFlow() } returns emptyFlow()
         val testObserver = TestLiveDataObserver<SafeSettingsState>()
-        safeSettingsViewModel = SafeSettingsViewModel(safeRepository, ensRepository, notificationRepository, tracker, appDispatchers)
+        safeSettingsViewModel =
+            SafeSettingsViewModel(safeRepository, ensRepository, notificationRepository, notificationManager, tracker, appDispatchers)
 
         safeSettingsViewModel.reload()
         safeSettingsViewModel.state.observeForever(testObserver)
@@ -220,7 +231,8 @@ class SafeSettingsViewModelTest {
         coEvery { notificationRepository.unregisterSafe(any()) } just Runs
         coEvery { tracker.setNumSafes(any()) } just Runs
 
-        safeSettingsViewModel = SafeSettingsViewModel(safeRepository, ensRepository, notificationRepository, tracker, appDispatchers)
+        safeSettingsViewModel =
+            SafeSettingsViewModel(safeRepository, ensRepository, notificationRepository, notificationManager, tracker, appDispatchers)
         val stateObserver = TestLiveDataObserver<BaseStateViewModel.State>()
         safeSettingsViewModel.state.observeForever(stateObserver)
 
@@ -231,7 +243,9 @@ class SafeSettingsViewModelTest {
         }
 
         with(stateObserver.values()[1] as SafeSettingsState) {
-            assert(safe == SAFE_1 && viewAction is SafeRemoved)
+            assertEquals(safe, SAFE_1)
+            println("viewAction: $viewAction")
+            assertTrue(viewAction is SafeRemoved)
         }
 
         coVerifySequence {
@@ -271,7 +285,8 @@ class SafeSettingsViewModelTest {
         coEvery { notificationRepository.unregisterSafe(any()) } just Runs
         coEvery { tracker.setNumSafes(any()) } just Runs
 
-        safeSettingsViewModel = SafeSettingsViewModel(safeRepository, ensRepository, notificationRepository, tracker, appDispatchers)
+        safeSettingsViewModel =
+            SafeSettingsViewModel(safeRepository, ensRepository, notificationRepository, notificationManager, tracker, appDispatchers)
         val stateObserver = TestLiveDataObserver<BaseStateViewModel.State>()
         safeSettingsViewModel.state.observeForever(stateObserver)
 

--- a/app/src/test/java/io/gnosis/safe/ui/settings/safe/SafeSettingsEditNameViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/settings/safe/SafeSettingsEditNameViewModelTest.kt
@@ -6,8 +6,12 @@ import io.gnosis.safe.MainCoroutineScopeRule
 import io.gnosis.safe.TestLifecycleRule
 import io.gnosis.safe.TestLiveDataObserver
 import io.gnosis.safe.appDispatchers
+import io.gnosis.safe.notifications.NotificationManager
 import io.gnosis.safe.ui.base.BaseStateViewModel
-import io.mockk.*
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.just
+import io.mockk.mockk
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Rule
@@ -24,6 +28,7 @@ class SafeSettingsEditNameViewModelTest {
     val instantExecutorRule = TestLifecycleRule()
 
     private val safeRepository = mockk<SafeRepository>(relaxed = true)
+    private val notificationManager = mockk<NotificationManager>(relaxed = true)
     private lateinit var viewModel: SafeSettingsEditNameViewModel
 
     @Test
@@ -41,7 +46,7 @@ class SafeSettingsEditNameViewModelTest {
         coEvery { safeRepository.saveSafe(any()) } just Runs
 
         val stateObserver = TestLiveDataObserver<BaseStateViewModel.State>()
-        viewModel = SafeSettingsEditNameViewModel(safeRepository, appDispatchers)
+        viewModel = SafeSettingsEditNameViewModel(safeRepository, notificationManager, appDispatchers)
         viewModel.state.observeForever(stateObserver)
 
         with(stateObserver.values()[0] as EditNameState) {
@@ -71,7 +76,7 @@ class SafeSettingsEditNameViewModelTest {
         coEvery { safeRepository.saveSafe(any()) } throws throwable
 
         val stateObserver = TestLiveDataObserver<BaseStateViewModel.State>()
-        viewModel = SafeSettingsEditNameViewModel(safeRepository, appDispatchers)
+        viewModel = SafeSettingsEditNameViewModel(safeRepository, notificationManager, appDispatchers)
         viewModel.state.observeForever(stateObserver)
 
         with(stateObserver.values()[0] as EditNameState) {


### PR DESCRIPTION
Changes proposed in this pull request:
- Add Notification Channel Group per added safe
- Update Group when local safe name is changed
- Delete Notification Channel Group when a safe is removed from the app
- On app startup: Create Notification Channel Group per existing safe (this can be removed in a future update)

Home -> Safe Multisig -> App Info -> Notifications: 
![Screenshot_20210219-234453](https://user-images.githubusercontent.com/246473/108569667-931ec080-730c-11eb-9ba6-2febe897ab9b.png)


@gnosis/mobile-devs
