### PR TITLE
Don't crash in initializer

### DIFF
--- a/app/src/main/java/io/gnosis/safe/di/modules/RepositoryModule.kt
+++ b/app/src/main/java/io/gnosis/safe/di/modules/RepositoryModule.kt
@@ -3,6 +3,9 @@ package io.gnosis.safe.di.modules
 import com.unstoppabledomains.config.network.model.Network
 import com.unstoppabledomains.resolution.DomainResolution
 import com.unstoppabledomains.resolution.Resolution
+import com.unstoppabledomains.resolution.TickerVersion
+import com.unstoppabledomains.resolution.dns.DnsRecord
+import com.unstoppabledomains.resolution.dns.DnsRecordsType
 import com.unstoppabledomains.resolution.naming.service.NamingServiceType
 import dagger.Module
 import dagger.Provides
@@ -10,12 +13,11 @@ import io.gnosis.data.BuildConfig
 import io.gnosis.data.backend.GatewayApi
 import io.gnosis.data.db.daos.SafeDao
 import io.gnosis.data.repositories.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import pm.gnosis.ethereum.EthereumRepository
 import pm.gnosis.ethereum.rpc.EthereumRpcConnector
 import pm.gnosis.ethereum.rpc.RpcEthereumRepository
 import pm.gnosis.svalinn.common.PreferencesManager
+import timber.log.Timber
 import javax.inject.Singleton
 
 @Module
@@ -51,20 +53,86 @@ class RepositoryModule {
     @Provides
     @Singleton
     fun providesDomainResolutionLibrary(): DomainResolution {
-        val firstWord = BuildConfig.BLOCKCHAIN_NET_URL.removePrefix("https://").split(".").first();
-        val network = Network.valueOf(firstWord.toUpperCase());
-        return Resolution.builder()
+        val firstWord = BuildConfig.BLOCKCHAIN_NET_URL.removePrefix("https://").split(".").first()
+        val network = Network.valueOf(firstWord.toUpperCase())
+        return try {
+            Resolution.builder()
                 .chainId(NamingServiceType.CNS, network)
                 .infura(NamingServiceType.CNS, BuildConfig.INFURA_API_KEY)
                 .build()
+        } catch (throwable: Throwable) {
+            Timber.e(throwable, "Error initializing UnstoppableDomains")
+            object : DomainResolution {
+                override fun getOwner(domain: String?): String {
+                    TODO("Not yet implemented")
+                }
+
+                override fun email(domain: String?): String {
+                    TODO("Not yet implemented")
+                }
+
+                override fun getEmail(domain: String?): String {
+                    TODO("Not yet implemented")
+                }
+
+                override fun namehash(domain: String?): String {
+                    TODO("Not yet implemented")
+                }
+
+                override fun owner(domain: String?): String {
+                    TODO("Not yet implemented")
+                }
+
+                override fun addr(domain: String?, ticker: String?): String {
+                    TODO("Not yet implemented")
+                }
+
+                override fun getNetwork(type: NamingServiceType?): Network {
+                    TODO("Not yet implemented")
+                }
+
+                override fun ipfsHash(domain: String?): String {
+                    TODO("Not yet implemented")
+                }
+
+                override fun getMultiChainAddress(domain: String?, ticker: String?, chain: String?): String {
+                    TODO("Not yet implemented")
+                }
+
+                override fun isSupported(domain: String?): Boolean {
+                    TODO("Not yet implemented")
+                }
+
+                override fun getDns(domain: String?, types: MutableList<DnsRecordsType>?): MutableList<DnsRecord> {
+                    TODO("Not yet implemented")
+                }
+
+                override fun getAddress(domain: String?, ticker: String?): String {
+                    TODO("Not yet implemented")
+                }
+
+                override fun getIpfsHash(domain: String?): String {
+                    TODO("Not yet implemented")
+                }
+
+                override fun getUsdt(domain: String?, version: TickerVersion?): String {
+                    TODO("Not yet implemented")
+                }
+
+                override fun getNamehash(domain: String?): String {
+                    TODO("Not yet implemented")
+                }
+
+            }
+        }
     }
 
     @Provides
     @Singleton
     fun providesUnstoppableRepository(
-            domainResolutionLibrary: DomainResolution
+        domainResolutionLibrary: DomainResolution
     ): UnstoppableDomainsRepository =
-            UnstoppableDomainsRepository(domainResolutionLibrary)
+        UnstoppableDomainsRepository(domainResolutionLibrary)
 
     @Provides
     @Singleton

--- a/app/src/main/java/io/gnosis/safe/di/modules/RepositoryModule.kt
+++ b/app/src/main/java/io/gnosis/safe/di/modules/RepositoryModule.kt
@@ -3,9 +3,6 @@ package io.gnosis.safe.di.modules
 import com.unstoppabledomains.config.network.model.Network
 import com.unstoppabledomains.resolution.DomainResolution
 import com.unstoppabledomains.resolution.Resolution
-import com.unstoppabledomains.resolution.TickerVersion
-import com.unstoppabledomains.resolution.dns.DnsRecord
-import com.unstoppabledomains.resolution.dns.DnsRecordsType
 import com.unstoppabledomains.resolution.naming.service.NamingServiceType
 import dagger.Module
 import dagger.Provides
@@ -62,68 +59,7 @@ class RepositoryModule {
                 .build()
         } catch (throwable: Throwable) {
             Timber.e(throwable, "Error initializing UnstoppableDomains")
-            object : DomainResolution {
-                override fun getOwner(domain: String?): String {
-                    TODO("Not yet implemented")
-                }
-
-                override fun email(domain: String?): String {
-                    TODO("Not yet implemented")
-                }
-
-                override fun getEmail(domain: String?): String {
-                    TODO("Not yet implemented")
-                }
-
-                override fun namehash(domain: String?): String {
-                    TODO("Not yet implemented")
-                }
-
-                override fun owner(domain: String?): String {
-                    TODO("Not yet implemented")
-                }
-
-                override fun addr(domain: String?, ticker: String?): String {
-                    TODO("Not yet implemented")
-                }
-
-                override fun getNetwork(type: NamingServiceType?): Network {
-                    TODO("Not yet implemented")
-                }
-
-                override fun ipfsHash(domain: String?): String {
-                    TODO("Not yet implemented")
-                }
-
-                override fun getMultiChainAddress(domain: String?, ticker: String?, chain: String?): String {
-                    TODO("Not yet implemented")
-                }
-
-                override fun isSupported(domain: String?): Boolean {
-                    TODO("Not yet implemented")
-                }
-
-                override fun getDns(domain: String?, types: MutableList<DnsRecordsType>?): MutableList<DnsRecord> {
-                    TODO("Not yet implemented")
-                }
-
-                override fun getAddress(domain: String?, ticker: String?): String {
-                    TODO("Not yet implemented")
-                }
-
-                override fun getIpfsHash(domain: String?): String {
-                    TODO("Not yet implemented")
-                }
-
-                override fun getUsdt(domain: String?, version: TickerVersion?): String {
-                    TODO("Not yet implemented")
-                }
-
-                override fun getNamehash(domain: String?): String {
-                    TODO("Not yet implemented")
-                }
-
-            }
+            DummyDomainResolution()
         }
     }
 

--- a/buildsystem/versions.gradle
+++ b/buildsystem/versions.gradle
@@ -49,7 +49,7 @@ ext {
             zxing                           : '3.3.1',
             play_core                       : '1.9.1',
             play_core_ktx                   : '1.8.1',
-            unstoppabledomains              : '1.13.0',
+            unstoppabledomains              : '1.13.1',
 
             // Test dependencies
             espresso                        : '3.1.1',

--- a/data/src/main/java/io/gnosis/data/repositories/DummyDomainResolution.kt
+++ b/data/src/main/java/io/gnosis/data/repositories/DummyDomainResolution.kt
@@ -6,7 +6,9 @@ import com.unstoppabledomains.resolution.TickerVersion
 import com.unstoppabledomains.resolution.dns.DnsRecord
 import com.unstoppabledomains.resolution.dns.DnsRecordsType
 import com.unstoppabledomains.resolution.naming.service.NamingServiceType
+import io.gnosis.data.utils.ExcludeClassFromJacocoGeneratedReport
 
+@ExcludeClassFromJacocoGeneratedReport
 class DummyDomainResolution :DomainResolution{
     override fun getOwner(domain: String?): String {
         TODO("Not yet implemented")

--- a/data/src/main/java/io/gnosis/data/repositories/DummyDomainResolution.kt
+++ b/data/src/main/java/io/gnosis/data/repositories/DummyDomainResolution.kt
@@ -1,0 +1,70 @@
+package io.gnosis.data.repositories
+
+import com.unstoppabledomains.config.network.model.Network
+import com.unstoppabledomains.resolution.DomainResolution
+import com.unstoppabledomains.resolution.TickerVersion
+import com.unstoppabledomains.resolution.dns.DnsRecord
+import com.unstoppabledomains.resolution.dns.DnsRecordsType
+import com.unstoppabledomains.resolution.naming.service.NamingServiceType
+
+class DummyDomainResolution :DomainResolution{
+    override fun getOwner(domain: String?): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun email(domain: String?): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun getEmail(domain: String?): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun namehash(domain: String?): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun owner(domain: String?): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun addr(domain: String?, ticker: String?): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun getNetwork(type: NamingServiceType?): Network {
+        TODO("Not yet implemented")
+    }
+
+    override fun ipfsHash(domain: String?): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun getMultiChainAddress(domain: String?, ticker: String?, chain: String?): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun isSupported(domain: String?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getDns(domain: String?, types: MutableList<DnsRecordsType>?): MutableList<DnsRecord> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAddress(domain: String?, ticker: String?): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun getIpfsHash(domain: String?): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun getUsdt(domain: String?, version: TickerVersion?): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun getNamehash(domain: String?): String {
+        TODO("Not yet implemented")
+    }
+}

--- a/data/src/main/java/io/gnosis/data/repositories/DummyDomainResolution.kt
+++ b/data/src/main/java/io/gnosis/data/repositories/DummyDomainResolution.kt
@@ -9,7 +9,7 @@ import com.unstoppabledomains.resolution.naming.service.NamingServiceType
 import io.gnosis.data.utils.ExcludeClassFromJacocoGeneratedReport
 
 @ExcludeClassFromJacocoGeneratedReport
-class DummyDomainResolution :DomainResolution{
+class DummyDomainResolution : DomainResolution {
     override fun getOwner(domain: String?): String {
         TODO("Not yet implemented")
     }
@@ -39,6 +39,10 @@ class DummyDomainResolution :DomainResolution{
     }
 
     override fun ipfsHash(domain: String?): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun getRecord(domain: String?, recordKey: String?): String {
         TODO("Not yet implemented")
     }
 

--- a/data/src/main/java/io/gnosis/data/repositories/UnstoppableDomainsRepository.kt
+++ b/data/src/main/java/io/gnosis/data/repositories/UnstoppableDomainsRepository.kt
@@ -7,7 +7,7 @@ import pm.gnosis.model.Solidity
 import pm.gnosis.utils.asEthereumAddress
 
 class UnstoppableDomainsRepository(
-        private val domainResolutionLibrary: DomainResolution
+    private val domainResolutionLibrary: DomainResolution
 ) {
 
     suspend fun resolve(domain: String): Solidity.Address {

--- a/data/src/main/java/io/gnosis/data/utils/ExcludeClassFromJacocoGeneratedReport.kt
+++ b/data/src/main/java/io/gnosis/data/utils/ExcludeClassFromJacocoGeneratedReport.kt
@@ -1,0 +1,6 @@
+package io.gnosis.data.utils
+
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+annotation class ExcludeClassFromJacocoGeneratedReport


### PR DESCRIPTION
Handles #1398

Changes proposed in this pull request:
- Capture exception in initializing unstoppable dependency
- This does not fix the bug itself but it prevents crashing
- Until the lib gets an update, we should probably remove the menu entry.

@gnosis/mobile-devs
