### PR TITLE
Don't show nonceItem and nonceSeparator if nonce is blank

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/AdvancedTransactionDetailsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/AdvancedTransactionDetailsFragment.kt
@@ -39,11 +39,11 @@ class AdvancedTransactionDetailsFragment : BaseViewBindingFragment<FragmentTrans
             backButton.setOnClickListener {
                 Navigation.findNavController(it).navigateUp()
             }
-            if (nonce.isNotEmpty()) {
-                nonceItem.value = nonce
-            } else {
+            if (nonce.isBlank()) {
                 nonceItem.visible(false)
                 nonceSeparator.visible(false)
+            } else {
+                nonceItem.value = nonce
             }
             operationItem.value = operation
             if (hash.isNullOrBlank()) {

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/AdvancedTransactionDetailsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/AdvancedTransactionDetailsFragment.kt
@@ -39,7 +39,12 @@ class AdvancedTransactionDetailsFragment : BaseViewBindingFragment<FragmentTrans
             backButton.setOnClickListener {
                 Navigation.findNavController(it).navigateUp()
             }
-            nonceItem.value = nonce
+            if (nonce.isNotEmpty()) {
+                nonceItem.value = nonce
+            } else {
+                nonceItem.visible(false)
+                nonceSeparator.visible(false)
+            }
             operationItem.value = operation
             if (hash.isNullOrBlank()) {
                 hashItem.visible(false)


### PR DESCRIPTION


Handles #1222

Changes proposed in this pull request:
- Don't show nonceItem and nonceSeparator if nonce is blank

Before | After
-------|------
![Screenshot_20210309-113208](https://user-images.githubusercontent.com/246473/110457656-299fff80-80cb-11eb-9fe5-141c5d4329fa.png) |![Screenshot_20210309-112534](https://user-images.githubusercontent.com/246473/110457344-d463ee00-80ca-11eb-98c5-57f3a5d30092.png)


@gnosis/mobile-devs
