### PR TITLE
Use launch single top instead of tracking opening and closing.

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/StartActivity.kt
@@ -11,6 +11,7 @@ import android.view.View
 import androidx.core.view.marginLeft
 import androidx.core.view.marginRight
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.NavOptions
 import androidx.navigation.Navigation
 import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -323,6 +324,7 @@ class StartActivity : BaseActivity(), SafeOverviewNavigationHandler, AppStateLis
             // that were opened in the foreground and the background.
         }
     }
+
     /*
      * appInBackground() is triggered when the last activity is going into onActivityStopped().
      * See HeimdallApplication.activityLifecycleCallbacks()
@@ -338,9 +340,8 @@ class StartActivity : BaseActivity(), SafeOverviewNavigationHandler, AppStateLis
     }
 
     private fun navigateToPasscodePrompt() {
-
         Navigation.findNavController(this@StartActivity, R.id.nav_host).navigate(R.id.enterPasscodeFragment, Bundle().apply {
             putBoolean("requirePasscodeToOpen", true)
-        })
+        }, NavOptions.Builder().setLaunchSingleTop(true).build())
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
@@ -52,7 +52,7 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
 
     override fun onResume() {
         super.onResume()
-        binding.input.delayShowKeyboardForView(600)
+        binding.input.delayShowKeyboardForView()
         authenticateWithBiometrics()
     }
 
@@ -92,7 +92,7 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
                 backButton.visible(false)
                 requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, object : OnBackPressedCallback(true) {
                     override fun handleOnBackPressed() {
-                        input.delayShowKeyboardForView(600)
+                        input.delayShowKeyboardForView()
                     }
                 })
             } else {
@@ -188,11 +188,11 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
     }
 
     private fun onUsePasscode() {
-        binding.input.delayShowKeyboardForView(600)
+        binding.input.delayShowKeyboardForView()
     }
 
     private fun onBiometricsAuthFailed() {
-        binding.input.delayShowKeyboardForView(600)
+        binding.input.delayShowKeyboardForView()
     }
 
     private fun onBiometricsSuccess(authenticationResult: BiometricPrompt.AuthenticationResult) {

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
@@ -3,7 +3,6 @@ package io.gnosis.safe.ui.settings.app.passcode
 import android.content.Context
 import android.os.Build
 import android.os.Bundle
-import android.text.InputType
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -38,8 +37,6 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
     private val selectedOwner by lazy { navArgs.selectedOwner }
     private val requirePasscodeToOpen by lazy { navArgs.requirePasscodeToOpen }
 
-    private var alreadyStarted: Boolean = false
-
     @Inject
     lateinit var viewModel: PasscodeViewModel
 
@@ -55,15 +52,8 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
 
     override fun onResume() {
         super.onResume()
-        if (alreadyStarted) {
-            findNavController().popBackStack(R.id.enterPasscodeFragment, true)
-            binding.input.hideSoftKeyboard()
-            alreadyStarted = false
-        } else {
-            alreadyStarted = true
-            binding.input.delayShowKeyboardForView()
-            authenticateWithBiometrics()
-        }
+        binding.input.delayShowKeyboardForView()
+        authenticateWithBiometrics()
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -77,7 +67,6 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
                     } else {
                         findNavController().popBackStack(R.id.transactionDetailsFragment, false)
                     }
-                    alreadyStarted = false
                 }
                 is BaseStateViewModel.ViewAction.ShowError -> {
                     binding.errorMessage.setText(R.string.settings_passcode_owner_removal_failed)
@@ -155,7 +144,6 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
                 selectedOwner
             )
         }
-        alreadyStarted = false
     }
 
     private fun authenticateWithBiometrics() {
@@ -205,7 +193,6 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
         if (requirePasscodeToOpen) {
             findNavController().popBackStack(R.id.enterPasscodeFragment, true)
             binding.input.hideSoftKeyboard()
-            alreadyStarted = false
         } else {
             viewModel.decryptPasscode(authenticationResult)
             binding.input.delayShowKeyboardForView()

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
@@ -52,7 +52,7 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
 
     override fun onResume() {
         super.onResume()
-        binding.input.delayShowKeyboardForView()
+        binding.input.delayShowKeyboardForView(600)
         authenticateWithBiometrics()
     }
 
@@ -92,7 +92,7 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
                 backButton.visible(false)
                 requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, object : OnBackPressedCallback(true) {
                     override fun handleOnBackPressed() {
-                        input.delayShowKeyboardForView()
+                        input.delayShowKeyboardForView(600)
                     }
                 })
             } else {
@@ -129,6 +129,12 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
                     viewModel.onForgotPasscode()
                     input.hideSoftKeyboard()
                 }
+            }
+            contentView.setOnClickListener {
+                input.showKeyboardForView()
+            }
+            showKeyboard.setOnClickListener {
+                input.showKeyboardForView()
             }
         }
     }
@@ -182,11 +188,11 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
     }
 
     private fun onUsePasscode() {
-        binding.input.delayShowKeyboardForView()
+        binding.input.delayShowKeyboardForView(600)
     }
 
     private fun onBiometricsAuthFailed() {
-        binding.input.delayShowKeyboardForView()
+        binding.input.delayShowKeyboardForView(600)
     }
 
     private fun onBiometricsSuccess(authenticationResult: BiometricPrompt.AuthenticationResult) {

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
@@ -130,7 +130,7 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
                     input.hideSoftKeyboard()
                 }
             }
-            contentView.setOnClickListener {
+            rootView.setOnClickListener {
                 input.showKeyboardForView()
             }
         }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
@@ -133,9 +133,6 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
             contentView.setOnClickListener {
                 input.showKeyboardForView()
             }
-            showKeyboard.setOnClickListener {
-                input.showKeyboardForView()
-            }
         }
     }
 

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/PasscodeSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/PasscodeSettingsFragment.kt
@@ -78,7 +78,7 @@ class PasscodeSettingsFragment : SafeOverviewBaseFragment<FragmentSettingsAppPas
             useBiometrics.settingSwitch.setOnClickListener {
                 if (useBiometrics.settingSwitch.isChecked) {
                     if (canAuthenticate() == BIOMETRIC_ERROR_NONE_ENROLLED) {
-                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
                             startActivity(Intent(Settings.ACTION_SECURITY_SETTINGS));
                         } else {
                             startActivityForResult(Intent(Settings.ACTION_FINGERPRINT_ENROLL), 1 /* REQUESTCODE_FINGERPRINT_ENROLLMENT */)

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/PasscodeSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/PasscodeSettingsFragment.kt
@@ -78,10 +78,10 @@ class PasscodeSettingsFragment : SafeOverviewBaseFragment<FragmentSettingsAppPas
             useBiometrics.settingSwitch.setOnClickListener {
                 if (useBiometrics.settingSwitch.isChecked) {
                     if (canAuthenticate() == BIOMETRIC_ERROR_NONE_ENROLLED) {
-                        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
-                            startActivity(Intent(Settings.ACTION_SECURITY_SETTINGS));
+                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+                            startActivity(Intent(Settings.ACTION_SECURITY_SETTINGS))
                         } else {
-                            startActivityForResult(Intent(Settings.ACTION_FINGERPRINT_ENROLL), 1 /* REQUESTCODE_FINGERPRINT_ENROLLMENT */)
+                            startActivityForResult(Intent(Settings.ACTION_FINGERPRINT_ENROLL), REQUESTCODE_FINGERPRINT_ENROLLMENT)
                         }
 
                         Toast.makeText(requireContext(), getString(R.string.biometric_prompt_please_enroll_biometric_attribute), Toast.LENGTH_LONG)
@@ -143,7 +143,7 @@ class PasscodeSettingsFragment : SafeOverviewBaseFragment<FragmentSettingsAppPas
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         //TODO: What could we do here?
-        Timber.i("---> Handle result from Security setting: $requestCode, $resultCode, $data")
+        Timber.d("---> Handle result from Security setting: $requestCode, $resultCode, $data")
     }
 
     private fun canAuthenticate() = BiometricManager.from(requireContext())
@@ -164,5 +164,9 @@ class PasscodeSettingsFragment : SafeOverviewBaseFragment<FragmentSettingsAppPas
             requireToOpen.settingSwitch.isChecked = settingsHandler.requirePasscodeToOpen
             useBiometrics.settingSwitch.isChecked = settingsHandler.useBiometrics
         }
+    }
+
+    companion object {
+        private const val REQUESTCODE_FINGERPRINT_ENROLLMENT = 0
     }
 }

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/PasscodeUtils.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/PasscodeUtils.kt
@@ -9,7 +9,7 @@ import io.gnosis.safe.R
 import pm.gnosis.svalinn.common.utils.showKeyboardForView
 
 
-fun View.delayShowKeyboardForView(delay: Long = 200) {
+fun View.delayShowKeyboardForView(delay: Long = 600) {
     postDelayed({
         showKeyboardForView()
     }, delay)

--- a/app/src/main/res/layout/fragment_passcode.xml
+++ b/app/src/main/res/layout/fragment_passcode.xml
@@ -57,6 +57,7 @@
         app:layout_constraintTop_toBottomOf="@+id/appbar">
 
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/content_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:background="@color/surface_04" >
@@ -214,6 +215,22 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent" />
+
+
+            <TextView
+                android:id="@+id/show_keyboard"
+                style="@style/TextLink"
+                android:layout_width="256dp"
+                android:layout_height="56dp"
+                android:layout_marginEnd="@dimen/default_margin"
+                android:layout_marginStart="@dimen/default_margin"
+                android:layout_marginTop="280dp"
+                android:gravity="center"
+                android:text="@string/settings_passcode_show_keyboard"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/action_button" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_passcode.xml
+++ b/app/src/main/res/layout/fragment_passcode.xml
@@ -4,8 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:tool="http://schemas.android.com/tools"
-    android:background="@color/surface_01">
+    android:background="@color/surface_04"
+    android:id="@+id/root_view">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar"
@@ -50,14 +50,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="46dp"
-        android:background="@color/background"
+        android:background="@color/surface_04"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/appbar">
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/content_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:background="@color/surface_04" >
@@ -216,22 +215,21 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent" />
 
-
-            <TextView
-                android:id="@+id/show_keyboard"
-                style="@style/TextLink"
-                android:layout_width="256dp"
-                android:layout_height="56dp"
-                android:layout_marginEnd="@dimen/default_margin"
-                android:layout_marginStart="@dimen/default_margin"
-                android:layout_marginTop="280dp"
-                android:gravity="center"
-                android:text="@string/settings_passcode_show_keyboard"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/action_button" />
-
         </androidx.constraintlayout.widget.ConstraintLayout>
+
     </androidx.core.widget.NestedScrollView>
+
+    <TextView
+        android:id="@+id/show_keyboard"
+        style="@style/TextLink"
+        android:layout_width="256dp"
+        android:layout_height="56dp"
+        android:layout_marginEnd="@dimen/default_margin"
+        android:layout_marginStart="@dimen/default_margin"
+        android:gravity="center"
+        android:text="@string/settings_passcode_show_keyboard"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -200,6 +200,7 @@
     <string name="settings_passcode_login_with_biometrics">Login with biometrics</string>
     <string name="settings_passcode_require_to_open_app">Require to open app</string>
     <string name="settings_passcode_require_for_confirmations">Require for confirmations</string>
+    <string name="settings_passcode_show_keyboard">Show keyboard</string>
 
     <string name="settings_app_network">Network</string>
     <string name="settings_app_advanced">Advanced</string>


### PR DESCRIPTION
Handles #1469, #1470

Changes proposed in this pull request:
- Use singleTop to show passcode fragment only once after sending app to background multiple times
- Try to show keyboard with a bigger delay and show button to reopen keyboard if that fails

@gnosis/mobile-devs
