### PR TITLE
Use toInfo in recipient address. Ignore safeAppInfo for recipient

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/view/TxStatusView.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/view/TxStatusView.kt
@@ -21,7 +21,6 @@ class TxStatusView @JvmOverloads constructor(
 
     private val binding by lazy { ViewTxStatusBinding.inflate(LayoutInflater.from(context), this) }
 
-
     fun setStatus(
         title: String,
         iconUrl: String? = null,
@@ -56,14 +55,12 @@ class TxStatusView @JvmOverloads constructor(
         }
     }
 
-
     fun setStatus(
         @StringRes titleRes: Int,
         @DrawableRes iconRes: Int,
         @StringRes statusTextRes: Int,
         @ColorRes statusColorRes: Int
     ) {
-
         val resources = context.resources
         setStatus(title = resources.getString(titleRes), defaultIconRes = iconRes, statusTextRes = statusTextRes, statusColorRes = statusColorRes)
     }

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/viewdata/TransactionDetailsViewData.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/viewdata/TransactionDetailsViewData.kt
@@ -117,11 +117,11 @@ fun TransactionDetails.toTransactionDetailsViewData(safes: List<Safe>): Transact
 internal fun TransactionInfo.toTransactionInfoViewData(safes: List<Safe>, safeAppInfo: SafeAppInfo? = null): TransactionInfoViewData =
     when (this) {
         is TransactionInfo.Custom -> {
-            val addressUri = when (val toInfo = toInfo.toAddressInfoData(to, safes, safeAppInfo)) {
+            val addressUri = when (val toInfo = toInfo.toAddressInfoData(to, safes, null)) {
                 is AddressInfoData.Remote -> toInfo.addressLogoUri
                 else -> null
             }
-            val addressName = when (val toInfo = toInfo.toAddressInfoData(to, safes, safeAppInfo)) {
+            val addressName = when (val toInfo = toInfo.toAddressInfoData(to, safes, null)) {
                 is AddressInfoData.Local -> toInfo.name
                 is AddressInfoData.Remote -> toInfo.name
                 else -> null

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/details/viewdata/TransactionDetailsViewDataTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/details/viewdata/TransactionDetailsViewDataTest.kt
@@ -220,10 +220,10 @@ class TransactionDetailsViewDataTest {
         assertEquals(
             TransactionInfoViewData.Custom(
                 to = anyAddress,
+                actionInfoAddressName = "Remote Name",
+                actionInfoAddressUri = null,
                 statusTitle = "app name",
                 statusIconUri = "http://www.de/image.png",
-                actionInfoAddressName = "app name",
-                actionInfoAddressUri = "http://www.de/image.png",
                 safeApp = true,
                 value = BigInteger.ZERO,
                 dataSize = 1    ,


### PR DESCRIPTION
Handles #1298 

Changes proposed in this pull request:
- Ignore safeAppInfo for reciepient display

Old | New
--- | ----
![image](https://user-images.githubusercontent.com/246473/110804476-7e38ab80-8280-11eb-8c3f-845ae7a63c93.png)| ![image](https://user-images.githubusercontent.com/246473/110804288-547f8480-8280-11eb-9aeb-bad080581964.png)


@gnosis/mobile-devs
