### PR TITLE
Fix url for unsafe flavor

### DIFF
--- a/data/build.gradle
+++ b/data/build.gradle
@@ -48,7 +48,7 @@ android {
 
         unsafe {
             buildConfigField javaTypes.STRING, "TRANSACTION_SERVICE_URL", asString(getKey("TRANSACTION_SERVICE_URL", "https://safe-transaction.staging.gnosisdev.com/api/"))
-            buildConfigField javaTypes.STRING, "CLIENT_GATEWAY_URL", asString(getKey("CLIENT_GATEWAY_URL", "https://safe-client.rinkeby.staging.gnosisdev.com/"))
+            buildConfigField javaTypes.STRING, "CLIENT_GATEWAY_URL", asString(getKey("CLIENT_GATEWAY_URL", "https://safe-client.staging.gnosisdev.com/"))
             buildConfigField (javaTypes.INT, "CHAIN_ID", "4")
             buildConfigField (javaTypes.STRING, "CHAIN_TEXT_COLOR", asString("#ffffff"))
             buildConfigField (javaTypes.STRING, "CHAIN_BACKGROUND_COLOR", asString("#E8673C"))


### PR DESCRIPTION
The unsafe flavor should use the unified backend.

@gnosis/mobile-devs
