### PR TITLE
Do not request passcode for confirmation if it's off in passcode settings

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/settings/owner/list/OwnerListViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/owner/list/OwnerListViewModel.kt
@@ -48,7 +48,7 @@ class OwnerListViewModel
 
     fun selectKeyForSigning(owner: Solidity.Address, isConfirmation: Boolean) {
         safeLaunch {
-            if (settingsHandler.usePasscode) {
+            if (settingsHandler.usePasscode && settingsHandler.requirePasscodeForConfirmations) {
                 updateState {
                     OwnerListState(
                         ViewAction.NavigateTo(

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/TransactionDetailsViewModel.kt
@@ -125,7 +125,7 @@ class TransactionDetailsViewModel
                 )
             }
 
-            if (!settingsHandler.usePasscode || (settingsHandler.usePasscode && credentialsRepository.credentialsUnlocked())) {
+            if (!settingsHandler.requirePasscodeForConfirmations || (settingsHandler.requirePasscodeForConfirmations && credentialsRepository.credentialsUnlocked())) {
                 submitConfirmation(txDetails!!, selectedOwnerAddress)
             }
         }


### PR DESCRIPTION
Handles #1497 

Changes proposed in this pull request:
- Check if passcode is required for confirmation

@gnosis/mobile-devs
