### PR TITLE
Go back to tx details when resetting passcode

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
@@ -52,7 +52,7 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
             when (val viewAction = it.viewAction) {
                 is PasscodeViewModel.AllOwnersRemoved -> {
                     snackbar(requireView(), R.string.passcode_disabled)
-                    findNavController().navigateUp()
+                    findNavController().popBackStack(R.id.signingOwnerSelectionFragment, true)
                 }
                 is BaseStateViewModel.ViewAction.ShowError -> {
                     binding.errorMessage.setText(R.string.settings_passcode_owner_removal_failed)

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
@@ -52,7 +52,7 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
             when (val viewAction = it.viewAction) {
                 is PasscodeViewModel.AllOwnersRemoved -> {
                     snackbar(requireView(), R.string.passcode_disabled)
-                    findNavController().popBackStack(R.id.signingOwnerSelectionFragment, true)
+                    findNavController().popBackStack(R.id.transactionDetailsFragment, false)
                 }
                 is BaseStateViewModel.ViewAction.ShowError -> {
                     binding.errorMessage.setText(R.string.settings_passcode_owner_removal_failed)


### PR DESCRIPTION
Handles #1388, #1350

Changes proposed in this pull request:
- Fix navigation for passcode reset in confirmation
-
-

@gnosis/mobile-devs
