### PR TITLE
Confirm button should not be on confirmed tx

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/ButtonStateHelper.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/ButtonStateHelper.kt
@@ -36,6 +36,9 @@ class ButtonStateHelper(
             !isRejection && !hasBeenRejected && !needsExecution -> {
                 true
             }
+            needsExecution && !canReject && !needsYourConfirmation-> {
+                false
+            }
             !isRejection && !needsYourConfirmation && hasBeenRejected && needsExecution -> {
                 true
             }

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsViewModel.kt
@@ -81,18 +81,16 @@ class TransactionDetailsViewModel
                 }
 
 
-    //TODO: remove when backend provides info about rejections
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     suspend fun canBeRejectedFromDevice(
         executionInfo: DetailedExecutionInfo.MultisigExecutionDetails,
         status: TransactionStatus,
         owners: List<Owner>
-    ): Boolean =
-        !status.isCompleted() &&
-                owners.isNotEmpty() &&
-                owners[0].let { credentials ->
-                    executionInfo.signers.contains(credentials.address)
-                }
+    ): Boolean = !status.isCompleted() &&
+            owners.isNotEmpty() &&
+            owners.any { credentials ->
+                !executionInfo.rejectors.contains(credentials.address)
+            }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     suspend fun isOwner(
@@ -250,7 +248,7 @@ data class ConfirmationSubmitted(
     var safeOwner: Boolean
 ) : BaseStateViewModel.ViewAction
 
-object ConfirmConfirmation: BaseStateViewModel.ViewAction
+object ConfirmConfirmation : BaseStateViewModel.ViewAction
 
 class TxConfirmationFailed(override val cause: Throwable) : Throwable(cause)
 class TxRejectionFailed(override val cause: Throwable) : Throwable(cause)

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/details/ButtonStateHelperTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/details/ButtonStateHelperTest.kt
@@ -279,4 +279,26 @@ class ButtonStateHelperTest {
         assertFalse(buttonStateHelper.confirmButtonIsEnabled())
         assertFalse(buttonStateHelper.buttonContainerIsVisible())
     }
+
+    @Test
+    fun `(issue #1346) when (needsExecution & !canReject & !needsYourConfirmation) should hide both buttons`() {
+        val buttonStateHelper =
+            ButtonStateHelper(
+                isRejection = false,
+                needsYourConfirmation = false,
+                hasBeenRejected = true,
+                needsExecution = true,
+                canReject = false,
+                isOwner = true,
+                completed = false
+            )
+
+        assertFalse(buttonStateHelper.confirmButtonIsVisible())
+        assertFalse(buttonStateHelper.buttonContainerIsVisible())
+        assertFalse(buttonStateHelper.rejectButtonIsVisible())
+        assertFalse(buttonStateHelper.rejectButtonIsEnabled())
+        assertFalse(buttonStateHelper.spacerIsVisible())
+        assertFalse(buttonStateHelper.confirmButtonIsEnabled())
+    }
+
 }


### PR DESCRIPTION
Handles #1346 

Changes proposed in this pull request:
- Uses rejectors now to determine whteher rejection is possible
- Hides confirmation button if tx has been confirmed by current owner

@gnosis/mobile-devs
