### PR TITLE
Fix rejection safeTxHash calculation; show network name in title of executed tx push notification

### DIFF
--- a/app/src/main/java/io/gnosis/safe/notifications/NotificationManager.kt
+++ b/app/src/main/java/io/gnosis/safe/notifications/NotificationManager.kt
@@ -134,7 +134,7 @@ class NotificationManager(
                     title = context.getString(R.string.push_title_failed, safe.chain.name)
                     text = context.getString(R.string.push_text_failed, safeName)
                 } else {
-                    title = context.getString(R.string.push_title_executed)
+                    title = context.getString(R.string.push_title_executed, safe.chain.name)
                     text = context.getString(R.string.push_text_executed, safeName)
                 }
                 intent = txDetailsIntent(safe, pushNotification.safeTxHash)

--- a/app/src/main/java/io/gnosis/safe/ui/transactions/details/ConfirmRejectionViewModel.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/transactions/details/ConfirmRejectionViewModel.kt
@@ -69,6 +69,9 @@ class ConfirmRejectionViewModel
         safeLaunch {
 
             val safe = safeRepository.getActiveSafe()!!
+            val contractVersion = safe.version?.let {
+                SemVer.parse(it)
+            } ?: SemVer(0, 0, 0)
 
             validateSafeTxHash(safe, txDetails!!, executionInfo).takeUnless { it }?.let { throw MismatchingSafeTxHash }
 
@@ -80,7 +83,7 @@ class ConfirmRejectionViewModel
             )
             val safeTxHash =
                 calculateSafeTxHash(
-                    implementationVersion = SemVer(1, 1, 0),
+                    implementationVersion = contractVersion,
                     chainId = safe.chainId,
                     safeAddress = safe.address,
                     transaction = rejectionTxDetails,


### PR DESCRIPTION
Handles #1605 
Handles #1606

Changes proposed in this pull request:
- Fix rejection safeTxHash calculation
- Show network name in title of executed tx push notification

@gnosis/mobile-devs
