### PR TITLE
Show contracts v1.3.0 as "up to date" in Safe Settings

### DIFF
--- a/app/src/main/java/io/gnosis/safe/utils/StringUtils.kt
+++ b/app/src/main/java/io/gnosis/safe/utils/StringUtils.kt
@@ -15,11 +15,6 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import io.gnosis.data.repositories.SafeRepository.Companion.DEFAULT_FALLBACK_HANDLER
-import io.gnosis.data.repositories.SafeRepository.Companion.SAFE_IMPLEMENTATION_0_0_2
-import io.gnosis.data.repositories.SafeRepository.Companion.SAFE_IMPLEMENTATION_0_1_0
-import io.gnosis.data.repositories.SafeRepository.Companion.SAFE_IMPLEMENTATION_1_0_0
-import io.gnosis.data.repositories.SafeRepository.Companion.SAFE_IMPLEMENTATION_1_1_1
-import io.gnosis.data.repositories.SafeRepository.Companion.SAFE_IMPLEMENTATION_1_2_0
 import io.gnosis.safe.R
 import pm.gnosis.crypto.utils.asEthereumAddressChecksumString
 import pm.gnosis.model.Solidity
@@ -94,18 +89,6 @@ fun Solidity.Address?.fallBackHandlerLabel(): Int =
     } else {
         R.string.unknown_fallback_handler
     }
-
-@StringRes
-fun Solidity.Address.implementationVersion(): Int {
-    val supportedContracts = mapOf(
-        SAFE_IMPLEMENTATION_0_0_2 to R.string.implementation_version_0_0_2,
-        SAFE_IMPLEMENTATION_0_1_0 to R.string.implementation_version_0_1_0,
-        SAFE_IMPLEMENTATION_1_0_0 to R.string.implementation_version_1_0_0,
-        SAFE_IMPLEMENTATION_1_1_1 to R.string.implementation_version_1_1_1,
-        SAFE_IMPLEMENTATION_1_2_0 to R.string.implementation_version_1_2_0
-    )
-    return supportedContracts[this] ?: R.string.unknown_implementation_version
-}
 
 fun String.formatEthAddressBold(prefixLength: Int = 6, suffixLength: Int = 4): Spannable {
     return SpannableStringBuilder(this.substring(0, this.length / 2) + "\n" + this.substring(this.length / 2, this.length)).apply {

--- a/app/src/main/java/io/gnosis/safe/utils/TxUtils.kt
+++ b/app/src/main/java/io/gnosis/safe/utils/TxUtils.kt
@@ -109,9 +109,7 @@ fun TransactionInfoViewData.SettingsChange.txActionInfoItems(resources: Resource
 
     when (val settingsInfo = settingsChange.settingsInfo) {
         is SettingsInfoViewData.ChangeImplementation -> {
-            val mainCopy = settingsInfo.implementation
-            val label = settingsInfo.implementationInfo?.getLabel() ?: resources.getString(mainCopy.implementationVersion())
-
+            val label = settingsInfo.implementationInfo?.getLabel() ?: resources.getString(R.string.unknown_implementation_version)
             result.add(
                 getAddressActionInfoItem(
                     settingsInfo.implementation,
@@ -141,7 +139,7 @@ fun TransactionInfoViewData.SettingsChange.txActionInfoItems(resources: Resource
         }
         is SettingsInfoViewData.SetFallbackHandler -> {
 
-            val label: String? = settingsInfo.handlerInfo?.getLabel()
+            val label: String = settingsInfo.handlerInfo?.getLabel()
                 ?: if (SafeRepository.DEFAULT_FALLBACK_HANDLER == settingsInfo.handler) {
                     resources.getString(R.string.default_fallback_handler)
                 } else {

--- a/app/src/main/res/values/static_strings.xml
+++ b/app/src/main/res/values/static_strings.xml
@@ -12,11 +12,6 @@
     <string name="id_discord">FPMRAwK</string>
     <string name="email_feedback" translatable="false">safe@gnosis.io</string>
     <string name="empty_string" translatable="false" />
-    <string name="implementation_version_0_0_2" translatable="false">0.0.2</string>
-    <string name="implementation_version_0_1_0" translatable="false">0.1.0</string>
-    <string name="implementation_version_1_0_0" translatable="false">1.0.0</string>
-    <string name="implementation_version_1_1_1" translatable="false">1.1.1</string>
-    <string name="implementation_version_1_2_0" translatable="false">1.2.0</string>
     <string name="safe_settings_fallback_handler_help_url">https://help.gnosis-safe.io/en/articles/4738352-what-is-a-fallback-handler-and-how-does-it-relate-to-the-gnosis-safe</string>
     <string name="safe_settings_guard_help_url">https://help.gnosis-safe.io/en/articles/5324092-what-is-a-transaction-guard</string>
     <string name="owner_key_intro_private_key_url">https://help.gnosis-safe.io/en/articles/4866738-how-are-private-keys-stored-on-gnosis-safe-mobile</string>

--- a/app/src/test/java/io/gnosis/safe/ui/settings/SafeSettingsViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/settings/SafeSettingsViewModelTest.kt
@@ -3,6 +3,7 @@ package io.gnosis.safe.ui.settings
 import io.gnosis.data.models.AddressInfo
 import io.gnosis.data.models.Safe
 import io.gnosis.data.models.SafeInfo
+import io.gnosis.data.models.VersionState
 import io.gnosis.data.repositories.CredentialsRepository
 import io.gnosis.data.repositories.EnsRepository
 import io.gnosis.data.repositories.SafeRepository
@@ -88,7 +89,8 @@ class SafeSettingsViewModelTest {
             emptyList(),
             null,
             null,
-            "1.1.1"
+            "1.1.1",
+            VersionState.OUTDATED
         )
         val safeInfo2 = SafeInfo(
             AddressInfo(safe2.address),
@@ -99,7 +101,8 @@ class SafeSettingsViewModelTest {
             emptyList(),
             null,
             null,
-            "1.1.1"
+            "1.1.1",
+            VersionState.OUTDATED
         )
         val ensName1 = "ens.name"
         val ensName2 = "ens.name"
@@ -184,7 +187,8 @@ class SafeSettingsViewModelTest {
             emptyList(),
             null,
             null,
-            "1.1.1"
+            "1.1.1",
+            VersionState.OUTDATED
         )
         val ensName = "ens.name"
         coEvery { safeRepository.getActiveSafe() } returns safe
@@ -235,7 +239,8 @@ class SafeSettingsViewModelTest {
             emptyList(),
             null,
             null,
-            "1.1.1"
+            "1.1.1",
+            VersionState.OUTDATED
         )
         coEvery { safeRepository.getActiveSafe() } returns safe
         coEvery { credentialsRepository.owners() } returns emptyList()
@@ -377,7 +382,8 @@ class SafeSettingsViewModelTest {
             emptyList(),
             AddressInfo(Solidity.Address(BigInteger.ONE)),
             null,
-            "1.1.1"
+            "1.1.1",
+            VersionState.OUTDATED
         )
         coEvery { safeRepository.getActiveSafe() } returnsMany listOf(SAFE_1, SAFE_2)
         coEvery { safeRepository.activeSafeFlow() } returns flow {

--- a/app/src/test/java/io/gnosis/safe/ui/settings/safe/AdvancedSafeSettingsViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/settings/safe/AdvancedSafeSettingsViewModelTest.kt
@@ -1,9 +1,6 @@
 package io.gnosis.safe.ui.settings.safe
 
-import io.gnosis.data.models.AddressInfo
-import io.gnosis.data.models.Chain
-import io.gnosis.data.models.Safe
-import io.gnosis.data.models.SafeInfo
+import io.gnosis.data.models.*
 import io.gnosis.data.repositories.SafeRepository
 import io.gnosis.safe.MainCoroutineScopeRule
 import io.gnosis.safe.TestLifecycleRule
@@ -76,7 +73,8 @@ class AdvancedSafeSettingsViewModelTest {
             emptyList(),
             AddressInfo(Solidity.Address(BigInteger.ONE)),
             null,
-            "1.1.1"
+            "1.1.1",
+            VersionState.OUTDATED
         )
         val chain = Chain.DEFAULT_CHAIN
         coEvery { safeRepository.getSafeInfo(any()) } returns safeInfo

--- a/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
+++ b/app/src/test/java/io/gnosis/safe/ui/transactions/TransactionListViewModelTest.kt
@@ -14,8 +14,6 @@ import io.gnosis.data.repositories.SafeRepository.Companion.METHOD_DISABLE_MODUL
 import io.gnosis.data.repositories.SafeRepository.Companion.METHOD_ENABLE_MODULE
 import io.gnosis.data.repositories.SafeRepository.Companion.METHOD_REMOVE_OWNER
 import io.gnosis.data.repositories.SafeRepository.Companion.METHOD_SET_FALLBACK_HANDLER
-import io.gnosis.data.repositories.SafeRepository.Companion.SAFE_IMPLEMENTATION_1_0_0
-import io.gnosis.data.repositories.SafeRepository.Companion.SAFE_IMPLEMENTATION_1_1_1
 import io.gnosis.data.repositories.TransactionRepository
 import io.gnosis.safe.*
 import io.gnosis.safe.ui.base.BaseStateViewModel
@@ -1199,6 +1197,9 @@ class TransactionListViewModelTest {
     )
 
     companion object {
+
+        private val SAFE_IMPLEMENTATION_1_0_0 = "0x8942595A2dC5181Df0465AF0D7be08c8f23C93af".asEthereumAddress()!!
+        private val SAFE_IMPLEMENTATION_1_1_1 = "0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A".asEthereumAddress()!!
 
         private val CHAIN = Chain.DEFAULT_CHAIN
 

--- a/app/src/test/java/io/gnosis/safe/utils/TxUtilsKtTest.kt
+++ b/app/src/test/java/io/gnosis/safe/utils/TxUtilsKtTest.kt
@@ -7,8 +7,8 @@ import io.gnosis.data.models.transaction.DataDecoded
 import io.gnosis.data.models.transaction.TransactionDirection
 import io.gnosis.data.models.transaction.TransferInfo
 import io.gnosis.data.repositories.SafeRepository
-import io.gnosis.data.repositories.SafeRepository.Companion.SAFE_IMPLEMENTATION_1_1_1
 import io.gnosis.safe.R
+import io.gnosis.safe.ui.transactions.AddressInfoData
 import io.gnosis.safe.ui.transactions.details.view.ActionInfoItem
 import io.gnosis.safe.ui.transactions.details.viewdata.SettingsInfoViewData
 import io.gnosis.safe.ui.transactions.details.viewdata.TransactionInfoViewData
@@ -38,7 +38,7 @@ class TxUtilsKtTest {
         resources.apply {
             every { getString(R.string.default_fallback_handler) } returns "DefaultFallbackHandler"
             every { getString(R.string.unknown_fallback_handler) } returns "Unknown"
-            every { getString(R.string.implementation_version_1_1_1) } returns SAFE_IMPLEMENTATION_1_1_1.asEthereumAddressChecksumString()
+            every { getString(R.string.implementation_version_1_1_1) } returns "1.1.1"
             every { getString(R.string.tx_details_change_required_confirmations) } returns "Change required confirmations:"
         }
     }
@@ -248,7 +248,7 @@ class TxUtilsKtTest {
         val settingsChange: TransactionInfoViewData.SettingsChange =
             TransactionInfoViewData.SettingsChange(
                 dataDecoded = dummyDataDecoded,
-                settingsInfo = SettingsInfoViewData.ChangeImplementation(SAFE_IMPLEMENTATION_1_1_1, null)
+                settingsInfo = SettingsInfoViewData.ChangeImplementation(SAFE_IMPLEMENTATION_1_1_1, AddressInfoData.Remote("1.1.1", null, null))
             )
 
         val result = settingsChange.txActionInfoItems(resources)
@@ -373,4 +373,8 @@ class TxUtilsKtTest {
         method = "dummy",
         parameters = null
     )
+
+    companion object {
+        private val SAFE_IMPLEMENTATION_1_1_1 = "0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A".asEthereumAddress()!!
+    }
 }

--- a/app/src/test/java/io/gnosis/safe/utils/TxUtilsKtTest.kt
+++ b/app/src/test/java/io/gnosis/safe/utils/TxUtilsKtTest.kt
@@ -38,7 +38,6 @@ class TxUtilsKtTest {
         resources.apply {
             every { getString(R.string.default_fallback_handler) } returns "DefaultFallbackHandler"
             every { getString(R.string.unknown_fallback_handler) } returns "Unknown"
-            every { getString(R.string.implementation_version_1_1_1) } returns "1.1.1"
             every { getString(R.string.tx_details_change_required_confirmations) } returns "Change required confirmations:"
         }
     }
@@ -256,7 +255,7 @@ class TxUtilsKtTest {
         assertEquals(R.string.tx_details_new_mastercopy, result[0].itemLabel)
         assertEquals(1, result.size)
         val address = (result[0] as ActionInfoItem.AddressWithLabel)
-        assertEquals(resources.getString(R.string.implementation_version_1_1_1), address.addressLabel)
+        assertEquals("1.1.1", address.addressLabel)
         assertEquals(SAFE_IMPLEMENTATION_1_1_1.asEthereumAddressChecksumString(), address.address?.asEthereumAddressChecksumString())
     }
 

--- a/contracts/build.gradle
+++ b/contracts/build.gradle
@@ -3,20 +3,6 @@ apply plugin: 'bivrost'
 
 android {
     defaultConfig {
-        // Contracts
-        buildConfigField javaTypes.STRING, "SAFE_IMPLEMENTATION_0_0_2", asString(getKey("SAFE_IMPLEMENTATION_0_0_2", "0xAC6072986E985aaBE7804695EC2d8970Cf7541A2"))
-        // Version 0.0.2-alpha (Mainnet)
-        buildConfigField javaTypes.STRING, "SAFE_IMPLEMENTATION_0_1_0", asString(getKey("SAFE_IMPLEMENTATION_0_1_0", "0x8942595A2dC5181Df0465AF0D7be08c8f23C93af"))
-        // Version 0.1.0 (All networks)
-        buildConfigField javaTypes.STRING, "SAFE_IMPLEMENTATION_1_0_0", asString(getKey("SAFE_IMPLEMENTATION_1_0_0", "0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A"))
-        // Version 1.0.0 (All networks)
-        buildConfigField javaTypes.STRING, "SAFE_IMPLEMENTATION_1_1_1", asString(getKey("SAFE_IMPLEMENTATION_1_1_1", "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F"))
-        // Version 1.1.1 (All networks)
-        buildConfigField javaTypes.STRING, "SAFE_IMPLEMENTATION_1_2_0", asString(getKey("SAFE_IMPLEMENTATION_1_2_0", "0x6851d6fdfafd08c0295c392436245e5bc78b0185"))
-        // Version 1.2.0 (All networks)
-        buildConfigField javaTypes.STRING, "SAFE_IMPLEMENTATION_1_3_0", asString(getKey("SAFE_IMPLEMENTATION_1_3_0", "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"))
-        // Version 1.3.0 (All networks)
-
         buildConfigField javaTypes.STRING, "PROXY_FACTORY_ADDRESS", asString(getKey("PROXY_FACTORY_ADDRESS", "0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B"))
         buildConfigField javaTypes.STRING, "MULTI_SEND_OLD_ADDRESS", asString(getKey("MULTI_SEND_ADDRESS", "0xe74d6af1670fb6560dd61ee29eb57c7bc027ce4e"))
         buildConfigField javaTypes.STRING, "MULTI_SEND_ADDRESS", asString(getKey("MULTI_SEND_ADDRESS", "0x8D29bE29923b68abfDD21e541b9374737B49cdAD"))

--- a/data/src/main/java/io/gnosis/data/models/SafeInfo.kt
+++ b/data/src/main/java/io/gnosis/data/models/SafeInfo.kt
@@ -14,5 +14,15 @@ data class SafeInfo(
     @Json(name = "modules") val modules: List<AddressInfo>?,
     @Json(name = "fallbackHandler") val fallbackHandler: AddressInfo?,
     @Json(name = "guard") val guard: AddressInfo?,
-    @Json(name = "version") val version: String
+    @Json(name = "version") val version: String,
+    @Json(name = "implementationVersionState") val versionState: VersionState
 )
+
+enum class VersionState {
+    @Json(name = "UPTODATE")
+    UP_TO_DATE,
+    @Json(name = "OUTDATED")
+    OUTDATED,
+    @Json(name = "UNKNOWN")
+    UNKNOWN
+}

--- a/data/src/main/java/io/gnosis/data/models/SafeInfo.kt
+++ b/data/src/main/java/io/gnosis/data/models/SafeInfo.kt
@@ -19,7 +19,7 @@ data class SafeInfo(
 )
 
 enum class VersionState {
-    @Json(name = "UPTODATE")
+    @Json(name = "UP_TO_DATE")
     UP_TO_DATE,
     @Json(name = "OUTDATED")
     OUTDATED,

--- a/data/src/main/java/io/gnosis/data/repositories/SafeRepository.kt
+++ b/data/src/main/java/io/gnosis/data/repositories/SafeRepository.kt
@@ -112,10 +112,6 @@ class SafeRepository(
         val safeInfo = gatewayApi.getSafeInfo(address = safe.address.asEthereumAddressChecksumString(), chainId = safe.chainId)
         val version = kotlin.runCatching {
             SemVer.parse(safeInfo.version)
-        }.onSuccess {
-            it
-        }.onFailure {
-            SemVer(0, 0, 0)
         }.getOrNull()
 
         return when {

--- a/data/src/test/java/io/gnosis/data/repositories/SafeRepositoryTest.kt
+++ b/data/src/test/java/io/gnosis/data/repositories/SafeRepositoryTest.kt
@@ -16,6 +16,7 @@ import pm.gnosis.crypto.utils.asEthereumAddressChecksumString
 import pm.gnosis.model.Solidity
 import pm.gnosis.svalinn.common.PreferencesManager
 import pm.gnosis.tests.utils.TestPreferences
+import pm.gnosis.utils.asEthereumAddress
 import pm.gnosis.utils.asEthereumAddressString
 import java.math.BigInteger
 
@@ -150,11 +151,12 @@ class SafeRepositoryTest {
             listOf(
                 AddressInfo(Solidity.Address(BigInteger.ONE))
             ),
-            AddressInfo(SafeRepository.SAFE_IMPLEMENTATION_1_0_0),
+            AddressInfo(SAFE_IMPLEMENTATION_1_0_0),
             listOf(AddressInfo(Solidity.Address(BigInteger.ONE))),
             AddressInfo(Solidity.Address(BigInteger.ONE)),
             null,
-            "v1"
+            "1.1.1",
+            VersionState.OUTDATED
         )
 
         coEvery { gatewayApi.getSafeInfo(address = any(), chainId = any()) } returns safeInfo
@@ -245,7 +247,8 @@ class SafeRepositoryTest {
             listOf(AddressInfo(Solidity.Address(BigInteger.ONE))),
             AddressInfo(Solidity.Address(BigInteger.ONE)),
             null,
-            "v1"
+            "1.1.1",
+            VersionState.OUTDATED
         )
         coEvery { gatewayApi.getSafeInfo(address = any(), chainId = any()) } returns safeInfo
 
@@ -282,5 +285,10 @@ class SafeRepositoryTest {
     companion object {
         private const val ACTIVE_SAFE = "prefs.string.active_safe"
         private val CHAIN_ID = BuildConfig.CHAIN_ID.toBigInteger()
+
+        private val SAFE_IMPLEMENTATION_1_0_0 = "0x8942595A2dC5181Df0465AF0D7be08c8f23C93af".asEthereumAddress()!!
+        private val SAFE_IMPLEMENTATION_1_1_1 = "0xb6029EA3B2c51D09a50B53CA8012FeEB05bDa35A".asEthereumAddress()!!
+        private val SAFE_IMPLEMENTATION_1_2_0 = "0x6851d6fdfafd08c0295c392436245e5bc78b0185".asEthereumAddress()!!
+        private val SAFE_IMPLEMENTATION_1_3_0 = "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552".asEthereumAddress()!!
     }
 }


### PR DESCRIPTION
Handles #1492

Changes proposed in this pull request:
- Show the contract version "1.3.0 up to date"
- 1.1.1 and 1.2.0 versions should still be shown as "up to date".
- All supported versions: from 1.0.0 to 1.3.0 inclusive
- Disallow adding safe outside this version range
- Remove hardcoded versions & version strings


@gnosis/mobile-devs
