### PR TITLE
Fiat codes are no longer sorted in the client side

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/SettingsHandler.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/SettingsHandler.kt
@@ -85,7 +85,7 @@ class SettingsHandler @Inject constructor(
             }
         }
 
-    suspend fun loadSupportedFiatCodes(): List<String> = gatewayApi.loadSupportedCurrencies().sorted()
+    suspend fun loadSupportedFiatCodes(): List<String> = gatewayApi.loadSupportedCurrencies()
 
     companion object {
         internal const val KEY_NIGHT_MODE = "prefs.string.appearance.night_mode"

--- a/app/src/test/java/io/gnosis/safe/ui/settings/app/SettingsHandlerTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/settings/app/SettingsHandlerTest.kt
@@ -161,10 +161,9 @@ class SettingsHandlerTest {
         val settingsHandler = SettingsHandler(gatewayApi, preferencesManager)
 
         val actual = runCatching { settingsHandler.loadSupportedFiatCodes() }
-        val expected = supportedFiats
 
         coVerify(exactly = 1) { gatewayApi.loadSupportedCurrencies() }
-        Assert.assertEquals(expected, actual.getOrNull())
+        Assert.assertEquals(supportedFiats, actual.getOrNull())
     }
 
     @Test

--- a/app/src/test/java/io/gnosis/safe/ui/settings/app/SettingsHandlerTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/settings/app/SettingsHandlerTest.kt
@@ -155,13 +155,13 @@ class SettingsHandlerTest {
     }
 
     @Test
-    fun `loadSupportedFiatCodes - successful`() = runBlocking {
+    fun `loadSupportedFiatCodes - backend sorting is used - successful`() = runBlocking {
         val supportedFiats = listOf("USD", "EUR", "CAD")
         coEvery { gatewayApi.loadSupportedCurrencies() } returns supportedFiats
         val settingsHandler = SettingsHandler(gatewayApi, preferencesManager)
 
         val actual = runCatching { settingsHandler.loadSupportedFiatCodes() }
-        val expected = supportedFiats.sorted()
+        val expected = supportedFiats
 
         coVerify(exactly = 1) { gatewayApi.loadSupportedCurrencies() }
         Assert.assertEquals(expected, actual.getOrNull())

--- a/buildsystem/coverage_report.gradle
+++ b/buildsystem/coverage_report.gradle
@@ -52,6 +52,7 @@ def setupAndroidReporting() {
     tasks.withType(Test) {
         // Whether or not classes without source location should be instrumented
         jacoco.includeNoLocationClasses true
+        jacoco.excludes = ['jdk.internal.*'] // https://github.com/gradle/gradle/issues/5184#issuecomment-457865951
     }
 
     task jacocoTestReport(


### PR DESCRIPTION
Handles #1333 

Changes proposed in this pull request:
- Removed `sorted` to returned list from backend fiat codes
- Added ignore pattern for jacoco for those using versions of java > 1.9

@gnosis/mobile-devs
