### PR TITLE
Don't start login prompt twice.

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
@@ -136,7 +136,7 @@ class StartActivity : BaseActivity(), SafeOverviewNavigationHandler, AppStateLis
                     settingsHandler.askForPasscodeSetupOnFirstLaunch -> {
                         if (settingsHandler.usePasscode) {
                             settingsHandler.askForPasscodeSetupOnFirstLaunch = false
-                            settingsHandler.requirePasscodeToOpen = true
+                            settingsHandler.requirePasscodeToOpen = false
                             settingsHandler.requirePasscodeForConfirmations = true
                             askForPasscode()
                         } else {

--- a/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
@@ -338,6 +338,7 @@ class StartActivity : BaseActivity(), SafeOverviewNavigationHandler, AppStateLis
     }
 
     private fun navigateToPasscodePrompt() {
+
         Navigation.findNavController(this@StartActivity, R.id.nav_host).navigate(R.id.enterPasscodeFragment, Bundle().apply {
             putBoolean("requirePasscodeToOpen", true)
         })

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
@@ -31,7 +31,6 @@ import pm.gnosis.svalinn.common.utils.snackbar
 import pm.gnosis.svalinn.common.utils.visible
 import javax.inject.Inject
 
-
 class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>() {
 
     override fun screenId() = ScreenId.PASSCODE_ENTER
@@ -62,7 +61,6 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
             alreadyStarted = false
         } else {
             alreadyStarted = true
-            binding.input.setRawInputType(InputType.TYPE_CLASS_NUMBER)
             binding.input.delayShowKeyboardForView()
             authenticateWithBiometrics()
         }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
@@ -39,6 +39,8 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
     private val selectedOwner by lazy { navArgs.selectedOwner }
     private val requirePasscodeToOpen by lazy { navArgs.requirePasscodeToOpen }
 
+    private var alreadyStarted: Boolean = false
+
     @Inject
     lateinit var viewModel: PasscodeViewModel
 
@@ -54,9 +56,16 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
 
     override fun onResume() {
         super.onResume()
-        binding.input.setRawInputType(InputType.TYPE_CLASS_NUMBER)
-        binding.input.delayShowKeyboardForView()
-        authenticateWithBiometrics()
+        if (alreadyStarted) {
+            findNavController().popBackStack(R.id.enterPasscodeFragment, true)
+            binding.input.hideSoftKeyboard()
+            alreadyStarted = false
+        } else {
+            alreadyStarted = true
+            binding.input.setRawInputType(InputType.TYPE_CLASS_NUMBER)
+            binding.input.delayShowKeyboardForView()
+            authenticateWithBiometrics()
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -70,6 +79,7 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
                     } else {
                         findNavController().popBackStack(R.id.transactionDetailsFragment, false)
                     }
+                    alreadyStarted = false
                 }
                 is BaseStateViewModel.ViewAction.ShowError -> {
                     binding.errorMessage.setText(R.string.settings_passcode_owner_removal_failed)
@@ -147,6 +157,7 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
                 selectedOwner
             )
         }
+        alreadyStarted = false
     }
 
     private fun authenticateWithBiometrics() {
@@ -196,6 +207,7 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
         if (requirePasscodeToOpen) {
             findNavController().popBackStack(R.id.enterPasscodeFragment, true)
             binding.input.hideSoftKeyboard()
+            alreadyStarted = false
         } else {
             viewModel.decryptPasscode(authenticationResult)
             binding.input.delayShowKeyboardForView()


### PR DESCRIPTION
Handles #1462, #1465

Changes proposed in this pull request:
- Show passcode prompt only once when going to background multiple times
- When updating from previous app version do not enable request passcode on app start


@gnosis/mobile-devs
