### PR TITLE
Adjust add owner flow

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsAdapter.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsAdapter.kt
@@ -125,7 +125,7 @@ class BannerViewHolder(private val viewBinding: ItemBannerBinding) : BaseCoinsVi
         val context = viewBinding.root.context
         with(viewBinding) {
             when(type) {
-                Banner.Type.IMPORT_OWNER_KEY -> {
+                Banner.Type.ADD_OWNER_KEY -> {
                     bannerTitle.text = context.getString(R.string.banner_owner_title)
                     bannerText.text = context.getString(R.string.banner_owner_text)
                     bannerAction.text = context.getString(R.string.banner_owner_action)
@@ -143,8 +143,8 @@ class BannerViewHolder(private val viewBinding: ItemBannerBinding) : BaseCoinsVi
             bannerAction.setOnClickListener {
                 bannerListener.get()?.onBannerActionTriggered(type)
                 when(type) {
-                    Banner.Type.IMPORT_OWNER_KEY -> {
-                        Navigation.findNavController(it).navigate(R.id.action_to_import_owner)
+                    Banner.Type.ADD_OWNER_KEY -> {
+                        Navigation.findNavController(it).navigate(R.id.action_to_add_owner)
                     }
                     Banner.Type.PASSCODE -> {
                         Navigation.findNavController(it).navigate(R.id.action_to_passcode_setup)

--- a/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsViewData.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsViewData.kt
@@ -18,7 +18,7 @@ sealed class CoinsViewData {
         val type: Type
     ) : CoinsViewData() {
         enum class Type {
-            IMPORT_OWNER_KEY,
+            ADD_OWNER_KEY,
             PASSCODE,
             NONE
         }

--- a/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/assets/coins/CoinsViewModel.kt
@@ -50,7 +50,7 @@ class CoinsViewModel
                 val balanceInfo = tokenRepository.loadBalanceOf(safe.address, userDefaultFiat)
 
                 val banner = when {
-                    settingsHandler.showOwnerBanner && credentialsRepository.ownerCount() == 0 -> Banner.Type.IMPORT_OWNER_KEY
+                    settingsHandler.showOwnerBanner && credentialsRepository.ownerCount() == 0 -> Banner.Type.ADD_OWNER_KEY
                     settingsHandler.showPasscodeBanner && credentialsRepository.ownerCount() > 0 -> Banner.Type.PASSCODE
                     else -> Banner.Type.NONE
                 }
@@ -69,8 +69,8 @@ class CoinsViewModel
         val result = mutableListOf<CoinsViewData>()
 
         when (banner) {
-            Banner.Type.IMPORT_OWNER_KEY -> {
-                result.add(Banner(Banner.Type.IMPORT_OWNER_KEY))
+            Banner.Type.ADD_OWNER_KEY -> {
+                result.add(Banner(Banner.Type.ADD_OWNER_KEY))
             }
             Banner.Type.PASSCODE -> {
                 result.add(Banner(Banner.Type.PASSCODE))
@@ -104,7 +104,7 @@ class CoinsViewModel
 
     override fun onBannerDismissed(type: Banner.Type) {
         when (type) {
-            Banner.Type.IMPORT_OWNER_KEY -> {
+            Banner.Type.ADD_OWNER_KEY -> {
                 settingsHandler.showOwnerBanner = false
                 tracker.logBannerOwnerSkip()
             }
@@ -120,7 +120,7 @@ class CoinsViewModel
 
     override fun onBannerActionTriggered(type: Banner.Type) {
         when (type) {
-            Banner.Type.IMPORT_OWNER_KEY -> {
+            Banner.Type.ADD_OWNER_KEY -> {
                 settingsHandler.showOwnerBanner = false
                 tracker.logBannerOwnerImport()
             }

--- a/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeOwnerFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/safe/add/AddSafeOwnerFragment.kt
@@ -61,10 +61,10 @@ class AddSafeOwnerFragment : BaseViewBindingFragment<FragmentAddSafeOwnerBinding
             }
             blockie.setAddress(address)
             readOnlyDescription.text = getString(R.string.add_safe_owner_read_only_notice, name)
-            importButton.setOnClickListener {
+            addOwnerButton.setOnClickListener {
                 tracker.logOnboardingOwnerImport()
                 finishAddSafeFlow()
-                findNavController().navigate(R.id.action_to_import_owner)
+                findNavController().navigate(R.id.action_to_add_owner)
             }
             skip.setOnClickListener {
                 tracker.logOnboardingOwnerSkipped()

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/PasscodeSettingsFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/PasscodeSettingsFragment.kt
@@ -104,8 +104,8 @@ class PasscodeSettingsFragment : SafeOverviewBaseFragment<FragmentSettingsAppPas
             requireToOpen.visible(settingsHandler.usePasscode)
             requireToOpen.settingSwitch.isChecked = settingsHandler.requirePasscodeToOpen
             requireToOpen.settingSwitch.setOnClickListener {
-                // If both are disabled, disable passcode feature
-                if (!requireForConfirmations.settingSwitch.isChecked && !requireToOpen.settingSwitch.isChecked) {
+                // If all are disabled, disable passcode feature
+                if (!requireForConfirmations.settingSwitch.isChecked && !requireToOpen.settingSwitch.isChecked && !requireForExport.settingSwitch.isChecked) {
                     findNavController().navigate(
                         PasscodeSettingsFragmentDirections.actionPasscodeSettingsFragmentToConfigurePasscodeFragment(DISABLE)
                     )
@@ -124,8 +124,8 @@ class PasscodeSettingsFragment : SafeOverviewBaseFragment<FragmentSettingsAppPas
             requireForConfirmations.visible(settingsHandler.usePasscode)
             requireForConfirmations.settingSwitch.isChecked = settingsHandler.requirePasscodeForConfirmations
             requireForConfirmations.settingSwitch.setOnClickListener {
-                // If both are disabled, disable passcode feature
-                if (!requireForConfirmations.settingSwitch.isChecked && !requireToOpen.settingSwitch.isChecked) {
+                // If all are disabled, disable passcode feature
+                if (!requireForConfirmations.settingSwitch.isChecked && !requireToOpen.settingSwitch.isChecked && !requireForExport.settingSwitch.isChecked) {
                     findNavController().navigate(PasscodeSettingsFragmentDirections.actionPasscodeSettingsFragmentToConfigurePasscodeFragment(DISABLE))
                 } else if (requireForConfirmations.settingSwitch.isChecked) {
                     findNavController().navigate(
@@ -142,7 +142,10 @@ class PasscodeSettingsFragment : SafeOverviewBaseFragment<FragmentSettingsAppPas
             requireForExport.visible(settingsHandler.usePasscode)
             requireForExport.settingSwitch.isChecked = settingsHandler.requirePasscodeToExportKeys
             requireForExport.settingSwitch.setOnClickListener {
-                if (requireForExport.settingSwitch.isChecked) {
+                // If all are disabled, disable passcode feature
+                if (!requireForConfirmations.settingSwitch.isChecked && !requireToOpen.settingSwitch.isChecked && !requireForExport.settingSwitch.isChecked) {
+                    findNavController().navigate(PasscodeSettingsFragmentDirections.actionPasscodeSettingsFragmentToConfigurePasscodeFragment(DISABLE))
+                } else if (requireForExport.settingSwitch.isChecked) {
                     findNavController().navigate(
                         PasscodeSettingsFragmentDirections.actionPasscodeSettingsFragmentToConfigurePasscodeFragment(EXPORT_ENABLE)
                     )

--- a/app/src/main/java/io/gnosis/safe/ui/settings/owner/OwnerEnterNameFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/owner/OwnerEnterNameFragment.kt
@@ -49,20 +49,28 @@ class OwnerEnterNameFragment : BaseViewBindingFragment<FragmentOwnerNameEnterBin
             newAddressBlockies.setAddress(ownerAddress)
             newAddressHex.text = ownerAddress.formatEthAddress(requireContext(), addMiddleLinebreak = false)
             backButton.setOnClickListener { findNavController().navigateUp() }
-            importButton.setOnClickListener {
-                if (ownerSeedPhrase != null) {
+            if (ownerSeedPhrase != null) {
+                nextButton.text = getString(R.string.signing_owner_save)
+                nextButton.setOnClickListener {
                     viewModel.importGeneratedOwner(ownerAddress, ownerNameEntry.text.toString(), ownerKey, ownerSeedPhrase!!)
-                } else {
+                }
+            } else {
+                nextButton.text = getString(R.string.signing_owner_import)
+                nextButton.setOnClickListener {
                     viewModel.importOwner(ownerAddress, ownerNameEntry.text.toString(), ownerKey, fromSeedPhrase)
                 }
-             }
-            ownerNameEntry.doOnTextChanged { text, _, _, _ -> binding.importButton.isEnabled = !text.isNullOrBlank() }
+            }
+            ownerNameEntry.doOnTextChanged { text, _, _, _ -> binding.nextButton.isEnabled = !text.isNullOrBlank() }
         }
         viewModel.state.observe(viewLifecycleOwner, Observer {
-            when(val viewAction = it.viewAction) {
+            when (val viewAction = it.viewAction) {
                 is CloseScreen -> {
                     findNavController().popBackStack(R.id.ownerAddOptionsFragment, true)
-                    findNavController().currentBackStackEntry?.savedStateHandle?.set(SafeOverviewBaseFragment.OWNER_IMPORT_RESULT, true)
+                    if (ownerSeedPhrase != null) {
+                        findNavController().currentBackStackEntry?.savedStateHandle?.set(SafeOverviewBaseFragment.OWNER_CREATE_RESULT, true)
+                    } else {
+                        findNavController().currentBackStackEntry?.savedStateHandle?.set(SafeOverviewBaseFragment.OWNER_IMPORT_RESULT, true)
+                    }
                 }
                 is NavigateTo -> {
                     findNavController().navigate(viewAction.navDirections)

--- a/app/src/main/res/layout/fragment_add_safe_owner.xml
+++ b/app/src/main/res/layout/fragment_add_safe_owner.xml
@@ -133,13 +133,13 @@
         app:layout_constraintTop_toBottomOf="@id/safe_address" />
 
     <Button
-        android:id="@+id/import_button"
+        android:id="@+id/add_owner_button"
         style="@style/PrimaryButton"
         android:layout_width="0dp"
         android:layout_marginEnd="@dimen/default_margin"
         android:layout_marginStart="@dimen/default_margin"
         android:layout_marginTop="32dp"
-        android:text="@string/add_safe_owner_import"
+        android:text="@string/add_safe_owner_add"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/read_only_description" />
@@ -154,6 +154,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         android:gravity="center"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/import_button" />
+        app:layout_constraintTop_toBottomOf="@id/add_owner_button" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_owner_name_enter.xml
+++ b/app/src/main/res/layout/fragment_owner_name_enter.xml
@@ -39,7 +39,7 @@
             android:text="@string/signing_owner_name_title" />
 
         <TextView
-            android:id="@+id/import_button"
+            android:id="@+id/next_button"
             style="@style/ToolbarButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/navigation/main_nav.xml
+++ b/app/src/main/res/navigation/main_nav.xml
@@ -12,8 +12,8 @@
         app:launchSingleTop="true" />
 
     <action
-        android:id="@+id/action_to_import_owner"
-        app:destination="@id/ownerInfoFragment" />
+        android:id="@+id/action_to_add_owner"
+        app:destination="@id/ownerAddOptionsFragment" />
 
     <action
         android:id="@+id/action_to_passcode_setup"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -365,6 +365,7 @@
     <string name="signing_owner_key_created">Owner key successfully created. Add it to a Safe on desktop and then restart the mobile app.</string>
     <string name="signing_owner_key_removed">Owner key removed from this app</string>
 
+    <string name="signing_owner_save">Save</string>
     <string name="signing_owner_import">Import</string>
     <string name="signing_owner_export">Export</string>
     <string name="signing_owner_export_tab_seed">Seed Phrase</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,8 +28,9 @@
     <string name="add_safe_label_link">https://gnosis-safe.io</string>
     <string name="back">Back</string>
 
-    <string name="add_safe_owner_read_only_notice">%1$s is read-only. Would you like to import owner key for this Safe to confirm transactions?</string>
+    <string name="add_safe_owner_read_only_notice">%1$s is read-only. Would you like to add owner key for this Safe to confirm transactions?</string>
     <string name="add_safe_owner_import">Import owner key</string>
+    <string name="add_safe_owner_add">Add owner key</string>
     <string name="add_safe_owner_skip">Skip</string>
     <string name="choose_input_method">Choose input method</string>
     <string name="address_input_ens">ENS name</string>
@@ -388,9 +389,9 @@
     <string name="signing_owner_list_title">Owner keys</string>
     <string name="signing_owner_list_empty">There are no added owner keys</string>
 
-    <string name="banner_owner_title">Import owner key</string>
-    <string name="banner_owner_text">We added signing support to the app! Now you can import your owner key and sign transactions on the go.</string>
-    <string name="banner_owner_action">Import owner key now</string>
+    <string name="banner_owner_title">Add owner key</string>
+    <string name="banner_owner_text">We added signing support to the app! Now you can add your owner key and sign transactions on the go.</string>
+    <string name="banner_owner_action">Add owner key now</string>
 
     <string name="banner_passcode_title">Create passcode</string>
     <string name="banner_passcode_text">Secure your owner keys by setting up a passcode. The passcode will be needed to open the app and sign transactions.</string>

--- a/data/src/main/java/io/gnosis/data/repositories/CredentialsRepository.kt
+++ b/data/src/main/java/io/gnosis/data/repositories/CredentialsRepository.kt
@@ -108,9 +108,12 @@ class CredentialsRepository(
     }
 
     fun decryptKey(encryptedKey: EncryptedByteArray): BigInteger {
+        val converter = EncryptedByteArray.Converter()
+        val cryptoData = EncryptionManager.CryptoData.fromString(converter.toStorage(encryptedKey))
         encryptionManager.unlock()
-        val key = encryptedKey.value(encryptionManager).asBigInteger()
-        return key
+        val key = encryptionManager.decrypt(cryptoData)
+        encryptionManager.lock()
+        return key.asBigInteger()
     }
 
     fun encryptSeed(data: String): EncryptedString {


### PR DESCRIPTION
Handles #1480
Handles #1487
Handles #1488
Handles #1501

Changes proposed in this pull request:
- Disable passcode only when all sub options are disabled
- Rename import to save when adding created owner; fix confirmation snackbar
-  Adjust add safe flow & optionally proceed to add owner flow instead of just owner import

TODO: rename banner tracking event?

@gnosis/mobile-devs
