### PR TITLE
Improve stability & prevent crashes on invalid version strings & ranges

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
@@ -59,6 +59,8 @@ class StartActivity : BaseActivity(), SafeOverviewNavigationHandler {
 
         if (!settingsHandler.updateDeprecated) {
             handleIntent(intent)
+        } else {
+            askToUpdate()
         }
     }
 

--- a/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
@@ -67,13 +67,14 @@ class StartActivity : BaseActivity(), SafeOverviewNavigationHandler {
         handleIntent(intent)
     }
 
-    // Workaround in order to change active safe when push notification for unselected safe is received
+
     private fun handleIntent(intent: Intent?) {
         intent?.let {
             val safeAddress = it.getStringExtra(EXTRA_SAFE)?.asEthereumAddress()
             val txId = it.getStringExtra(EXTRA_TX_ID)
 
             safeAddress?.let {
+                // Workaround in order to change active safe when push notification for unselected safe is received
                 lifecycleScope.launch {
                     val safe = safeRepository.getSafeBy(safeAddress)
                     safe?.let {

--- a/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
@@ -57,11 +57,7 @@ class StartActivity : BaseActivity(), SafeOverviewNavigationHandler {
         }
         setupNav()
 
-        if (!settingsHandler.updateDeprecated) {
-            handleIntent(intent)
-        } else {
-            askToUpdate()
-        }
+        handleIntent(intent)
     }
 
     override fun onNewIntent(intent: Intent?) {
@@ -102,7 +98,9 @@ class StartActivity : BaseActivity(), SafeOverviewNavigationHandler {
                     }
                 }
             } ?: run {
-                settingsHandler.appStartCount++
+                if (!settingsHandler.showUpdateInfo) {
+                    settingsHandler.appStartCount++
+                }
                 // do not start rate flow and update screen together
                 when {
                     settingsHandler.showUpdateInfo -> askToUpdate()

--- a/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
@@ -104,8 +104,8 @@ class StartActivity : BaseActivity(), SafeOverviewNavigationHandler {
                 // do not start rate flow and update screen together
                 when {
                     settingsHandler.showUpdateInfo -> askToUpdate()
-                    settingsHandler.appStartCount >= 3 -> startRateFlow()
                     settingsHandler.askForPasscodeSetupOnFirstLaunch -> setupPasscode()
+                    settingsHandler.appStartCount >= 3 -> startRateFlow()
                 }
             }
         }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/SettingsHandler.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/SettingsHandler.kt
@@ -54,15 +54,20 @@ class SettingsHandler @Inject constructor(
         get() = updateNewestVersion && !updateNewestVersionShown || updateDeprecatedSoon || updateDeprecated
 
     fun updateUpdateInfo() {
+        kotlin.runCatching {
+            val current = SemVer.parse(BuildConfig.VERSION_NAME)
+            val newest = SemVer.parse(remoteConfig.getString(KEY_FIREBASE_NEWEST_VERSION))
 
-        val current = SemVer.parse(BuildConfig.VERSION_NAME)
-        val newest = SemVer.parse(remoteConfig.getString(KEY_FIREBASE_NEWEST_VERSION))
-
-        updateNewestVersion = current < newest
-        updateDeprecatedSoon = current.isInside(remoteConfig.getString(KEY_FIREBASE_DEPRECATED_SOON))
-        updateDeprecated = current.isInside(remoteConfig.getString(KEY_FIREBASE_DEPRECATED))
+            updateNewestVersion = current < newest
+            updateDeprecatedSoon = current.isInside(remoteConfig.getString(KEY_FIREBASE_DEPRECATED_SOON))
+            updateDeprecated = current.isInside(remoteConfig.getString(KEY_FIREBASE_DEPRECATED))
+        }.onFailure {
+            // fail silently
+            updateNewestVersion = false
+            updateDeprecatedSoon = false
+            updateDeprecated = false
+        }
     }
-
 
     @NightMode
     var nightMode: Int

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/PasscodeViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/PasscodeViewModel.kt
@@ -99,6 +99,7 @@ class PasscodeViewModel
                 settingsHandler.showPasscodeBanner = false
                 settingsHandler.requireForConfirmations = true
                 settingsHandler.requireToOpen = true
+                settingsHandler.askForPasscodeSetupOnFirstLaunch = false
 
                 tracker.setPasscodeIsSet(true)
                 tracker.logPasscodeEnabled()

--- a/app/src/main/java/io/gnosis/safe/ui/updates/UpdatesFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/updates/UpdatesFragment.kt
@@ -100,6 +100,7 @@ class UpdatesFragment : BaseViewBindingFragment<FragmentUpdatesBinding>() {
                 Timber.d("Update flow failed! Result code: $resultCode")
             } else {
                 viewModel.updateUpdateInfo()
+                viewModel.resetAppStartCount()
                 findNavController().navigateUp()
             }
         }

--- a/app/src/main/java/io/gnosis/safe/ui/updates/UpdatesViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/updates/UpdatesViewModel.kt
@@ -16,4 +16,8 @@ class UpdatesViewModel
     fun updateUpdateInfo() {
         settingsHandler.updateUpdateInfo()
     }
+
+    fun resetAppStartCount() {
+        settingsHandler.appStartCount = 0
+    }
 }

--- a/app/src/main/java/io/gnosis/safe/utils/SemVer.kt
+++ b/app/src/main/java/io/gnosis/safe/utils/SemVer.kt
@@ -67,7 +67,7 @@ data class SemVer(
 
         fun parse(version: String): SemVer {
             val pattern = Regex(REGEX_SEM_VER)
-            val result = pattern.matchEntire(version) ?: throw IllegalArgumentException("Invalid version string [$version]")
+            val result = pattern.matchEntire(version.trim()) ?: throw IllegalArgumentException("Invalid version string [$version]")
             return SemVer(
                 major = if (result.groupValues[1].isEmpty()) 0 else result.groupValues[1].toInt(),
                 minor = if (result.groupValues[2].isEmpty()) 0 else result.groupValues[2].toInt(),
@@ -78,7 +78,7 @@ data class SemVer(
 
         fun parseRange(range: String): Pair<SemVer, SemVer?> {
             val pattern = Regex(REGEX_SEM_VER_RANGE)
-            val result = pattern.matchEntire(range) ?: throw IllegalArgumentException("Invalid range version string [$range]")
+            val result = pattern.matchEntire(range.trim()) ?: throw IllegalArgumentException("Invalid range version string [$range]")
             return when {
                 result.groupValues[7].isEmpty() -> Pair(SemVer.parse(result.groupValues[1]), null)
                 else -> Pair(parse(result.groupValues[1]), SemVer.parse(result.groupValues[7]))


### PR DESCRIPTION
Handles #1421

Changes proposed in this pull request:
- Fail silently
- Don't handle notifications for depracated versions
- Show update screen when opening from push notification


@gnosis/mobile-devs
