### PR TITLE
Hide keyboard only on confirmation

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/ChangePasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/ChangePasscodeFragment.kt
@@ -99,9 +99,13 @@ class ChangePasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>(
                     confirmColor = R.color.error
                 ) {
                     viewModel.removeOwner()
-                    input.hideSoftKeyboard()
                 }
             }
         }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        binding.input.hideSoftKeyboard()
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/ChangePasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/ChangePasscodeFragment.kt
@@ -90,7 +90,6 @@ class ChangePasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>(
 
             actionButton.setText(R.string.settings_passcode_forgot_your_passcode)
             actionButton.setOnClickListener {
-                input.hideSoftKeyboard()
                 binding.errorMessage.visibility = View.INVISIBLE
 
                 showConfirmDialog(
@@ -100,6 +99,7 @@ class ChangePasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>(
                     confirmColor = R.color.error
                 ) {
                     viewModel.removeOwner()
+                    input.hideSoftKeyboard()
                 }
             }
         }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/DisablePasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/DisablePasscodeFragment.kt
@@ -98,10 +98,14 @@ class DisablePasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>
                     confirmColor = R.color.error
                 ) {
                     viewModel.onForgotPasscode()
-                    input.hideSoftKeyboard()
                 }
             }
         }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        binding.input.hideSoftKeyboard()
     }
 }
 

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/DisablePasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/DisablePasscodeFragment.kt
@@ -89,7 +89,6 @@ class DisablePasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>
 
             actionButton.setText(R.string.settings_passcode_forgot_your_passcode)
             actionButton.setOnClickListener {
-                input.hideSoftKeyboard()
                 binding.errorMessage.visibility = View.INVISIBLE
 
                 showConfirmDialog(
@@ -99,6 +98,7 @@ class DisablePasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>
                     confirmColor = R.color.error
                 ) {
                     viewModel.onForgotPasscode()
+                    input.hideSoftKeyboard()
                 }
             }
         }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
@@ -88,7 +88,6 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
             errorMessage.setText(R.string.settings_passcode_wrong_passcode)
             actionButton.setText(R.string.settings_passcode_forgot_your_passcode)
             actionButton.setOnClickListener {
-                input.hideSoftKeyboard()
                 binding.errorMessage.visibility = View.INVISIBLE
 
                 showConfirmDialog(
@@ -98,6 +97,7 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
                     confirmColor = R.color.error
                 ) {
                     viewModel.onForgotPasscode()
+                    input.hideSoftKeyboard()
                 }
             }
         }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
@@ -97,9 +97,13 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
                     confirmColor = R.color.error
                 ) {
                     viewModel.onForgotPasscode()
-                    input.hideSoftKeyboard()
                 }
             }
         }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        binding.input.hideSoftKeyboard()
     }
 }


### PR DESCRIPTION
Handles #1349 

Changes proposed in this pull request:
- Hide keyboard only when dialog is confirmed
-
-

@gnosis/mobile-devs
