### PR TITLE
Fix title when asking for passcode for confirmation

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
@@ -74,6 +74,7 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
         })
 
         with(binding) {
+            title.setText(R.string.settings_passcode_enter_passcode)
             createPasscode.setText(R.string.settings_passcode_enter_your_current_passcode)
             helpText.visible(false)
 


### PR DESCRIPTION
Handles #1412 

Changes proposed in this pull request:
- Fix title when asking for passcode for confirmation or rejection

![image](https://user-images.githubusercontent.com/246473/116726735-f94a5280-a9e3-11eb-9190-a43eed404e5b.png)

@gnosis/mobile-devs
