### PR TITLE
Receive and handle Itercom push notifications

### DIFF
--- a/app/src/main/java/io/gnosis/safe/di/modules/ApplicationModule.kt
+++ b/app/src/main/java/io/gnosis/safe/di/modules/ApplicationModule.kt
@@ -39,6 +39,7 @@ import io.gnosis.safe.utils.BalanceFormatter
 import io.gnosis.safe.utils.MnemonicKeyAndAddressDerivator
 import io.gnosis.safe.utils.ParamSerializer
 import io.gnosis.safe.workers.HeimdallWorkerFactory
+import io.intercom.android.sdk.push.IntercomPushClient
 import okhttp3.CertificatePinner
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -345,4 +346,7 @@ class ApplicationModule(private val application: Application) {
     fun providesLedgerOwnerPagingProvider(ledgerController: LedgerController): LedgerOwnerPagingProvider =
         LedgerOwnerPagingProvider(ledgerController)
 
+    @Provides
+    @Singleton
+    fun providesIntercomPushClient(): IntercomPushClient = IntercomPushClient()
 }

--- a/app/src/main/java/io/gnosis/safe/notifications/NotificationRepository.kt
+++ b/app/src/main/java/io/gnosis/safe/notifications/NotificationRepository.kt
@@ -32,6 +32,15 @@ class NotificationRepository(
     private val notificationManager: NotificationManager
 ) {
 
+    //FIXME: workaround to check for unhandled intercom pushes
+    var intercomPushReceived: Boolean
+        get() = preferencesManager.prefs.getBoolean(KEY_INTERCOM_PUSH_RECEIVED, false)
+        set(value) {
+            preferencesManager.prefs.edit {
+                putBoolean(KEY_INTERCOM_PUSH_RECEIVED, value)
+            }
+        }
+
     //FIXME: workaround for versioning validation on notification service
     private val appVersion: String = BuildConfig.VERSION_NAME
         .replace("(\\d*)\\.(\\d*)\\.(\\d*)(.*)".toRegex()) {
@@ -241,5 +250,6 @@ class NotificationRepository(
 
     companion object {
         private const val KEY_DEVICE_UUID = "prefs.string.device_uuid"
+        private const val KEY_INTERCOM_PUSH_RECEIVED = "prefs.boolean.intercom_push_received"
     }
 }


### PR DESCRIPTION
Handles #1752
Handles #1754 

Changes proposed in this pull request:
- Receive and handle push notifications from Intercom
- Opening the push message should open App and show Intercom chat screen in a popover 
- Only open Intercom window after passcode is unlocked

Intercom android sdk creates it's own notification channels:
![Screenshot_1643801231](https://user-images.githubusercontent.com/17750984/152145264-49c0dd85-5985-4c68-bb9d-192dea8f55c7.png)
Because Intercom android sdk has closed api there is no direct way to adjust naming/structure of those channels.
Same goes for the format of push notification itself
![Screenshot_1643801460](https://user-images.githubusercontent.com/17750984/152145812-d9e1c5bf-0f29-42b5-8620-c5002b37cbe7.png)
It is possible to adjust the icon in the top left part though. I would see it as low priority now and propose to adjust it if needed in a future pr.
Here is example of a notification for a single message
![Screenshot_1643801605](https://user-images.githubusercontent.com/17750984/152146141-60ea33ac-54b2-4add-9c01-8486ff5a2f78.png)

@gnosis/mobile-devs
