### PR TITLE
Prevent crash when no fingerprints enrolled although BIOMETRIC_SUCCESS was returned

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/PasscodeViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/PasscodeViewModel.kt
@@ -158,6 +158,17 @@ class PasscodeViewModel
         }
     }
 
+    fun activateBiometry(newPasscode: String) {
+        try {
+            //Some device still throw an IllegalStateException
+            // (due to no fingerprints enrolled) even though they return BIOMETRIC_SUCCESS
+            encryptPasscodeWithBiometricKey(newPasscode)
+            settingsHandler.useBiometrics = true
+        } catch (e: Exception) {
+            Timber.e(e, "activateBiometry() failed")
+        }
+    }
+
     fun encryptPasscodeWithBiometricKey(newPasscode: String) {
         if (settingsHandler.useBiometrics) {
             val cipher = biometricPasscodeManager.getInitializedRSACipherForEncryption(BiometricPasscodeManager.KEY_NAME)
@@ -203,10 +214,6 @@ class PasscodeViewModel
             Timber.e(e, "cannot decrypt passcode")
             settingsHandler.useBiometrics = false
         }
-    }
-
-    fun enableBiometry() {
-        settingsHandler.useBiometrics = true
     }
 
     data class PasscodeState(override var viewAction: ViewAction?) : State

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/RepeatPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/RepeatPasscodeFragment.kt
@@ -25,6 +25,7 @@ import io.gnosis.safe.ui.settings.app.SettingsHandler
 import io.gnosis.safe.utils.CustomAlertDialogBuilder
 import pm.gnosis.svalinn.common.utils.showKeyboardForView
 import pm.gnosis.svalinn.common.utils.visible
+import timber.log.Timber
 import javax.inject.Inject
 
 class RepeatPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>() {
@@ -84,7 +85,14 @@ class RepeatPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>(
                             },
                             confirmCallback = { dialog ->
                                 viewModel.enableBiometry()
-                                viewModel.encryptPasscodeWithBiometricKey(viewAction.passcode)
+                                try {
+                                    //Some device still throw an IllegalStateException
+                                    // (due to no fingerprints enrolled) even though they return BIOMETRIC_SUCCESS
+                                    viewModel.encryptPasscodeWithBiometricKey(viewAction.passcode)
+                                } catch (e: Exception) {
+                                    settingsHandler.useBiometrics = false
+                                    Timber.e(e, "encryptPasscodeWithBiometricKey() failed")
+                                }
                                 dialog.dismiss()
                             },
                             confirmColor = R.color.primary,

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/RepeatPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/RepeatPasscodeFragment.kt
@@ -25,7 +25,6 @@ import io.gnosis.safe.ui.settings.app.SettingsHandler
 import io.gnosis.safe.utils.CustomAlertDialogBuilder
 import pm.gnosis.svalinn.common.utils.showKeyboardForView
 import pm.gnosis.svalinn.common.utils.visible
-import timber.log.Timber
 import javax.inject.Inject
 
 class RepeatPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>() {
@@ -84,14 +83,7 @@ class RepeatPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>(
                                 dismissCreatePasscodeFragment()
                             },
                             confirmCallback = { dialog ->
-                                try {
-                                    //Some device still throw an IllegalStateException
-                                    // (due to no fingerprints enrolled) even though they return BIOMETRIC_SUCCESS
-                                    viewModel.encryptPasscodeWithBiometricKey(viewAction.passcode)
-                                    viewModel.enableBiometry()
-                                } catch (e: Exception) {
-                                    Timber.e(e, "encryptPasscodeWithBiometricKey() failed")
-                                }
+                                viewModel.activateBiometry(viewAction.passcode)
                                 dialog.dismiss()
                             },
                             confirmColor = R.color.primary,

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/RepeatPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/RepeatPasscodeFragment.kt
@@ -84,13 +84,12 @@ class RepeatPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>(
                                 dismissCreatePasscodeFragment()
                             },
                             confirmCallback = { dialog ->
-                                viewModel.enableBiometry()
                                 try {
                                     //Some device still throw an IllegalStateException
                                     // (due to no fingerprints enrolled) even though they return BIOMETRIC_SUCCESS
                                     viewModel.encryptPasscodeWithBiometricKey(viewAction.passcode)
+                                    viewModel.enableBiometry()
                                 } catch (e: Exception) {
-                                    settingsHandler.useBiometrics = false
                                     Timber.e(e, "encryptPasscodeWithBiometricKey() failed")
                                 }
                                 dialog.dismiss()


### PR DESCRIPTION
Handles #1511

Changes proposed in this pull request:
- catch IllegalStateException
- disable biometrics

@gnosis/mobile-devs
