### PR TITLE
More key validation

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/settings/owner/OwnerSeedPhraseViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/owner/OwnerSeedPhraseViewModel.kt
@@ -10,6 +10,8 @@ import pm.gnosis.mnemonic.Bip39
 import pm.gnosis.model.Solidity
 import pm.gnosis.utils.asBigInteger
 import pm.gnosis.utils.hexAsBigInteger
+import pm.gnosis.utils.hexToByteArray
+import java.math.BigInteger
 import javax.inject.Inject
 
 class OwnerSeedPhraseViewModel
@@ -47,8 +49,11 @@ class OwnerSeedPhraseViewModel
             safeLaunch {
                 updateState { ImportOwnerKeyState.Error(InvalidPrivateKey) }
             }
+        } else if (!keyCanBeUsedForSigning(input.hexAsBigInteger())) {
+            safeLaunch {
+                updateState { ImportOwnerKeyState.Error(InvalidPrivateKey) }
+            }
         } else {
-
             safeLaunch {
                 val ownerKeyPair = KeyPair.fromPrivate(input.hexAsBigInteger())
                 val ownerAddress = Solidity.Address(ownerKeyPair.address.asBigInteger())
@@ -58,6 +63,15 @@ class OwnerSeedPhraseViewModel
                     updateState { ImportOwnerKeyState.Error(KeyAlreadyImported) }
                 }
             }
+        }
+    }
+
+    private fun keyCanBeUsedForSigning(key: BigInteger): Boolean {
+        try {
+            KeyPair.fromPrivate(key).sign("0x1234567890".hexToByteArray())
+            return true
+        } catch (e: Exception) {
+            return false
         }
     }
 

--- a/app/src/main/java/io/gnosis/safe/ui/settings/owner/OwnerSeedPhraseViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/owner/OwnerSeedPhraseViewModel.kt
@@ -44,17 +44,12 @@ class OwnerSeedPhraseViewModel
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun validatePrivateKey(key: String) {
         val input = removeHexPrefix(key)
-
-        if (input == "0000000000000000000000000000000000000000000000000000000000000000") {
-            safeLaunch {
+        safeLaunch {
+            if (input == "0000000000000000000000000000000000000000000000000000000000000000") {
                 updateState { ImportOwnerKeyState.Error(InvalidPrivateKey) }
-            }
-        } else if (!keyCanBeUsedForSigning(input.hexAsBigInteger())) {
-            safeLaunch {
+            } else if (!keyCanBeUsedForSigning(input.hexAsBigInteger())) {
                 updateState { ImportOwnerKeyState.Error(InvalidPrivateKey) }
-            }
-        } else {
-            safeLaunch {
+            } else {
                 val ownerKeyPair = KeyPair.fromPrivate(input.hexAsBigInteger())
                 val ownerAddress = Solidity.Address(ownerKeyPair.address.asBigInteger())
                 if (credentialsRepository.owner(ownerAddress) == null) {

--- a/app/src/main/java/io/gnosis/safe/ui/settings/owner/OwnerSeedPhraseViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/owner/OwnerSeedPhraseViewModel.kt
@@ -67,11 +67,11 @@ class OwnerSeedPhraseViewModel
     }
 
     private fun keyCanBeUsedForSigning(key: BigInteger): Boolean {
-        try {
+        return try {
             KeyPair.fromPrivate(key).sign("0x1234567890".hexToByteArray())
-            return true
+            true
         } catch (e: Exception) {
-            return false
+            false
         }
     }
 

--- a/app/src/main/java/io/gnosis/safe/ui/settings/owner/OwnerSeedPhraseViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/owner/OwnerSeedPhraseViewModel.kt
@@ -66,6 +66,8 @@ class OwnerSeedPhraseViewModel
         }
     }
 
+    // Some keys fail additional checks. This makes sure a key can be used for signing without throwing an Exception.
+    // See: https://github.com/gnosis/safe-android/issues/1431
     private fun keyCanBeUsedForSigning(key: BigInteger): Boolean {
         return try {
             KeyPair.fromPrivate(key).sign("0x1234567890".hexToByteArray())


### PR DESCRIPTION
Handles #1431 

Changes proposed in this pull request:
- I could not reproduce the problem even after generating more than 10000 keys
- We now check that a key entered by the suer can be used to sign

@gnosis/mobile-devs
