### PR TITLE
Close tx details page after forgot passcode was used

### DIFF
--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
@@ -1,5 +1,6 @@
 package io.gnosis.safe.ui.settings.app.passcode
 
+import android.app.Dialog
 import android.content.Context
 import android.os.Build
 import android.os.Bundle
@@ -43,6 +44,8 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
 
     @Inject
     lateinit var settingsHandler: SettingsHandler
+
+    private var forgotPasscodeDialog: Dialog? = null
 
     override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentPasscodeBinding =
         FragmentPasscodeBinding.inflate(inflater, container, false)
@@ -123,7 +126,7 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
             actionButton.setOnClickListener {
                 binding.errorMessage.visibility = View.INVISIBLE
 
-                showConfirmDialog(
+                forgotPasscodeDialog = showConfirmDialog(
                     requireContext(),
                     message = R.string.settings_passcode_confirm_disable_passcode,
                     confirm = R.string.settings_passcode_disable_passcode,
@@ -137,6 +140,11 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
                 input.showKeyboardForView()
             }
         }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        forgotPasscodeDialog?.dismiss()
     }
 
     private fun handlePasscodeCorrect() {

--- a/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
+++ b/app/src/main/java/io/gnosis/safe/ui/settings/app/passcode/EnterPasscodeFragment.kt
@@ -69,7 +69,7 @@ class EnterPasscodeFragment : BaseViewBindingFragment<FragmentPasscodeBinding>()
                     if (requirePasscodeToOpen) {
                         findNavController().popBackStack(R.id.enterPasscodeFragment, true)
                     } else if (!selectedOwner.isNullOrBlank()) {
-                        findNavController().popBackStack(R.id.transactionDetailsFragment, false)
+                        findNavController().popBackStack(R.id.transactionDetailsFragment, true)
                     } else {
                         findNavController().popBackStack(R.id.ownerDetailsFragment, true)
                     }

--- a/app/src/main/java/io/gnosis/safe/utils/AppUtils.kt
+++ b/app/src/main/java/io/gnosis/safe/utils/AppUtils.kt
@@ -1,6 +1,7 @@
 package io.gnosis.safe.utils
 
 import android.app.Activity
+import android.app.Dialog
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
@@ -66,10 +67,10 @@ fun showConfirmDialog(
     @ColorRes confirmColor: Int = R.color.error,
     dismissCallback: DialogInterface.OnDismissListener = DialogInterface.OnDismissListener { },
     confirmCallback: () -> Unit
-) {
+): Dialog {
     val dialogBinding = DialogRemoveBinding.inflate(LayoutInflater.from(context), null, false)
     dialogBinding.message.setText(message)
-    CustomAlertDialogBuilder.build(
+    return CustomAlertDialogBuilder.build(
         context = context,
         confirmCallback = { dialog ->
             confirmCallback()
@@ -82,5 +83,7 @@ fun showConfirmDialog(
         confirmColor = confirmColor,
         cancelColor = R.color.primary,
         title = if (title == null) null else context.resources.getString(title)
-    ).show()
+    ).apply {
+        show()
+    }
 }


### PR DESCRIPTION
Handles #1475 
Handles #1522

Changes proposed in this pull request:
- Dismiss forgot passcode dialog on pause
- Close tx details page after forgot passcode was used


@gnosis/mobile-devs
