### PR TITLE
Hide crash setting on non staging builds

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/AdvancedAppSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/AdvancedAppSettingsFragment.kt
@@ -91,6 +91,8 @@ class AdvancedAppSettingsFragment : BaseViewBindingFragment<FragmentSettingsAppA
                 crashTheApp.setOnClickListener {
                     throw RuntimeException("Deliberate Crash")
                 }
+            } else {
+                debugContainer.visible(false)
             }
         }
     }


### PR DESCRIPTION

Changes proposed in this pull request:
- Hide crash setting on non staging builds


@gnosis/mobile-devs
