### PR TITLE
Passcode change crash on non bio devices

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         applicationId "io.gnosis.safe"
         versionCode getInt("APP_VERSION_CODE", 703)
-        versionName getKey("APP_VERSION_NAME", "2.17.0")
+        versionName getKey("APP_VERSION_NAME", "2.17.1")
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         // API keys

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/ChangeRepeatPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/ChangeRepeatPasscodeFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
+import androidx.biometric.BiometricManager
 import androidx.core.content.ContextCompat
 import androidx.core.widget.doOnTextChanged
 import androidx.lifecycle.Observer
@@ -80,7 +81,9 @@ class ChangeRepeatPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBin
             }
             input.doOnTextChanged(onSixDigitsHandler(digits, requireContext()) { digitsAsString ->
                 if (digitsAsString == passcodeArg) {
-                    viewModel.encryptPasscodeWithBiometricKey(digitsAsString)
+                    if (requireContext().canAuthenticateUsingBiometrics() == BiometricManager.BIOMETRIC_SUCCESS) {
+                        viewModel.encryptPasscodeWithBiometricKey(digitsAsString)
+                    }
                     viewModel.disableAndSetNewPasscode(newPasscode = passcodeArg, oldPasscode = oldPasscode)
                 } else {
                     errorMessage.visible(true)

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/PasscodeViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/PasscodeViewModel.kt
@@ -61,8 +61,8 @@ class PasscodeViewModel
                         updateState { PasscodeState(PasscodeCommandExecuted) }
                     }
                     BIOMETRICS_ENABLE -> {
-                        encryptPasscodeWithBiometricKey(passcode)
                         settingsHandler.useBiometrics = true
+                        encryptPasscodeWithBiometricKey(passcode)
                         updateState { PasscodeState(PasscodeCommandExecuted) }
                     }
                     BIOMETRICS_DISABLE -> {
@@ -159,14 +159,16 @@ class PasscodeViewModel
     }
 
     fun encryptPasscodeWithBiometricKey(newPasscode: String) {
-        val cipher = biometricPasscodeManager.getInitializedRSACipherForEncryption(BiometricPasscodeManager.KEY_NAME)
-        val encrypted = biometricPasscodeManager.encryptData(newPasscode, cipher)
-        biometricPasscodeManager.persistEncryptedPasscodeToSharedPrefs(
-            encrypted,
-            BiometricPasscodeManager.FILE_NAME,
-            Context.MODE_PRIVATE,
-            BiometricPasscodeManager.KEY_NAME
-        )
+        if (settingsHandler.useBiometrics) {
+            val cipher = biometricPasscodeManager.getInitializedRSACipherForEncryption(BiometricPasscodeManager.KEY_NAME)
+            val encrypted = biometricPasscodeManager.encryptData(newPasscode, cipher)
+            biometricPasscodeManager.persistEncryptedPasscodeToSharedPrefs(
+                encrypted,
+                BiometricPasscodeManager.FILE_NAME,
+                Context.MODE_PRIVATE,
+                BiometricPasscodeManager.KEY_NAME
+            )
+        }
     }
 
     @RequiresApi(Build.VERSION_CODES.M)

--- a/app/src/test/java/io/gnosis/safe/ui/settings/app/passcode/PasscodeViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/settings/app/passcode/PasscodeViewModelTest.kt
@@ -268,7 +268,8 @@ class PasscodeViewModelTest {
     }
 
     @Test
-    fun `encryptPasscodeWithBiometricKey - (passcode) should store encrypted key`() {
+    fun `encryptPasscodeWithBiometricKey - (passcode) should store encrypted key if bio enabled`() {
+        every { settingsHandler.useBiometrics } returns true
         every { biometricPasscodeManager.getInitializedRSACipherForEncryption(BiometricPasscodeManager.KEY_NAME) } returns mockk(relaxed = true)
         every { biometricPasscodeManager.encryptData(any(), any()) } returns mockk(relaxed = true)
 
@@ -277,6 +278,26 @@ class PasscodeViewModelTest {
         verify(exactly = 1) { biometricPasscodeManager.getInitializedRSACipherForEncryption(BiometricPasscodeManager.KEY_NAME) }
         verify(exactly = 1) { biometricPasscodeManager.encryptData(examplePasscode, any()) }
         verify(exactly = 1) {
+            biometricPasscodeManager.persistEncryptedPasscodeToSharedPrefs(
+                any(),
+                BiometricPasscodeManager.FILE_NAME,
+                Context.MODE_PRIVATE,
+                BiometricPasscodeManager.KEY_NAME
+            )
+        }
+    }
+
+    @Test
+    fun `encryptPasscodeWithBiometricKey - (passcode) should not store encrypted key if no bio enabled`() {
+        every { settingsHandler.useBiometrics } returns false
+        every { biometricPasscodeManager.getInitializedRSACipherForEncryption(BiometricPasscodeManager.KEY_NAME) } returns mockk(relaxed = true)
+        every { biometricPasscodeManager.encryptData(any(), any()) } returns mockk(relaxed = true)
+
+        viewModel.encryptPasscodeWithBiometricKey(examplePasscode)
+
+        verify(exactly = 0) { biometricPasscodeManager.getInitializedRSACipherForEncryption(BiometricPasscodeManager.KEY_NAME) }
+        verify(exactly = 0) { biometricPasscodeManager.encryptData(examplePasscode, any()) }
+        verify(exactly = 0) {
             biometricPasscodeManager.persistEncryptedPasscodeToSharedPrefs(
                 any(),
                 BiometricPasscodeManager.FILE_NAME,


### PR DESCRIPTION
Handles Crash in Passcode change on non bio devices

Changes proposed in this pull request:
- do not try to store passcode if device does not support biometrics or biometrics are disabled
-
-

@gnosis/mobile-devs
